### PR TITLE
Recorder and improved tournament selection

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - *
     paths:
       - 'test/**'
       - 'src/**'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ name: CI
 on:
   push:
     branches:
-      - *
+      - '*'
     paths:
       - 'test/**'
       - 'src/**'

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.6.0"
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FromFile = "ff7dd447-1dcb-4ce3-b8ac-22a812192de7"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 LossFunctions = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
@@ -19,7 +19,6 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [compat]
 FromFile = "0.1.0"
-JSON = "0.20, 0.21"
 LineSearches = "7"
 LossFunctions = "0.6, 0.7"
 Optim = "0.19, 1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.6.0"
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FromFile = "ff7dd447-1dcb-4ce3-b8ac-22a812192de7"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 LossFunctions = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
@@ -18,6 +19,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [compat]
 FromFile = "0.1.0"
+JSON = "0.20, 0.21"
 LineSearches = "7"
 LossFunctions = "0.6, 0.7"
 Optim = "0.19, 1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [compat]
 FromFile = "0.1.0"
+JSON3 = "1"
 LineSearches = "7"
 LossFunctions = "0.6, 0.7"
 Optim = "0.19, 1.1"

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -1,3 +1,5 @@
+@from "Core.jl" import RecordType
+
 # Check for errors before they happen
 function testOptionConfiguration(T, options::Options)
     
@@ -168,8 +170,8 @@ function test_entire_pipeline(procs, dataset::Dataset{T}, options::Options) wher
     for proc in procs
         push!(futures, @spawnat proc begin
             tmp_pop = Population(dataset, convert(T, 1), npop=20, nlength=3, options=options, nfeatures=dataset.nfeatures)
-            tmp_pop = SRCycle(dataset, convert(T, 1), tmp_pop, 5, 5, ones(T, dataset.n), verbosity=options.verbosity, options=options, record=Dict())[1]
-            tmp_pop = OptimizeAndSimplifyPopulation(dataset, T(1.0), tmp_pop, options, options.maxsize, Dict())
+            tmp_pop = SRCycle(dataset, convert(T, 1), tmp_pop, 5, 5, ones(T, dataset.n), verbosity=options.verbosity, options=options, record=RecordType())[1]
+            tmp_pop = OptimizeAndSimplifyPopulation(dataset, T(1.0), tmp_pop, options, options.maxsize, RecordType())
         end)
     end
     for future in futures

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -168,8 +168,8 @@ function test_entire_pipeline(procs, dataset::Dataset{T}, options::Options) wher
     for proc in procs
         push!(futures, @spawnat proc begin
             tmp_pop = Population(dataset, convert(T, 1), npop=20, nlength=3, options=options, nfeatures=dataset.nfeatures)
-            tmp_pop = SRCycle(dataset, convert(T, 1), tmp_pop, 5, 5, ones(T, dataset.n), verbosity=options.verbosity, options=options)[1]
-            tmp_pop = OptimizeAndSimplifyPopulation(dataset, T(1.0), tmp_pop, options, options.maxsize)
+            tmp_pop = SRCycle(dataset, convert(T, 1), tmp_pop, 5, 5, ones(T, dataset.n), verbosity=options.verbosity, options=options, record=Dict())[1]
+            tmp_pop = OptimizeAndSimplifyPopulation(dataset, T(1.0), tmp_pop, options, options.maxsize, Dict())
         end)
     end
     for future in futures

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,6 +1,6 @@
 using FromFile
 
-@from "ProgramConstants.jl" import CONST_TYPE, maxdegree, BATCH_DIM, FEATURE_DIM
+@from "ProgramConstants.jl" import CONST_TYPE, maxdegree, BATCH_DIM, FEATURE_DIM, RecordType
 @from "Dataset.jl" import Dataset
 @from "Equation.jl" import Node, copyNode
 @from "Options.jl" import Options

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -15,6 +15,7 @@ function nextGeneration(dataset::Dataset{T},
                         options::Options)::PopMember where {T<:Real}
 
     prev = member.tree
