### PR TITLE
Batched equation search / multi-output search

### DIFF
--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -28,7 +28,7 @@ function optimizeConstants(dataset::Dataset{T},
     differentiable_f(x::Vector{CONST_TYPE})::T = optFunc(x, dataset, baseline, member.tree, options; allow_diff=true)
     use_differentiable = false
     if nconst == 1
-        algorithm = Optim.Newton()
+        algorithm = Optim.Newton(linesearch=LineSearches.BackTracking())
     else
         if options.optimizer_algorithm == "NelderMead"
             algorithm = Optim.NelderMead(linesearch=LineSearches.BackTracking())

--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -31,7 +31,7 @@ function optimizeConstants(dataset::Dataset{T},
         algorithm = Optim.Newton()
     else
         if options.optimizer_algorithm == "NelderMead"
-            algorithm = Optim.NelderMead()
+            algorithm = Optim.NelderMead(linesearch=LineSearches.BackTracking())
         elseif options.optimizer_algorithm == "BFGS"
             use_differentiable = true
             algorithm = Optim.BFGS(linesearch=LineSearches.BackTracking())#order=3))

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,6 +1,6 @@
 using FromFile
 
-@from "ProgramConstants.jl" import CONST_TYPE, maxdegree
+@from "ProgramConstants.jl" import CONST_TYPE, maxdegree, BATCH_DIM, FEATURE_DIM
 @from "Dataset.jl" import Dataset
 @from "Equation.jl" import Node, copyNode
 @from "Options.jl" import Options

--- a/src/Dataset.jl
+++ b/src/Dataset.jl
@@ -1,3 +1,5 @@
+@from "ProgramConstants" import BATCH_DIM, FEATURE_DIM
+
 struct Dataset{T<:Real}
 
     X::AbstractMatrix{T}
@@ -24,8 +26,8 @@ function Dataset(
         varMap::Union{Array{String, 1}, Nothing}=nothing
        ) where {T<:Real}
 
-    n = size(X, 2)
-    nfeatures = size(X, 1)
+    n = size(X, BATCH_DIM)
+    nfeatures = size(X, FEATURE_DIM)
     weighted = weights !== nothing
     if varMap == nothing
         varMap = ["x$(i)" for i=1:nfeatures]

--- a/src/Dataset.jl
+++ b/src/Dataset.jl
@@ -1,4 +1,5 @@
-@from "ProgramConstants" import BATCH_DIM, FEATURE_DIM
+using FromFile
+@from "ProgramConstants.jl" import BATCH_DIM, FEATURE_DIM
 
 struct Dataset{T<:Real}
 

--- a/src/ProgramConstants.jl
+++ b/src/ProgramConstants.jl
@@ -1,2 +1,4 @@
 const maxdegree = 2
 const CONST_TYPE = Float32
+const BATCH_DIM = 2
+const FEATURE_DIM = 1

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -455,17 +455,17 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractMatrix{T};
                 @printf("\n")
                 average_speed = sum(equation_speed)/length(equation_speed)
                 @printf("Cycles per second: %.3e\n", round(average_speed, sigdigits=3))
-                cycles_elapsed = total_cycles - sum(cycles_remaining)/nout
+                cycles_elapsed = total_cycles * nout - sum(cycles_remaining)
                 @printf("Progress: %d / %d total iterations (%.3f%%)\n",
-                        cycles_elapsed, total_cycles,
-                        100.0*cycles_elapsed/total_cycles)
+                        cycles_elapsed, total_cycles * nout,
+                        100.0*cycles_elapsed/total_cycles/nout)
 
                 @printf("==============================\n")
                 for j=1:nout
                     if nout > 1
                         @printf("Best equations for output %d\n", j)
                     end
-                    equation_strings = string_dominating_pareto_curve(hallOfFame[j], baselineMSE,
+                    equation_strings = string_dominating_pareto_curve(hallOfFame[j], baselineMSEs[j],
                                                                       datasets[j], options,
                                                                       avgys[j])
                     print(equation_strings)

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -53,12 +53,12 @@ export Population,
 using Distributed
 using Printf: @printf
 using Pkg
-using Random: seed!
+using Random: seed!, shuffle
 using FromFile
 using Reexport
 @reexport using LossFunctions
 
-@from "Core.jl" import CONST_TYPE, maxdegree, Dataset, Node, copyNode, Options, plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip
+@from "Core.jl" import CONST_TYPE, maxdegree, BATCH_DIM, FEATURE_DIM, Dataset, Node, copyNode, Options, plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip
 @from "Utils.jl" import debug, debug_inline, is_anonymous_function
 @from "EquationUtils.jl" import countNodes, printTree, stringTree
 @from "EvaluateEquation.jl" import evalTreeArray, differentiableEvalTreeArray
@@ -91,11 +91,11 @@ which is useful for debugging and profiling.
 # Arguments
 - `X::AbstractMatrix{T}`:  The input dataset to predict `y` from.
     The first dimension is features, the second dimension is rows.
-- `y::AbstractVector{T}`: The values to predict. Only a single feature
+- `y::AbstractMatrix{T}`: The values to predict. Only a single feature
     is allowed, so `y` is a 1D array.
 - `niterations::Int=10`: The number of iterations to perform the search.
     More iterations will improve the results.
-- `weights::Union{AbstractVector{T}, Nothing}=nothing`: Optionally
+- `weights::Union{AbstractMatrix{T}, Nothing}=nothing`: Optionally
     weight the loss for each `y` by this value (same shape as `y`).
 - `varMap::Union{Array{String, 1}, Nothing}=nothing`: The names
     of each feature in `X`, which will be used during printing of equations.
@@ -119,9 +119,9 @@ which is useful for debugging and profiling.
     is given in `.score`. The array of `PopMember` objects
     is enumerated by size from `1` to `options.maxsize`.
 """
-function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
+function EquationSearch(X::AbstractMatrix{T}, y::AbstractMatrix{T};
         niterations::Int=10,
-        weights::Union{AbstractVector{T}, Nothing}=nothing,
+        weights::Union{AbstractMatrix{T}, Nothing}=nothing,
         varMap::Union{Array{String, 1}, Nothing}=nothing,
         options::Options=Options(),
         numprocs::Union{Int, Nothing}=nothing,
@@ -129,40 +129,49 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
         runtests::Bool=true
        ) where {T<:Real}
 
-    dataset = Dataset(X, y,
-                     weights=weights,
-                     varMap=varMap)
+    nout = size(y, FEATURE_DIM)
+    datasets = [Dataset(X, y[i, :],
+                       weights=weights[i, :],
+                       varMap=varMap) for i=1:nout]
+    example_dataset = datasets[1]
     serial = (procs == nothing && numprocs == 0)
     parallel = !serial
 
     if runtests
         testOptionConfiguration(T, options)
-        testDatasetConfiguration(dataset, options)
+        # Testing the first output variable is the same:
+        testDatasetConfiguration(example_dataset, options)
     end
 
-    if dataset.weighted
-        avgy = sum(dataset.y .* dataset.weights)/sum(dataset.weights)
-        baselineMSE = Loss(dataset.y, ones(T, dataset.n) .* avgy, dataset.weights, options)
+    if example_dataset.weighted
+        avgys = [sum(dataset.y .* dataset.weights) / sum(dataset.weights)
+                for dataset in datasets]
+        baselineMSEs = [Loss(dataset.y, ones(T, dataset.n) .* avgy, dataset.weights, options)
+                       for dataset in datasets, avgy in avgys]
     else
-        avgy = sum(dataset.y)/dataset.n
-        baselineMSE = Loss(dataset.y, ones(T, dataset.n) .* avgy, options)
+        avgy = [sum(dataset.y)/dataset.n for dataset in datasets]
+        baselineMSEs = [Loss(dataset.y, ones(T, dataset.n) .* avgy, options)
+                       for (dataset, avgy) in zip(datasets, avgys)]
     end
 
     if options.seed !== nothing
         seed!(options.seed)
     end
     # Start a population on every process
+    #    Store the population, hall of fame
     allPopsType = parallel ? Future : Tuple{Population,HallOfFame}
-    allPops = allPopsType[]
+    allPops = [allPopsType[] for i=1:nout]
     # Set up a channel to send finished populations back to head node
-    channels = [RemoteChannel(1) for j=1:options.npopulations]
-    bestSubPops = [Population(dataset, baselineMSE, npop=1, options=options, nfeatures=dataset.nfeatures) for j=1:options.npopulations]
-    hallOfFame = HallOfFame(options)
+    channels = [[RemoteChannel(1) for j=1:options.npopulations] for i=1:nout]
+    bestSubPops = [[Population(datasets[i], baselineMSE[i], npop=1, options=options, nfeatures=dataset.nfeatures)
+                    for j=1:options.npopulations]
+                    for i=1:nout]
+    hallOfFame = [HallOfFame(options) for j=1:nout]
     actualMaxsize = options.maxsize + maxdegree
-    frequencyComplexity = ones(T, actualMaxsize)
-    curmaxsize = 3
+    frequencyComplexities = [ones(T, actualMaxsize) for i=1:nout]
+    curmaxsizes = [3 for i=1:nout]
     if options.warmupMaxsizeBy == 0f0
-        curmaxsize = options.maxsize
+        curmaxsizes = [options.maxsize for i=1:nout]
     end
 
     we_created_procs = false
@@ -185,13 +194,13 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
             activate_env_on_workers(procs, project_path, options)
             import_module_on_workers(procs, @__FILE__, options)
         end
-        move_functions_to_workers(procs, options, dataset)
+        move_functions_to_workers(procs, options, example_dataset)
         if runtests
             test_module_on_workers(procs, options)
         end
 
         if runtests
-            test_entire_pipeline(procs, dataset, options)
+            test_entire_pipeline(procs, example_dataset, options)
         end
     end
     cur_proc_idx = 1
@@ -206,28 +215,48 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
         end
     end
 
-    for i=1:options.npopulations
-        worker_idx = next_worker()
-        new_pop = if parallel
-            (@spawnat worker_idx Population(dataset, baselineMSE,
-                                            npop=options.npop, nlength=3,
-                                            options=options,
-                                            nfeatures=dataset.nfeatures),
-            HallOfFame(options))
-        else
-            (Population(dataset, baselineMSE,
-                        npop=options.npop, nlength=3,
-                        options=options,
-                        nfeatures=dataset.nfeatures), HallOfFame(options))
+    for j=1:nout
+        for i=1:options.npopulations
+            worker_idx = next_worker()
+            new_pop = if parallel
+                (@spawnat worker_idx Population(datasets[j], baselineMSEs[j],
+                                                npop=options.npop, nlength=3,
+                                                options=options,
+                                                nfeatures=datasets[j].nfeatures),
+                HallOfFame(options),
+                j)
+            else
+                (Population(datasets[j], baselineMSEs[j],
+                            npop=options.npop, nlength=3,
+                            options=options,
+                            nfeatures=datasets[j].nfeatures),
+                 HallOfFame(options),
+                 j)
+            end
+            push!(allPops[j], new_pop)
         end
-        push!(allPops, new_pop)
     end
     # 2. Start the cycle on every process:
-    for i=1:options.npopulations
-        worker_idx = next_worker()
-        allPops[i] = if parallel
-            @spawnat worker_idx let
-                tmp_pop, tmp_best_seen = SRCycle(dataset, baselineMSE, fetch(allPops[i])[1], options.ncyclesperiteration, curmaxsize, copy(frequencyComplexity)/sum(frequencyComplexity), verbosity=options.verbosity, options=options)
+    for j=1:nout
+        dataset = datasets[j]
+        baselineMSE = baselineMSEs[j]
+        frequencyComplexity = frequencyComplexities[j]
+        curmaxsize = curmaxsizes[j]
+        for i=1:options.npopulations
+            worker_idx = next_worker()
+            allPops[j][i] = if parallel
+                @spawnat worker_idx let
+                    tmp_pop, tmp_best_seen = SRCycle(dataset, baselineMSE, fetch(allPops[j][i])[1], options.ncyclesperiteration, curmaxsize, copy(frequencyComplexity)/sum(frequencyComplexity), verbosity=options.verbosity, options=options)
+                    tmp_pop = OptimizeAndSimplifyPopulation(dataset, baselineMSE, tmp_pop, options, curmaxsize)
+                    if options.batching
+                        for i_member=1:(options.maxsize + maxdegree)
+                            tmp_best_seen.members[i_member].score = scoreFunc(dataset, baselineMSE, tmp_best_seen.members[i_member].tree, options)
+                        end
+                    end
+                    (tmp_pop, tmp_best_seen)
+                end
+            else
+                tmp_pop, tmp_best_seen = SRCycle(dataset, baselineMSE, allPops[j][i][1], options.ncyclesperiteration, curmaxsize, copy(frequencyComplexity)/sum(frequencyComplexity), verbosity=options.verbosity, options=options)
                 tmp_pop = OptimizeAndSimplifyPopulation(dataset, baselineMSE, tmp_pop, options, curmaxsize)
                 if options.batching
                     for i_member=1:(options.maxsize + maxdegree)
@@ -236,50 +265,58 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
                 end
                 (tmp_pop, tmp_best_seen)
             end
-        else
-            tmp_pop, tmp_best_seen = SRCycle(dataset, baselineMSE, allPops[i][1], options.ncyclesperiteration, curmaxsize, copy(frequencyComplexity)/sum(frequencyComplexity), verbosity=options.verbosity, options=options)
-            tmp_pop = OptimizeAndSimplifyPopulation(dataset, baselineMSE, tmp_pop, options, curmaxsize)
-            if options.batching
-                for i_member=1:(options.maxsize + maxdegree)
-                    tmp_best_seen.members[i_member].score = scoreFunc(dataset, baselineMSE, tmp_best_seen.members[i_member].tree, options)
-                end
-            end
-            (tmp_pop, tmp_best_seen)
         end
     end
 
     debug(options.verbosity > 0 || options.progress, "Started!")
     total_cycles = options.npopulations * niterations
-    cycles_remaining = total_cycles
+    cycles_remaining = [total_cycles for j=1:nout]
     if options.progress
+        #TODO: need to iterate this on the max cycles remaining!
         progress_bar = ProgressBar(1:cycles_remaining;
                                    width=options.terminal_width)
         cur_cycle = nothing
         cur_state = nothing
     end
 
-    last_print_time = time()
-    num_equations = 0.0
+    last_print_time = [time() for j=1:nout]
+    num_equations = [0.0 for j=1:nout]
     print_every_n_seconds = 5
     equation_speed = Float32[]
 
     if parallel
-        for i=1:options.npopulations
-            # Start listening for each population to finish:
-            @async put!(channels[i], fetch(allPops[i]))
+        for j=1:nout
+            for i=1:options.npopulations
+                # Start listening for each population to finish:
+                @async put!(channels[j][i], fetch(allPops[j][i]))
+            end
         end
     end
 
-    while cycles_remaining > 0
-        for i=1:options.npopulations
+    # Randomly order which order to check populations:
+    # This is done so that we do work on all nout equally.
+    all_idx = [(j, i) for j=1:nout for i=1:options.npopulations]
+    shuffle!(all_idx)
+    while max(cycles_remaining) > 0
+        for kappa=1:(options.npopulations * nout)
+            # nout, npopulations:
+            j, i = all_idx[kappa]
+
             # Non-blocking check if a population is ready:
-            population_ready = parallel ? isready(channels[i]) : true
+            population_ready = parallel ? isready(channels[j][i]) : true
+            # Don't start more if this output has finished its cycles:
+            # TODO - this might skip extra cycles?
+            population_ready &= (cycles_remaining[j] > 0)
             if population_ready
                 # Take the fetch operation from the channel since its ready
-                (cur_pop, best_seen) = parallel ? take!(channels[i]) : allPops[i]
+                (cur_pop, best_seen) = parallel ? take!(channels[j][i]) : allPops[j][i]
                 cur_pop::Population
                 best_seen::HallOfFame
-                bestSubPops[i] = bestSubPop(cur_pop, topn=options.topn)
+                bestSubPops[j][i] = bestSubPop(cur_pop, topn=options.topn)
+
+                dataset = datasets[j]
+                baselineMSE = baselineMSEs[j]
+                curmaxsize = curmaxsizes[j]
 
                 #Try normal copy...
                 bestPops = Population([member for pop in bestSubPops for member in pop.members])
@@ -288,18 +325,22 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
                     part_of_cur_pop = i_member <= length(cur_pop.members)
                     size = countNodes(member.tree)
                     if part_of_cur_pop
-                        frequencyComplexity[size] += 1
+                        frequencyComplexities[j][size] += 1
                     end
                     actualMaxsize = options.maxsize + maxdegree
-                    if size < actualMaxsize && all([member.score < hallOfFame.members[size2].score for size2=1:size])
-                        hallOfFame.members[size] = copyPopMember(member)
-                        hallOfFame.exists[size] = true
+                    if size < actualMaxsize && all([member.score < hallOfFame[j].members[size2].score for size2=1:size])
+                        hallOfFame[j].members[size] = copyPopMember(member)
+                        hallOfFame[j].exists[size] = true
                     end
                 end
 
                 # Dominating pareto curve - must be better than all simpler equations
-                dominating = calculateParetoFrontier(dataset, hallOfFame, options)
-                open(options.hofFile, "w") do io
+                dominating = calculateParetoFrontier(dataset, hallOfFame[j], options)
+                hofFile = options.hofFile
+                if nout > 1
+                    hofFile = "out$j" * "_" *hofFile
+                end
+                open(, "w") do io
                     println(io,"Complexity|MSE|Equation")
                     for member in dominating
                         println(io, "$(countNodes(member.tree))|$(member.score)|$(stringTree(member.tree, options, varMap=dataset.varMap))")
@@ -327,16 +368,16 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
                     end
                 end
 
-                cycles_remaining -= 1
-                if cycles_remaining == 0
+                cycles_remaining[j] -= 1
+                if cycles_remaining[j] == 0
                     break
                 end
                 worker_idx = next_worker()
-                allPops[i] = if parallel
+                allPops[j][i] = if parallel
                     @spawnat worker_idx let
                         tmp_pop, tmp_best_seen = SRCycle(
                             dataset, baselineMSE, cur_pop, options.ncyclesperiteration,
-                            curmaxsize, copy(frequencyComplexity)/sum(frequencyComplexity),
+                            curmaxsize, copy(frequencyComplexities[j])/sum(frequencyComplexities[j]),
                             verbosity=options.verbosity, options=options)
                         tmp_pop = OptimizeAndSimplifyPopulation(dataset, baselineMSE, tmp_pop, options, curmaxsize)
                         if options.batching
@@ -349,7 +390,7 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
                 else
                     tmp_pop, tmp_best_seen = SRCycle(
                         dataset, baselineMSE, cur_pop, options.ncyclesperiteration,
-                        curmaxsize, copy(frequencyComplexity)/sum(frequencyComplexity),
+                        curmaxsize, copy(frequencyComplexities[j])/sum(frequencyComplexities[j]),
                         verbosity=options.verbosity, options=options)
                     tmp_pop = OptimizeAndSimplifyPopulation(dataset, baselineMSE, tmp_pop, options, curmaxsize)
                     if options.batching
@@ -360,23 +401,23 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
                     (tmp_pop, tmp_best_seen)
                 end
                 if parallel
-                    @async put!(channels[i], fetch(allPops[i]))
+                    @async put!(channels[j][i], fetch(allPops[j][i]))
                 end
 
-                cycles_elapsed = total_cycles - cycles_remaining
+                cycles_elapsed = total_cycles - cycles_remaining[j]
                 if options.warmupMaxsizeBy > 0
                     fraction_elapsed = 1f0 * cycles_elapsed / total_cycles
                     if fraction_elapsed > options.warmupMaxsizeBy
-                        curmaxsize = options.maxsize
+                        curmaxsizes[j] = options.maxsize
                     else
-                        curmaxsize = 3 + floor(Int, (options.maxsize - 3) * fraction_elapsed / options.warmupMaxsizeBy)
+                        curmaxsizes[j] = 3 + floor(Int, (options.maxsize - 3) * fraction_elapsed / options.warmupMaxsizeBy)
                     end
                 end
-                num_equations += options.ncyclesperiteration * options.npop / 10.0
+                num_equations[j] += options.ncyclesperiteration * options.npop / 10.0
 
                 if options.progress
                     # set_postfix(iter, Equations=)
-                    equation_strings = string_dominating_pareto_curve(hallOfFame, baselineMSE,
+                    equation_strings = string_dominating_pareto_curve(hallOfFame[j], baselineMSE,
                                                                       dataset, options,
                                                                       avgy)
                     set_multiline_postfix(progress_bar, equation_strings)
@@ -387,11 +428,11 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
                     end
                 end
             end
-            elapsed = time() - last_print_time
+            elapsed = time() - last_print_time[j]
             #Update if time has passed, and some new equations generated.
-            if elapsed > print_every_n_seconds && num_equations > 0.0
+            if elapsed > print_every_n_seconds && num_equations[j] > 0.0
                 # Dominating pareto curve - must be better than all simpler equations
-                current_speed = num_equations/elapsed
+                current_speed = num_equations[j]/elapsed
                 average_over_m_measurements = 10 #for print_every...=5, this gives 50 second running average
                 push!(equation_speed, current_speed)
                 if length(equation_speed) > average_over_m_measurements
@@ -400,17 +441,20 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
                 if options.verbosity > 0
                     @printf("\n")
                     average_speed = sum(equation_speed)/length(equation_speed)
+                    if nout > 1
+                        @printf("Report for output %d", j)
+                    end
                     @printf("Cycles per second: %.3e\n", round(average_speed, sigdigits=3))
-                    cycles_elapsed = total_cycles - cycles_remaining
+                    cycles_elapsed = total_cycles - cycles_remaining[j]
                     @printf("Progress: %d / %d total iterations (%.3f%%)\n",
                             cycles_elapsed, total_cycles,
                             100.0*cycles_elapsed/total_cycles)
-                    equation_strings = string_dominating_pareto_curve(hallOfFame, baselineMSE,
+                    equation_strings = string_dominating_pareto_curve(hallOfFame[j], baselineMSE,
                                                                       dataset, options,
                                                                       avgy)
                     print(equation_strings)
                 end
-                last_print_time = time()
+                last_print_time[j] = time()
                 num_equations = 0.0
             end
         end
@@ -422,12 +466,20 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractVector{T};
     ##########################################################################
     ### Distributed code^
     ##########################################################################
-    return hallOfFame
+    if nout > 1
+        return hallOfFame[1]
+    else
+        return hallOfFame
+    end
+end
+
+function EquationSearch(X::AbstractMatrix{T1}, y::AbstractMatrix{T2}; kw...) where {T1<:Real,T2<:Real}
+    U = promote_type(T1, T2)
+    EquationSearch(convert(AbstractMatrix{U}, X), convert(AbstractMatrix{U}, y); kw...)
 end
 
 function EquationSearch(X::AbstractMatrix{T1}, y::AbstractVector{T2}; kw...) where {T1<:Real,T2<:Real}
-    U = promote_type(T1, T2)
-    EquationSearch(convert(AbstractMatrix{U}, X), convert(AbstractVector{U}, y); kw...)
+    EquationSearch(X, reshape(y, (1, size(y, 1))); kw...)
 end
 
 end #module SR

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -510,7 +510,7 @@ function EquationSearch(datasets::Array{Dataset{T}, 1};
     ##########################################################################
     ### Distributed code^
     ##########################################################################
-    if nout > 1
+    if nout == 1
         return hallOfFame[1]
     else
         return hallOfFame

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -135,9 +135,36 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractMatrix{T};
         weights = reshape(weights, size(y))
     end
     datasets = [Dataset(X, y[j, :],
-                        weights=(weights == nothing ? weights : weights[j, :]),
-                        varMap=varMap) for j=1:nout]
+                    weights=(weights == nothing ? weights : weights[j, :]),
+                    varMap=varMap)
+                for j=1:nout]
+
+    return EquationSearch(datasets;
+        niterations=niterations, options=options,
+        numprocs=numprocs, procs=procs,
+        runtests=runtests)
+end
+
+function EquationSearch(X::AbstractMatrix{T1}, y::AbstractMatrix{T2}; kw...) where {T1<:Real,T2<:Real}
+    U = promote_type(T1, T2)
+    EquationSearch(convert(AbstractMatrix{U}, X), convert(AbstractMatrix{U}, y); kw...)
+end
+
+function EquationSearch(X::AbstractMatrix{T1}, y::AbstractVector{T2}; kw...) where {T1<:Real,T2<:Real}
+    EquationSearch(X, reshape(y, (1, size(y, 1))); kw...)
+end
+
+function EquationSearch(datasets::Array{Dataset{T}, 1};
+        niterations::Int=10,
+        options::Options=Options(),
+        numprocs::Union{Int, Nothing}=nothing,
+        procs::Union{Array{Int, 1}, Nothing}=nothing,
+        runtests::Bool=true
+       ) where {T<:Real}
+
     example_dataset = datasets[1]
+    nout = size(datasets, 1)
+
     serial = (procs == nothing && numprocs == 0)
     parallel = !serial
 
@@ -490,13 +517,5 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractMatrix{T};
     end
 end
 
-function EquationSearch(X::AbstractMatrix{T1}, y::AbstractMatrix{T2}; kw...) where {T1<:Real,T2<:Real}
-    U = promote_type(T1, T2)
-    EquationSearch(convert(AbstractMatrix{U}, X), convert(AbstractMatrix{U}, y); kw...)
-end
-
-function EquationSearch(X::AbstractMatrix{T1}, y::AbstractVector{T2}; kw...) where {T1<:Real,T2<:Real}
-    EquationSearch(X, reshape(y, (1, size(y, 1))); kw...)
-end
 
 end #module SR

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -91,12 +91,12 @@ which is useful for debugging and profiling.
 # Arguments
 - `X::AbstractMatrix{T}`:  The input dataset to predict `y` from.
     The first dimension is features, the second dimension is rows.
-- `y::AbstractMatrix{T}`: The values to predict. The first dimension
+- `y::Union{AbstractMatrix{T}, AbstractVector{T}}`: The values to predict. The first dimension
     is the output feature to predict with each equation, and the
     second dimension is rows.
 - `niterations::Int=10`: The number of iterations to perform the search.
     More iterations will improve the results.
-- `weights::Union{AbstractMatrix{T}, Nothing}=nothing`: Optionally
+- `weights::Union{AbstractMatrix{T}, AbstractVector{T}, Nothing}=nothing`: Optionally
     weight the loss for each `y` by this value (same shape as `y`).
 - `varMap::Union{Array{String, 1}, Nothing}=nothing`: The names
     of each feature in `X`, which will be used during printing of equations.
@@ -122,7 +122,7 @@ which is useful for debugging and profiling.
 """
 function EquationSearch(X::AbstractMatrix{T}, y::AbstractMatrix{T};
         niterations::Int=10,
-        weights::Union{AbstractMatrix{T}, Nothing}=nothing,
+        weights::Union{AbstractMatrix{T}, AbstractVector{T}, Nothing}=nothing,
         varMap::Union{Array{String, 1}, Nothing}=nothing,
         options::Options=Options(),
         numprocs::Union{Int, Nothing}=nothing,
@@ -131,6 +131,9 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractMatrix{T};
        ) where {T<:Real}
 
     nout = size(y, FEATURE_DIM)
+    if weights != nothing
+        weights = reshape(weights, size(y))
+    end
     datasets = [Dataset(X, y[j, :],
                         weights=(weights == nothing ? weights : weights[j, :]),
                         varMap=varMap) for j=1:nout]

--- a/test/full.jl
+++ b/test/full.jl
@@ -38,36 +38,28 @@ for batching in [true, false]
             # Completely different function superimposed - need
             # to use correct weights to figure it out!
             y = (2 .* cos.(X[4, :])) .* weights .+ (1 .- weights) .* (5 .* X[2, :])
-            if multi
-                y = repeat(y, 1, 2)
-                y = transpose(y)
-            end
             hallOfFame = EquationSearch(X, y, weights=weights,
                                         niterations=2, options=options,
                                         numprocs=numprocs
                                        )
-            if multi
-                dominating = [calculateParetoFrontier(X, y, hof,
-                                                     options; weights=weights)
-                              for hof in hallOfFame]
-            else
-                dominating = calculateParetoFrontier(X, y, hallOfFame,
-                                                     options; weights=weights)
-            end
+            dominating = [calculateParetoFrontier(X, y, hallOfFame,
+                                                  options; weights=weights)]
         else
             y = 2 * cos.(X[4, :])
+            if multi
+                # Copy the same output twice; make sure we can find it twice
+                y = repeat(y, 1, 2)
+                y = transpose(y)
+            end
             hallOfFame = EquationSearch(X, y, niterations=2, options=options)
             if multi
-                dominating = [calculateParetoFrontier(X, y, hof, options)
-                              for hof in hallOfFame]
+                dominating = [calculateParetoFrontier(X, y[j, :], hallOfFame[j], options)
+                              for j=1:2]
             else
-                dominating = calculateParetoFrontier(X, y, hallOfFame, options)
+                dominating = [calculateParetoFrontier(X, y, hallOfFame, options)]
             end
         end
 
-        if !multi
-            dominating = [dominating]
-        end
         
         # Always assume multi
         for dom in dominating

--- a/test/full.jl
+++ b/test/full.jl
@@ -11,11 +11,15 @@ for batching in [true, false]
         progress = false
         warmupMaxsizeBy = 0f0
         optimizer_algorithm = "NelderMead"
+        multi = false
         if weighted && batching
             numprocs = 0 #Try serial computation here.
             progress = true #Also try the progress bar.
             warmupMaxsizeBy = 0.5f0 #Smaller maxsize at first, build up slowly
             optimizer_algorithm = "BFGS"
+        end
+        if !weighted && !batching
+            multi = true
         end
         options = SymbolicRegression.Options(
             binary_operators=(+, *),
@@ -34,30 +38,52 @@ for batching in [true, false]
             # Completely different function superimposed - need
             # to use correct weights to figure it out!
             y = (2 .* cos.(X[4, :])) .* weights .+ (1 .- weights) .* (5 .* X[2, :])
+            if multi
+                y = repeat(y, 1, 2)
+                y = transpose(y)
+            end
             hallOfFame = EquationSearch(X, y, weights=weights,
                                         niterations=2, options=options,
                                         numprocs=numprocs
                                        )
-            dominating = calculateParetoFrontier(X, y, hallOfFame,
-                                                 options; weights=weights)
+            if multi
+                dominating = [calculateParetoFrontier(X, y, hof,
+                                                     options; weights=weights)
+                              for hof in hallOfFame]
+            else
+                dominating = calculateParetoFrontier(X, y, hallOfFame,
+                                                     options; weights=weights)
+            end
         else
             y = 2 * cos.(X[4, :])
             hallOfFame = EquationSearch(X, y, niterations=2, options=options)
-            dominating = calculateParetoFrontier(X, y, hallOfFame, options)
+            if multi
+                dominating = [calculateParetoFrontier(X, y, hof, options)
+                              for hof in hallOfFame]
+            else
+                dominating = calculateParetoFrontier(X, y, hallOfFame, options)
+            end
         end
 
-        best = dominating[end]
-        eqn = node_to_symbolic(best.tree, options, evaluate_functions=true)
+        if !multi
+            dominating = [dominating]
+        end
+        
+        # Always assume multi
+        for dom in dominating
+            best = dom[end]
+            eqn = node_to_symbolic(best.tree, options, evaluate_functions=true)
 
-        local x4 = SymbolicUtils.Sym{Real}(Symbol("x4"))
-        true_eqn = 2*cos(x4)
-        residual = simplify(eqn - true_eqn) + x4 * 1e-10
+            local x4 = SymbolicUtils.Sym{Real}(Symbol("x4"))
+            true_eqn = 2*cos(x4)
+            residual = simplify(eqn - true_eqn) + x4 * 1e-10
 
-        # Test the score
-        @test best.score < maximum_residual / 10
-        # Test the actual equation found:
-        # eval evaluates inside global
-        @test abs(eval(Meta.parse(string(residual)))) < maximum_residual
+            # Test the score
+            @test best.score < maximum_residual / 10
+            # Test the actual equation found:
+            # eval evaluates inside global
+            @test abs(eval(Meta.parse(string(residual)))) < maximum_residual
+        end
     end
 end
 


### PR DESCRIPTION
This PR allows one to pass an array of `Dataset`  to EquationSearch, assuming they have they have the same type, and you use the same options. 

This change enables one to pass a matrix `y` to EquationSearch, which will get split up into a dataset for each `y` feature, before doing the equation search.

This means one can do an equation search for multiple outputs at the same time! Will solve https://github.com/MilesCranmer/PySR/issues/45 and https://github.com/MilesCranmer/PySR/issues/35.

Multiple outputs disables the progress bar option, but default printing still works - it prints the list of equations for each output separately.

It will return an array of `HallOfFame` objects for multiple outputs, or one for a single default, meaning this shouldn't affect compatibility.

This PR also uses the `BackTracking` line search for `Newton` and `NelderMead` methods, rather than the default HagerZhang. This seems to be much more robust to very nonlinear operators like `pow` and `exp`, fixing #17. 