### PR TITLE
Dimension swap

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ using Pkg
 Pkg.add("SymbolicRegression")
 ```
 
+The heart of this package is the
+`EquationSearch` function, which takes
+a 2D array (shape [features, rows]) and attempts
+to model a 1D array (shape [rows])
+using analytic functional forms.
+
 Run distributed on four processes with:
 ```julia
 using Distributed

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ procs = addprocs()
 
 @everywhere using SymbolicRegression
 
-X = randn(Float32, 100, 5)
-y = 2 * cos.(X[:, 4]) + X[:, 1] .^ 2 .- 2
+X = randn(Float32, 5, 100)
+y = 2 * cos.(X[4, :]) + X[1, :] .^ 2 .- 2
 
 options = SymbolicRegression.Options(
     binary_operators=(+, *, /, -),
@@ -36,7 +36,7 @@ options = SymbolicRegression.Options(
 )
 niterations = 5
 
-hallOfFame = RunSR(X, y, niterations=niterations, options=options)
+hallOfFame = EquationSearch(X, y, niterations=niterations, options=options)
 
 rmprocs(procs)
 ```

--- a/example.jl
+++ b/example.jl
@@ -15,6 +15,6 @@ options = SymbolicRegression.Options(
 )
 niterations = 5
 
-hallOfFame = RunSR(X, y, niterations=niterations, options=options)
+hallOfFame = EquationSearch(X, y, niterations=niterations, options=options)
 
 rmprocs(procs)

--- a/example.jl
+++ b/example.jl
@@ -5,13 +5,13 @@ procs = addprocs()
 @everywhere include("src/SymbolicRegression.jl")
 @everywhere using .SymbolicRegression
 
-X = randn(Float32, 100, 5)
-y = 2 * cos.(X[:, 4]) + X[:, 1] .^ 2 .- 2
+X = randn(Float32, 5, 100)
+y = 2 * cos.(X[4, :]) + X[1, :] .^ 2 .- 2
 
 options = SymbolicRegression.Options(
     binary_operators=(+, *, /, -),
     unary_operators=(cos, exp),
-    npopulations=20
+    npopulations=20,
 )
 niterations = 5
 

--- a/src/Dataset.jl
+++ b/src/Dataset.jl
@@ -17,8 +17,8 @@ function Dataset(
         varMap::Union{Array{String, 1}, Nothing}=nothing
        ) where {T<:Real}
 
-    n = size(X)[1]
-    nfeatures = size(X)[2]
+    n = size(X)[2]
+    nfeatures = size(X)[1]
     weighted = true
     if weights == nothing
         weighted = false

--- a/src/Deprecates.jl
+++ b/src/Deprecates.jl
@@ -1,0 +1,4 @@
+using Base: @deprecate
+
+# Now the batch dimension is the last axis!
+@deprecate RunSR(X, y; kw...) EquationSearch(convert(Array, X'), y; kw...)

--- a/src/Deprecates.jl
+++ b/src/Deprecates.jl
@@ -1,4 +1,4 @@
 using Base: @deprecate
 
 # Now the batch dimension is the last axis!
-@deprecate RunSR(X, y; kw...) EquationSearch(convert(Array, X'), y; kw...)
+@deprecate RunSR(X, y; kw...) EquationSearch(copy(transpose(X)), y; kw...)

--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -86,7 +86,7 @@ function stringTree(tree::Node, options::Options;
             if varMap == nothing
                 return "x$(tree.feature)"
             else
-                return varMap[tree.feature::Int]
+                return varMap[tree.feature]
             end
         end
     elseif tree.degree == 1

--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -20,12 +20,12 @@ end
 
 # Evaluate an equation over an array of datapoints
 function evalTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options)::Tuple{AbstractVector{T}, Bool} where {T<:Real}
-    clen = size(cX)[1]
+    clen = size(cX)[2]
     if tree.degree == 0
         if tree.constant #TODO: Make this done with types instead
             return (fill(convert(T, tree.val), clen), true)
         else
-            return (copy(cX[:, tree.feature]), true)
+            return (copy(cX[tree.feature, :]), true)
         end
     end
 

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -50,7 +50,7 @@ function scoreFuncBatch(dataset::Dataset{T}, baseline::T,
                         tree::Node, options::Options)::T where {T<:Real}
     batchSize = options.batchSize
     batch_idx = randperm(dataset.n)[1:options.batchSize]
-    batch_X = dataset.X[batch_idx, :]
+    batch_X = dataset.X[:, batch_idx]
     batch_y = dataset.y[batch_idx]
     (prediction, completion) = evalTreeArray(tree, batch_X, options)
     if !completion

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -7,7 +7,7 @@ export Population,
     Options,
 
     #Functions:
-    RunSR,
+    EquationSearch,
     SRCycle,
     calculateParetoFrontier,
     countNodes,
@@ -62,16 +62,17 @@ include("Population.jl")
 include("RegularizedEvolution.jl")
 include("SingleIteration.jl")
 include("ConstantOptimization.jl")
+include("Deprecates.jl")
 
-function RunSR(X::AbstractMatrix{T}, y::AbstractVector{T};
+function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
         niterations::Int=10,
         weights::Union{AbstractVector{T}, Nothing}=nothing,
         varMap::Union{Array{String, 1}, Nothing}=nothing,
         options::Options=Options()) where {T<:Real}
 
-    testConfiguration(options)
+    testOptionConfiguration(options)
 
-    if size(X)[1] > 10000
+    if size(X)[2] > 10000
         if !options.batching
             println("Note: you are running with more than 10,000 datapoints. You should consider turning on batching (`options.batching`), and also if you need that many datapoints. Unless you have a large amount of noise (in which case you should smooth your dataset first), generally < 10,000 datapoints is enough to find a functional form.")
         end
@@ -80,6 +81,8 @@ function RunSR(X::AbstractMatrix{T}, y::AbstractVector{T};
     dataset = Dataset(X, y,
                      weights=weights,
                      varMap=varMap)
+
+    testDatasetConfiguration(dataset)
 
     if dataset.weighted
         avgy = sum(dataset.y .* dataset.weights)/sum(dataset.weights)
@@ -277,5 +280,6 @@ function RunSR(X::AbstractMatrix{T}, y::AbstractVector{T};
     end
     return hallOfFame
 end
+
 
 end #module SR

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -16,7 +16,7 @@ end
 
 
 # Check for errors before they happen
-function testConfiguration(options::Options)
+function testOptionConfiguration(options::Options)
     test_input = LinRange(-100f0, 100f0, 99)
 
     try
@@ -42,3 +42,10 @@ function testConfiguration(options::Options)
     end
 end
 
+# Check for errors before they happen
+function testDatasetConfiguration(dataset::Dataset{T}) where {T<:Real}
+    n = dataset.n
+    if n != size(dataset.X)[2] || n != size(dataset.y)[1]
+        throw(error("Dataset dimensions are invalid. Make sure X is of shape [features, rows], y is of shape [rows] and if there are weights, they are of shape [rows]."))
+    end
+end


### PR DESCRIPTION
Following Flux.jl's format, this PR switches the batch axis to be the last axis. Now the input `X` array is [features, rows] rather than previous [rows, features].

I have `@deprecated` `RunSR` to do this transpose automatically, so existing code should still work. I also created a new function `EquationSearch` which requires the proper format at input. This will be the main SR function going forward.

I do not plan on changing the array format of https://github.com/MilesCranmer/PySR - that one will remain [rows, features] following the standard format in many Python ML frameworks. I will just have https://github.com/MilesCranmer/PySR/pull/26 transpose the array when calling out to the Julia backend.

@patrick-kidger how does this look?

cc @DhananjayAshok