+    parent_ref = prev.ref
     tree = prev
     #TODO - reconsider this
     if options.batching
@@ -87,7 +88,7 @@ function nextGeneration(dataset::Dataset{T},
             if rand() < 0.01
                 tree = simplifyWithSymbolicUtils(tree, options, curmaxsize)
             end
-            return PopMember(tree, beforeLoss)
+            return PopMember(tree, beforeLoss, parent=parent_ref)
 
             is_success_always_possible = true
             # Simplification shouldn't hurt complexity; unless some non-symmetric constraint
@@ -98,7 +99,7 @@ function nextGeneration(dataset::Dataset{T},
 
             is_success_always_possible = true
         else # no mutation applied
-            return PopMember(tree, beforeLoss)
+            return PopMember(tree, beforeLoss, parent=parent_ref)
         end
 
         successful_mutation = successful_mutation && check_constraints(tree, options, curmaxsize)
@@ -108,7 +109,7 @@ function nextGeneration(dataset::Dataset{T},
     #############################################
 
     if !successful_mutation
-        return PopMember(copyNode(prev), beforeLoss)
+        return PopMember(copyNode(prev), beforeLoss, parent=parent_ref)
     end
 
     if options.batching
@@ -118,7 +119,7 @@ function nextGeneration(dataset::Dataset{T},
     end
 
     if isnan(afterLoss)
-        return PopMember(copyNode(prev), beforeLoss)
+        return PopMember(copyNode(prev), beforeLoss, parent=parent_ref)
     end
 
     probChange = 1.0
@@ -133,8 +134,8 @@ function nextGeneration(dataset::Dataset{T},
     end
 
     if probChange < rand()
-        return PopMember(copyNode(prev), beforeLoss)
+        return PopMember(copyNode(prev), beforeLoss, parent=parent_ref)
     else
-        return PopMember(tree, afterLoss)
+        return PopMember(tree, afterLoss, parent=parent_ref)
     end
 end

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -12,7 +12,7 @@ using FromFile
 function nextGeneration(dataset::Dataset{T},
                         baseline::T, member::PopMember, temperature::T,
                         curmaxsize::Int, frequencyComplexity::AbstractVector{T},
-                        options::Options; tmp_recorder::RecordType=RecordType())::PopMember where {T<:Real}
+                        options::Options; tmp_recorder::RecordType)::PopMember where {T<:Real}
 
     prev = member.tree
     parent_ref = member.ref

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -381,7 +381,8 @@ function Options(;
         verbosity = 0
     end
 
-    Options{typeof(binary_operators),typeof(unary_operators), typeof(loss)}(binary_operators, unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, warmupMaxsizeBy, useFrequency, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file)
+    options = Options{typeof(binary_operators),typeof(unary_operators), typeof(loss)}(binary_operators, unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, warmupMaxsizeBy, useFrequency, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file)
+    return options
 end
 
 

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -141,6 +141,8 @@ struct Options{A,B,C<:Union{SupervisedLoss,Function}}
     optimize_probability::Float32
     optimizer_nrestarts::Int
     optimizer_iterations::Int
+    recorder::Bool
+    recorder_file::String
 
 end
 
@@ -292,6 +294,8 @@ function Options(;
     optimize_probability=0.1f0,
     optimizer_iterations=100,
     nrestarts=nothing,
+    recorder=false,
+    recorder_file="pysr_recorder.json"
    ) where {nuna,nbin}
 
     if nrestarts != nothing
@@ -377,7 +381,7 @@ function Options(;
         verbosity = 0
     end
 
-    Options{typeof(binary_operators),typeof(unary_operators), typeof(loss)}(binary_operators, unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, warmupMaxsizeBy, useFrequency, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations)
+    Options{typeof(binary_operators),typeof(unary_operators), typeof(loss)}(binary_operators, unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, warmupMaxsizeBy, useFrequency, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file)
 end
 
 

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -143,6 +143,7 @@ struct Options{A,B,C<:Union{SupervisedLoss,Function}}
     optimizer_iterations::Int
     recorder::Bool
     recorder_file::String
+    probPickFirst::Float32
 
 end
 
@@ -252,6 +253,10 @@ Construct options for `EquationSearch` and other functions.
 - `seed=nothing`: What random seed to use. `nothing` uses no seed.
 - `progress=false`: Whether to use a progress bar output (`verbosity` will
     have no effect).
+
+
+- `probPickFirst=1.0`: Expressions in subsample are chosen based on, for
+    p=probPickFirst: p, p*(1-p), p*(1-p)^2, and so on.
 """
 function Options(;
     binary_operators::NTuple{nbin, Any}=(div, plus, mult),
@@ -295,7 +300,8 @@ function Options(;
     optimizer_iterations=100,
     nrestarts=nothing,
     recorder=false,
-    recorder_file="pysr_recorder.json"
+    recorder_file="pysr_recorder.json",
+    probPickFirst=1.0,
    ) where {nuna,nbin}
 
     if nrestarts != nothing
@@ -381,7 +387,7 @@ function Options(;
         verbosity = 0
     end
 
-    options = Options{typeof(binary_operators),typeof(unary_operators), typeof(loss)}(binary_operators, unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, warmupMaxsizeBy, useFrequency, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file)
+    options = Options{typeof(binary_operators),typeof(unary_operators), typeof(loss)}(binary_operators, unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, warmupMaxsizeBy, useFrequency, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file, probPickFirst)
     return options
 end
 

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -299,7 +299,7 @@ function Options(;
     optimize_probability=0.1f0,
     optimizer_iterations=100,
     nrestarts=nothing,
-    recorder=false,
+    recorder=nothing,
     recorder_file="pysr_recorder.json",
     probPickFirst=1.0,
    ) where {nuna,nbin}
@@ -385,6 +385,12 @@ function Options(;
 
     if progress
         verbosity = 0
+    end
+
+    if recorder == nothing
+        recorder = haskey(ENV, "PYSR_RECORDER") && (ENV["PYSR_RECORDER"] == "1")
+    else
+        recorder = false
     end
 
     options = Options{typeof(binary_operators),typeof(unary_operators), typeof(loss)}(binary_operators, unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, warmupMaxsizeBy, useFrequency, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file, probPickFirst)

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -8,6 +8,10 @@ mutable struct PopMember{T<:Real}
     tree::Node
     score::T
     birth::Int
+
+    # For recording history:
+    ref::Int
+    parent::Int
 end
 
 """
@@ -20,8 +24,11 @@ Create a population member with a birth date at the current time.
 - `t::Node`: The tree for the population member.
 - `score::T`: The loss to assign this member.
 """
-function PopMember(t::Node, score::T) where {T<:Real}
-    PopMember{T}(t, score, getTime())
+function PopMember(t::Node, score::T; ref::Int=-1, parent::Int=-1) where {T<:Real}
+    if ref == -1
+        ref = abs(rand(Int))
+    end
+    PopMember{T}(t, score, getTime(), ref, parent)
 end
 
 """
@@ -40,13 +47,15 @@ Automatically compute the score for this tree.
 """
 function PopMember(dataset::Dataset{T},
                    baseline::T, t::Node,
-                   options::Options) where {T<:Real}
-    PopMember(t, scoreFunc(dataset, baseline, t, options))
+                   options::Options; ref::Int=-1, parent::Int=-1) where {T<:Real}
+    PopMember(t, scoreFunc(dataset, baseline, t, options), ref=ref, parent=parent)
 end
 
 function copyPopMember(p::PopMember{T}) where {T<:Real}
     tree = copyNode(p.tree)
     score = p.score
     birth = p.birth
-    return PopMember{T}(tree, score, birth)
+    ref = p.ref
+    parent = p.parent
+    return PopMember{T}(tree, score, birth, ref, parent)
 end

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -106,7 +106,7 @@ function record_population(pop::Population{T}, options::Options)::RecordType whe
     RecordType("population"=>[RecordType("tree"=>stringTree(member.tree, options),
                                          "loss"=>member.score,
                                          "complexity"=>countNodes(member.tree),
-                                         "age"=>member.age,
+                                         "birth"=>member.birth,
                                          "ref"=>member.ref,
                                          "parent"=>member.parent)
                              for member in pop.members],

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -87,35 +87,6 @@ function bestSubPop(pop::Population; topn::Int=10)::Population
     return Population(pop.members[best_idx[1:topn]])
 end
 
-# Return best 10 examples size that are pareto dominating
-function bestSubPopParetoDominating(pop::Population{T}; topn::Int=10)::Population where {T<:Real}
-    scores = [pop.members[member].score for member=1:pop.n]
-    best_idx = sortperm(scores)
-
-    sorted = pop.members[best_idx]
-    score_sorted = scores[best_idx]
-    sizes = [countNodes(sorted[i].tree) for i=1:pop.n]
-
-    best = [1]
-    for i=2:pop.n
-        better_than_all_smaller = true
-        for j=i-1:1
-            if sizes[j] < sizes[i] #Another model is smaller AND better
-                better_than_all_smaller = false
-                break
-            end
-        end
-        if better_than_all_smaller
-            best = vcat(best, [i])
-        end
-        if length(best) == topn
-            break
-        end
-    end
-    return Population(sorted[best])
-end
-
-
 
 function record_population(pop::Population{T}, options::Options)::RecordType where {T<:Real}
     RecordType("population"=>[RecordType("tree"=>stringTree(member.tree, options),

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -1,5 +1,6 @@
 using FromFile
-@from "Core.jl" import Options, Dataset
+@from "Core.jl" import Options, Dataset, RecordType
+@from "EquationUtils.jl" import stringTree, countNodes
 @from "LossFunctions.jl" import scoreFunc
 @from "MutationFunctions.jl" import genRandomTree
 @from "PopMember.jl" import PopMember
@@ -100,3 +101,15 @@ function bestSubPopParetoDominating(pop::Population{T}; topn::Int=10)::Populatio
 end
 
 
+
+function record_population(pop::Population{T}, options::Options)::RecordType where {T<:Real}
+    RecordType("population"=>[RecordType("tree"=>stringTree(member.tree, options),
+                                         "loss"=>member.score,
+                                         "complexity"=>countNodes(member.tree),
+                                         "age"=>member.age,
+                                         "ref"=>member.ref,
+                                         "parent"=>member.parent)
+                             for member in pop.members],
+               "time"=>time()
+    )
+end

--- a/src/ProgramConstants.jl
+++ b/src/ProgramConstants.jl
@@ -3,7 +3,3 @@ const CONST_TYPE = Float32
 const BATCH_DIM = 2
 const FEATURE_DIM = 1
 const RecordType = Dict{String, Any}
-# macro RecordType()
-    # Dict{String, Union{Dict, <:Real, String, Array{Any, 1}}}
-    # Dict{String, Any}
-# end

--- a/src/ProgramConstants.jl
+++ b/src/ProgramConstants.jl
@@ -2,3 +2,5 @@ const maxdegree = 2
 const CONST_TYPE = Float32
 const BATCH_DIM = 2
 const FEATURE_DIM = 1
+const RecordType = Dict{String, Union{Dict, <:Real, String, Array}}
+

--- a/src/ProgramConstants.jl
+++ b/src/ProgramConstants.jl
@@ -2,5 +2,8 @@ const maxdegree = 2
 const CONST_TYPE = Float32
 const BATCH_DIM = 2
 const FEATURE_DIM = 1
-const RecordType = Dict{String, Union{Dict, <:Real, String, Array}}
-
+const RecordType = Dict{String, Any}
+# macro RecordType()
+    # Dict{String, Union{Dict, <:Real, String, Array{Any, 1}}}
+    # Dict{String, Any}
+# end

--- a/src/Recorder.jl
+++ b/src/Recorder.jl
@@ -1,0 +1,16 @@
+"Assumes that `options` holds the user options::Options"
+macro recorder(ex)
+    quote
+        if options.recorder
+            $(esc(ex))
+        end
+    end
+end
+
+function find_iteration_from_record(key::String, record::RecordType)
+    iteration = 0
+    while haskey(record[key], "iteration$(iteration)")
+        iteration += 1
+    end
+    return iteration - 1
+end

--- a/src/Recorder.jl
+++ b/src/Recorder.jl
@@ -4,7 +4,7 @@ using FromFile
 "Assumes that `options` holds the user options::Options"
 macro recorder(ex)
     quote
-        if options.recorder
+        if $(esc(:options)).recorder
             $(esc(ex))
         end
     end

--- a/src/Recorder.jl
+++ b/src/Recorder.jl
@@ -1,3 +1,6 @@
+using FromFile
+@from "Core.jl" import RecordType
+
 "Assumes that `options` holds the user options::Options"
 macro recorder(ex)
     quote

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -5,6 +5,7 @@ using Random: shuffle!
 @from "PopMember.jl" import PopMember
 @from "Population.jl" import Population, bestOfSample
 @from "Mutate.jl" import nextGeneration
+@from "Recorder.jl" import @recorder
 
 # Pass through the population several times, replacing the oldest
 # with the fittest of a small subsample
@@ -19,7 +20,7 @@ function regEvolCycle(dataset::Dataset{T},
     if options.fast_cycle
 
         # These options are not implemented for fast_cycle:
-        @assert !options.recorder
+        @recorder error("You cannot have the recorder and fast_cycle set to true at the same time!")
         @assert options.probPickFirst == 1.0
 
         shuffle!(pop.members)
@@ -57,7 +58,7 @@ function regEvolCycle(dataset::Dataset{T},
 
             oldest = argmin([pop.members[member].birth for member=1:pop.n])
 
-            if options.recorder
+            @recorder begin
                 if !haskey(record, "mutations")
                     record["mutations"] = RecordType()
                 end

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -39,8 +39,10 @@ function regEvolCycle(dataset::Dataset{T},
                 end
             end
             allstar = pop.members[best_idx]
+            mutation_recorder = RecordType()
             babies[i] = nextGeneration(dataset, baseline, allstar, temperature,
-                                       curmaxsize, frequencyComplexity, options)
+                                       curmaxsize, frequencyComplexity, options,
+                                       tmp_recorder=mutation_recorder)
         end
 
         # Replace the n_evol_cycles-oldest members of each population

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -62,21 +62,18 @@ function regEvolCycle(dataset::Dataset{T},
                 end
                 for member in [allstar, baby, pop.members[oldest]]
                     if !haskey(record["mutations"], "$(member.ref)")
-                        record["mutations"]["$(member.ref)"] = RecordType("events"=>RecordType(),
+                        record["mutations"]["$(member.ref)"] = RecordType("events"=>Vector{RecordType}(),
                                                                           "tree"=>stringTree(member.tree, options),
                                                                           "score"=>member.score,
                                                                           "parent"=>member.parent)
                     end
                 end
-                mutate_event = RecordType("type"=>"mutate",
-                                          "time"=>time(),
-                                          "child"=>baby.ref,
-                                          "mutation"=>mutation_recorder)
+                mutate_event = RecordType("type"=>"mutate", "time"=>time(), "child"=>baby.ref, "mutation"=>mutation_recorder)
                 death_event  = RecordType("type"=>"death",  "time"=>time())
 
                 # Put in random key rather than vector; otherwise there are collisions!
-                record["mutations"]["$(allstar.ref)"]["events"]["$(abs(rand(Int)))"] = mutate_event
-                record["mutations"]["$(pop.members[oldest].ref)"]["events"]["$(abs(rand(Int)))"] = death_event
+                push!(record["mutations"]["$(allstar.ref)"]["events"], mutate_event)
+                push!(record["mutations"]["$(pop.members[oldest].ref)"]["events"], death_event)
             end
 
             pop.members[oldest] = baby

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -18,8 +18,9 @@ function regEvolCycle(dataset::Dataset{T},
     # as good.
     if options.fast_cycle
 
-        #No recording allowed here:
+        # These options are not implemented for fast_cycle:
         @assert !options.recorder
+        @assert options.probPickFirst == 1.0
 
         shuffle!(pop.members)
         n_evol_cycles = round(Int, pop.n/options.ns)

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -1,5 +1,5 @@
 using FromFile
-@from "Core.jl" import Options, Dataset
+@from "Core.jl" import Options, Dataset, RecordType
 @from "EquationUtils.jl" import countNodes
 @from "Utils.jl" import debug
 @from "EquationUtils.jl" import stringTree
@@ -19,7 +19,8 @@ function SRCycle(dataset::Dataset{T}, baseline::T,
         curmaxsize::Int,
         frequencyComplexity::AbstractVector{T};
         verbosity::Int=0,
-        options::Options
+        options::Options,
+        record::RecordType
         )::Tuple{Population, HallOfFame} where {T<:Real}
 
     top = convert(T, 1)
@@ -28,9 +29,9 @@ function SRCycle(dataset::Dataset{T}, baseline::T,
 
     for temperature in 1:size(allT, 1)
         if options.annealing
-            pop = regEvolCycle(dataset, baseline, pop, allT[temperature], curmaxsize, frequencyComplexity, options)
+            pop = regEvolCycle(dataset, baseline, pop, allT[temperature], curmaxsize, frequencyComplexity, options, record)
         else
-            pop = regEvolCycle(dataset, baseline, pop, top, curmaxsize, frequencyComplexity, options)
+            pop = regEvolCycle(dataset, baseline, pop, top, curmaxsize, frequencyComplexity, options, record)
         end
         for member in pop.members
             size = countNodes(member.tree)
@@ -55,7 +56,8 @@ end
 function OptimizeAndSimplifyPopulation(
             dataset::Dataset{T}, baseline::T,
             pop::Population, options::Options,
-            curmaxsize::Int
+            curmaxsize::Int,
+            record::RecordType
         )::Population where {T<:Real}
     @inbounds @simd for j=1:pop.n
         pop.members[j].tree = simplifyTree(pop.members[j].tree, options)

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -226,6 +226,7 @@ function EquationSearch(datasets::Array{Dataset{T}, 1};
             procs = addprocs(numprocs)
             we_created_procs = true
         end
+
         if we_created_procs
             project_path = splitdir(Pkg.project().path)[1]
             activate_env_on_workers(procs, project_path, options)

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -51,7 +51,7 @@ export Population,
     atanh_clip
 
 using Distributed
-import JSON
+import JSON3
 using Printf: @printf
 using Pkg
 using Random: seed!, shuffle!
@@ -551,9 +551,8 @@ function EquationSearch(datasets::Array{Dataset{T}, 1};
     ##########################################################################
 
     if options.recorder
-        recorder_data = JSON.json(record)
-        open(options.recorder_file, "w") do f
-            write(f, recorder_data)
+        open(options.recorder_file, "w") do io
+            JSON3.write(io, record)
         end
     end
 

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -279,7 +279,9 @@ function EquationSearch(datasets::Array{Dataset{T}, 1};
         frequencyComplexity = frequencyComplexities[j]
         curmaxsize = curmaxsizes[j]
         for i=1:options.npopulations
-            record["out$(j)_pop$(i)"] = RecordType()
+            if options.recorder
+                record["out$(j)_pop$(i)"] = RecordType()
+            end
             worker_idx = next_worker()
             allPops[j][i] = if parallel
                 @spawnat worker_idx let

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -25,3 +25,7 @@ function is_anonymous_function(op)
 	op_string = string(nameof(op))
 	return length(op_string) > 1 && op_string[1] == '#' && check_numeric(op_string[2:2])
 end
+
+function recursive_merge(x::AbstractDict...)
+    merge(recursive_merge, x...)
+end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -26,6 +26,15 @@ function is_anonymous_function(op)
 	return length(op_string) > 1 && op_string[1] == '#' && check_numeric(op_string[2:2])
 end
 
+function recursive_merge(x::AbstractVector...)
+    cat(x...; dims=1)
+end
+
 function recursive_merge(x::AbstractDict...)
     merge(recursive_merge, x...)
 end
+
+function recursive_merge(x...)
+    x[end]
+end
+

--- a/test/full.jl
+++ b/test/full.jl
@@ -21,7 +21,7 @@ for batching in [true, false]
             warmupMaxsizeBy = 0.5f0 #Smaller maxsize at first, build up slowly
             optimizer_algorithm = "BFGS"
             recorder = true
-            probPickFirst = 0.5
+            probPickFirst = 0.8
         end
         if !weighted && !batching
             multi = true

--- a/test/full.jl
+++ b/test/full.jl
@@ -12,11 +12,15 @@ for batching in [true, false]
         warmupMaxsizeBy = 0f0
         optimizer_algorithm = "NelderMead"
         multi = false
+        recorder = false
+        probPickFirst = 1.0
         if weighted && batching
             numprocs = 0 #Try serial computation here.
             progress = true #Also try the progress bar.
             warmupMaxsizeBy = 0.5f0 #Smaller maxsize at first, build up slowly
             optimizer_algorithm = "BFGS"
+            recorder = true
+            probPickFirst = 0.5
         end
         if !weighted && !batching
             multi = true
@@ -29,7 +33,9 @@ for batching in [true, false]
             seed=0,
             progress=progress,
             warmupMaxsizeBy=warmupMaxsizeBy,
-            optimizer_algorithm=optimizer_algorithm
+            optimizer_algorithm=optimizer_algorithm,
+            recorder=recorder,
+            probPickFirst=probPickFirst
         )
         X = randn(MersenneTwister(0), Float32, 5, 100)
         if weighted

--- a/test/full.jl
+++ b/test/full.jl
@@ -97,7 +97,7 @@ X = randn(MersenneTwister(0), Float32, 5, 100)
 y = 2 * cos.(X[4, :])
 varMap = ["t1", "t2", "t3", "t4", "t5"]
 hallOfFame = EquationSearch(X, y; varMap=varMap,
-                            niterations=2, options=options)
+                            niterations=2, options=options, numprocs=0)
 dominating = calculateParetoFrontier(X, y, hallOfFame, options)
 
 best = dominating[end]

--- a/test/full.jl
+++ b/test/full.jl
@@ -1,6 +1,7 @@
 using FromFile
 @from "test_params.jl" import maximum_residual
-using SymbolicRegression, SymbolicUtils, Test
+using SymbolicRegression, SymbolicUtils
+using Test
 using SymbolicRegression: stringTree
 using Random
 

--- a/test/full.jl
+++ b/test/full.jl
@@ -20,10 +20,10 @@ for batching in [true, false]
             progress = true #Also try the progress bar.
             warmupMaxsizeBy = 0.5f0 #Smaller maxsize at first, build up slowly
             optimizer_algorithm = "BFGS"
-            recorder = true
             probPickFirst = 0.8
         end
         if !weighted && !batching
+            recorder = true
             multi = true
         end
         options = SymbolicRegression.Options(
@@ -97,7 +97,7 @@ X = randn(MersenneTwister(0), Float32, 5, 100)
 y = 2 * cos.(X[4, :])
 varMap = ["t1", "t2", "t3", "t4", "t5"]
 hallOfFame = EquationSearch(X, y; varMap=varMap,
-                            niterations=2, options=options, numprocs=0)
+                            niterations=2, options=options)
 dominating = calculateParetoFrontier(X, y, hallOfFame, options)
 
 best = dominating[end]


### PR DESCRIPTION
This adds two features:

1. A data recorder. This records all the internal behaviour of PySR into a JSON file that contains structured information about mutations, population over time, ancestry trees, etc. Helpful for improving the algorithm.
2. Regularized tournament selection with the use of `probPickFirst` in [0, 1]. Default is 1 which is equivalent to the current algorithm. Smaller probPickFirst is more regularization => more diversity of equations. Makes each run take a bit longer but seems to help exploration.