### PR TITLE
Add multithreading as alternative to distributed

### DIFF
--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -1,5 +1,4 @@
 @from "Core.jl" import RecordType
-using Distributed
 
 # Check for errors before they happen
 function testOptionConfiguration(T, options::Options)

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -1,4 +1,5 @@
 @from "Core.jl" import RecordType
+import Distributed: @spawnat, @everywhere
 
 # Check for errors before they happen
 function testOptionConfiguration(T, options::Options)

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -1,5 +1,5 @@
 @from "Core.jl" import RecordType
-import Distributed: @spawnat, @everywhere
+using Distributed
 
 # Check for errors before they happen
 function testOptionConfiguration(T, options::Options)

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,6 +1,6 @@
 using FromFile
 
-@from "ProgramConstants.jl" import CONST_TYPE, maxdegree, BATCH_DIM, FEATURE_DIM, RecordType
+@from "ProgramConstants.jl" import CONST_TYPE, maxdegree, BATCH_DIM, FEATURE_DIM, RecordType, SRConcurrency, SRSerial, SRThreaded, SRDistributed
 @from "Dataset.jl" import Dataset
 @from "Equation.jl" import Node, copyNode
 @from "Options.jl" import Options

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,6 +1,6 @@
 using FromFile
 
-@from "ProgramConstants.jl" import CONST_TYPE, maxdegree, BATCH_DIM, FEATURE_DIM, RecordType, SRConcurrency, SRSerial, SRThreaded, SRDistributed
+@from "ProgramConstants.jl" import CONST_TYPE, MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType, SRConcurrency, SRSerial, SRThreaded, SRDistributed
 @from "Dataset.jl" import Dataset
 @from "Equation.jl" import Node, copyNode
 @from "Options.jl" import Options

--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -1,5 +1,5 @@
 using FromFile
-@from "Core.jl" import CONST_TYPE, maxdegree, Node, Options, Dataset
+@from "Core.jl" import CONST_TYPE, MAX_DEGREE, Node, Options, Dataset
 @from "EquationUtils.jl" import stringTree
 @from "PopMember.jl" import PopMember
 @from "LossFunctions.jl" import EvalLoss
@@ -23,7 +23,7 @@ by size (i.e., `.members[1]` is the constant solution).
 has been instantiated or not.
 """
 function HallOfFame(options::Options)
-    actualMaxsize = options.maxsize + maxdegree
+    actualMaxsize = options.maxsize + MAX_DEGREE
     HallOfFame([PopMember(Node(convert(CONST_TYPE, 1)), 1f9) for i=1:actualMaxsize], [false for i=1:actualMaxsize])
 end
 
@@ -37,7 +37,7 @@ function calculateParetoFrontier(dataset::Dataset{T},
                                  options::Options)::Array{PopMember, 1} where {T<:Real}
     # Dominating pareto curve - must be better than all simpler equations
     dominating = PopMember[]
-    actualMaxsize = options.maxsize + maxdegree
+    actualMaxsize = options.maxsize + MAX_DEGREE
     for size=1:actualMaxsize
         if hallOfFame.exists[size]
             member = hallOfFame.members[size]
@@ -86,7 +86,7 @@ function string_dominating_pareto_curve(hallOfFame, baselineMSE,
     output *= @sprintf("%-10s  %-8s   %-8s  %-8s\n", "Complexity", "Loss", "Score", "Equation")
 
     #TODO - call pareto function!
-    actualMaxsize = options.maxsize + maxdegree
+    actualMaxsize = options.maxsize + MAX_DEGREE
     for size=1:actualMaxsize
         if hallOfFame.exists[size]
             member = hallOfFame.members[size]

--- a/src/ProgramConstants.jl
+++ b/src/ProgramConstants.jl
@@ -3,3 +3,9 @@ const CONST_TYPE = Float32
 const BATCH_DIM = 2
 const FEATURE_DIM = 1
 const RecordType = Dict{String, Any}
+
+"""Enum for concurrency type (to get function specialization)"""
+abstract type SRConcurrency end
+struct SRSerial <: SRConcurrency end
+struct SRThreaded <: SRConcurrency end
+struct SRDistributed <: SRConcurrency end

--- a/src/ProgramConstants.jl
+++ b/src/ProgramConstants.jl
@@ -1,4 +1,4 @@
-const maxdegree = 2
+const MAX_DEGREE = 2
 const CONST_TYPE = Float32
 const BATCH_DIM = 2
 const FEATURE_DIM = 1

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -310,6 +310,8 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
             if ConcurrencyType == SRDistributed
                 worker_assignment[(j, i)] = worker_idx
             end
+
+            # TODO - why is this needed??
             # Multi-threaded doesn't like to fetch within a new task:
             in_pop = if ConcurrencyType == SRThreaded
                 fetch(allPops[j][i])[1]

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -60,7 +60,7 @@ using Reexport
 @reexport using LossFunctions
 
 @from "Core.jl" import CONST_TYPE, MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType, Dataset, Node, copyNode, Options, plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip, SRConcurrency, SRSerial, SRThreaded, SRDistributed
-@from "Utils.jl" import debug, debug_inline, is_anonymous_function, recursive_merge, next_worker, @maybespawnat
+@from "Utils.jl" import debug, debug_inline, is_anonymous_function, recursive_merge, next_worker, @pysr_spawner
 @from "EquationUtils.jl" import countNodes, printTree, stringTree
 @from "EvaluateEquation.jl" import evalTreeArray, differentiableEvalTreeArray
 @from "CheckConstraints.jl" import check_constraints
@@ -289,7 +289,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
             if ConcurrencyType == SRDistributed
                 worker_assignment[(j, i)] = worker_idx
             end
-            new_pop = @maybespawnat ConcurrencyType worker_idx (
+            new_pop = @pysr_spawner ConcurrencyType worker_idx (
                 Population(datasets[j], baselineMSEs[j], npop=options.npop,
                            nlength=3, options=options, nfeatures=datasets[j].nfeatures),
                 HallOfFame(options),
@@ -318,7 +318,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
             else
                 allPops[j][i][1]
             end
-            allPops[j][i] = @maybespawnat ConcurrencyType worker_idx let
+            allPops[j][i] = @pysr_spawner ConcurrencyType worker_idx let
                 in_pop = if ConcurrencyType == SRDistributed
                     fetch(allPops[j][i])[1]
                 else
@@ -473,7 +473,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                 iteration = find_iteration_from_record(key, record) + 1
             end
 
-            allPops[j][i] = @maybespawnat ConcurrencyType worker_idx let
+            allPops[j][i] = @pysr_spawner ConcurrencyType worker_idx let
                 cur_record = RecordType()
                 @recorder cur_record[key] = RecordType("iteration$(iteration)"=>record_population(cur_pop, options))
                 tmp_pop, tmp_best_seen = SRCycle(

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -129,7 +129,7 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractMatrix{T};
         options::Options=Options(),
         numprocs::Union{Int, Nothing}=nothing,
         procs::Union{Array{Int, 1}, Nothing}=nothing,
-        multithreaded::Bool=false,
+        multithreading::Bool=false,
         runtests::Bool=true
        ) where {T<:Real}
 
@@ -144,7 +144,7 @@ function EquationSearch(X::AbstractMatrix{T}, y::AbstractMatrix{T};
 
     return EquationSearch(datasets;
         niterations=niterations, options=options,
-        numprocs=numprocs, procs=procs, multithreaded=multithreaded,
+        numprocs=numprocs, procs=procs, multithreading=multithreading,
         runtests=runtests)
 end
 
@@ -162,19 +162,19 @@ function EquationSearch(datasets::Array{Dataset{T}, 1};
         options::Options=Options(),
         numprocs::Union{Int, Nothing}=nothing,
         procs::Union{Array{Int, 1}, Nothing}=nothing,
-        multithreaded::Bool=false,
+        multithreading::Bool=false,
         runtests::Bool=true
        ) where {T<:Real}
 
     noprocs = (procs == nothing && numprocs == 0)
     someprocs = !noprocs
 
-    concurrency = if multithreaded
+    concurrency = if multithreading
         @assert procs == nothing && numprocs in [0, nothing]
         SRThreaded()
     elseif someprocs
         SRDistributed()
-    else #noprocs, multithreaded=false
+    else #noprocs, multithreading=false
         SRSerial()
     end
 

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -437,14 +437,13 @@ function EquationSearch(datasets::Array{Dataset{T}, 1};
             if parallel
                 worker_assignment[(j, i)] = worker_idx
             end
+            key = "out$(j)_pop$(i)"
+            iteration = find_iteration_from_record(key, record) + 1
+
             allPops[j][i] = if parallel
                 @spawnat worker_idx let
                     cur_record = RecordType()
-                    @recorder begin
-                        key = "out$(j)_pop$(i)"
-                        iteration = find_iteration_from_record(key, record) + 1
-                        cur_record[key] = RecordType("iteration$(iteration)"=>record_population(cur_pop, options))
-                    end
+                    @recorder cur_record[key] = RecordType("iteration$(iteration)"=>record_population(cur_pop, options))
                     tmp_pop, tmp_best_seen = SRCycle(
                         dataset, baselineMSE, cur_pop, options.ncyclesperiteration,
                         curmaxsize, copy(frequencyComplexities[j])/sum(frequencyComplexities[j]),
@@ -459,11 +458,7 @@ function EquationSearch(datasets::Array{Dataset{T}, 1};
                 end
             else
                 cur_record = RecordType()#copy(record)
-                @recorder begin
-                    key = "out$(j)_pop$(i)"
-                    iteration = find_iteration_from_record(key, record) + 1
-                    cur_record[key] = RecordType("iteration$(iteration)"=>record_population(cur_pop, options))
-                end
+                @recorder cur_record[key] = RecordType("iteration$(iteration)"=>record_population(cur_pop, options))
                 tmp_pop, tmp_best_seen = SRCycle(
                     dataset, baselineMSE, cur_pop, options.ncyclesperiteration,
                     curmaxsize, copy(frequencyComplexities[j])/sum(frequencyComplexities[j]),

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -59,7 +59,7 @@ using FromFile
 using Reexport
 @reexport using LossFunctions
 
-@from "Core.jl" import CONST_TYPE, maxdegree, BATCH_DIM, FEATURE_DIM, RecordType, Dataset, Node, copyNode, Options, plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip, SRConcurrency, SRSerial, SRThreaded, SRDistributed
+@from "Core.jl" import CONST_TYPE, MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType, Dataset, Node, copyNode, Options, plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip, SRConcurrency, SRSerial, SRThreaded, SRDistributed
 @from "Utils.jl" import debug, debug_inline, is_anonymous_function, recursive_merge, next_worker, @maybespawnat
 @from "EquationUtils.jl" import countNodes, printTree, stringTree
 @from "EvaluateEquation.jl" import evalTreeArray, differentiableEvalTreeArray
@@ -242,7 +242,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                     for i=1:options.npopulations]
                     for j=1:nout]
     hallOfFame = [HallOfFame(options) for j=1:nout]
-    actualMaxsize = options.maxsize + maxdegree
+    actualMaxsize = options.maxsize + MAX_DEGREE
     frequencyComplexities = [ones(T, actualMaxsize) for i=1:nout]
     curmaxsizes = [3 for j=1:nout]
     record = RecordType("options"=>"$(options)")
@@ -327,7 +327,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                                                  record=cur_record)
                 tmp_pop = OptimizeAndSimplifyPopulation(dataset, baselineMSE, tmp_pop, options, curmaxsize, cur_record)
                 if options.batching
-                    for i_member=1:(options.maxsize + maxdegree)
+                    for i_member=1:(options.maxsize + MAX_DEGREE)
                         tmp_best_seen.members[i_member].score = scoreFunc(dataset, baselineMSE, tmp_best_seen.members[i_member].tree, options)
                     end
                 end
@@ -412,7 +412,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                 if part_of_cur_pop
                     frequencyComplexities[j][size] += 1
                 end
-                actualMaxsize = options.maxsize + maxdegree
+                actualMaxsize = options.maxsize + MAX_DEGREE
                 if size < actualMaxsize && all([member.score < hallOfFame[j].members[size2].score for size2=1:size])
                     hallOfFame[j].members[size] = copyPopMember(member)
                     hallOfFame[j].exists[size] = true
@@ -475,7 +475,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                     verbosity=options.verbosity, options=options, record=cur_record)
                 tmp_pop = OptimizeAndSimplifyPopulation(dataset, baselineMSE, tmp_pop, options, curmaxsize, cur_record)
                 if options.batching
-                    for i_member=1:(options.maxsize + maxdegree)
+                    for i_member=1:(options.maxsize + MAX_DEGREE)
                         tmp_best_seen.members[i_member].score = scoreFunc(dataset, baselineMSE, tmp_best_seen.members[i_member].tree, options)
                     end
                 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,4 +1,5 @@
-using Printf: @printf
+import Printf: @printf
+import Distributed: @spawnat
 
 function debug(verbosity, string...)
     if verbosity > 0
@@ -65,4 +66,14 @@ end
 
 function next_worker(worker_assignment::Dict{Tuple{Int,Int}, Int}, procs::Nothing)::Int
     return 0
+end
+
+macro maybespawnat(is_parallel, p, expr)
+    quote
+        if $(esc(is_parallel))
+            @spawnat($(esc(p)), $(esc(expr)))
+        else
+            $(esc(expr))
+        end
+    end
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,5 +1,7 @@
 import Printf: @printf
-import Distributed: @spawnat
+using Distributed
+using FromFile
+@from "Core.jl" import SRThreaded, SRSerial, SRDistributed
 
 function debug(verbosity, string...)
     if verbosity > 0
@@ -68,12 +70,14 @@ function next_worker(worker_assignment::Dict{Tuple{Int,Int}, Int}, procs::Nothin
     return 0
 end
 
-macro maybespawnat(is_parallel, p, expr)
+macro maybespawnat(parallel, p, expr)
     quote
-        if $(esc(is_parallel))
+        if $(esc(parallel)) == SRSerial
+            $(esc(expr))
+        elseif $(esc(parallel)) == SRDistributed
             @spawnat($(esc(p)), $(esc(expr)))
         else
-            $(esc(expr))
+            Threads.@spawn($(esc(expr)))
         end
     end
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -70,7 +70,7 @@ function next_worker(worker_assignment::Dict{Tuple{Int,Int}, Int}, procs::Nothin
     return 0
 end
 
-macro pysr_spawner(parallel, p, expr)
+macro sr_spawner(parallel, p, expr)
     quote
         if $(esc(parallel)) == SRSerial
             $(esc(expr))

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -70,7 +70,7 @@ function next_worker(worker_assignment::Dict{Tuple{Int,Int}, Int}, procs::Nothin
     return 0
 end
 
-macro maybespawnat(parallel, p, expr)
+macro pysr_spawner(parallel, p, expr)
     quote
         if $(esc(parallel)) == SRSerial
             $(esc(expr))

--- a/test/full.jl
+++ b/test/full.jl
@@ -13,7 +13,6 @@ for batching in [true, false]
         warmupMaxsizeBy = 0f0
         optimizer_algorithm = "NelderMead"
         multi = false
-        recorder = false
         probPickFirst = 1.0
         multithreading = false
         if weighted && batching
@@ -25,8 +24,7 @@ for batching in [true, false]
             probPickFirst = 0.8
         end
         if !weighted && !batching
-            println("Recorder & multi-output.")
-            recorder = true
+            println("Multi-output.")
             multi = true
         end
         if !weighted && batching
@@ -43,7 +41,6 @@ for batching in [true, false]
             progress=progress,
             warmupMaxsizeBy=warmupMaxsizeBy,
             optimizer_algorithm=optimizer_algorithm,
-            recorder=recorder,
             probPickFirst=probPickFirst
         )
         X = randn(MersenneTwister(0), Float32, 5, 100)

--- a/test/full.jl
+++ b/test/full.jl
@@ -23,7 +23,7 @@ for batching in [true, false]
             probPickFirst = 0.8
         end
         if !weighted && !batching
-            # recorder = true
+            recorder = true
             multi = true
         end
         options = SymbolicRegression.Options(

--- a/test/full.jl
+++ b/test/full.jl
@@ -15,7 +15,9 @@ for batching in [true, false]
         multi = false
         recorder = false
         probPickFirst = 1.0
+        multithreading = false
         if weighted && batching
+            println("Serial & progress bar & warmup & BFGS")
             numprocs = 0 #Try serial computation here.
             progress = true #Also try the progress bar.
             warmupMaxsizeBy = 0.5f0 #Smaller maxsize at first, build up slowly
@@ -23,8 +25,14 @@ for batching in [true, false]
             probPickFirst = 0.8
         end
         if !weighted && !batching
+            println("Recorder & multi-output.")
             recorder = true
             multi = true
+        end
+        if !weighted && batching
+            println("Multi-threading")
+            multithreading = true
+            numprocs = 0
         end
         options = SymbolicRegression.Options(
             binary_operators=(+, *),
@@ -47,7 +55,8 @@ for batching in [true, false]
             y = (2 .* cos.(X[4, :])) .* weights .+ (1 .- weights) .* (5 .* X[2, :])
             hallOfFame = EquationSearch(X, y, weights=weights,
                                         niterations=2, options=options,
-                                        numprocs=numprocs
+                                        numprocs=numprocs,
+                                        multithreading=multithreading
                                        )
             dominating = [calculateParetoFrontier(X, y, hallOfFame,
                                                   options; weights=weights)]
@@ -58,7 +67,7 @@ for batching in [true, false]
                 y = repeat(y, 1, 2)
                 y = transpose(y)
             end
-            hallOfFame = EquationSearch(X, y, niterations=2, options=options)
+            hallOfFame = EquationSearch(X, y, niterations=2, options=options, multithreading=multithreading)
             if multi
                 dominating = [calculateParetoFrontier(X, y[j, :], hallOfFame[j], options)
                               for j=1:2]
@@ -85,6 +94,8 @@ for batching in [true, false]
         end
     end
 end
+
+println("fast-cycle and custom variable names")
 
 options = SymbolicRegression.Options(
     binary_operators=(+, *),


### PR DESCRIPTION
Instead of processes, this splits up the populations into threads. I haven't found it to be any faster than distributed, but I think there's a faster startup time which will eventually help PySR - e.g., https://github.com/MilesCranmer/PySR/issues/45.

Can turn on with:
```julia
EquationSearch(..., multithreading=true)
```
(can't simultaneously set any options on `procs` or `numprocs` obviously).

More importantly, this streamlines the parallel code so there are less re-used bits. A single macro:
```julia
@sr_spawner [SRThreaded/SRSerial/SRDistributed] [process_ID] [expression]
```
where the `SRThreaded/...` are types that act like an enum, controls how a particular chunk of work is spawned - whether it be on a process, in a thread, or executed right there serially. This results in much cleaner code despite the various parallelization options. Should make it easier, I think, if I want to do automatic submission with SLURM or something. This also lets the EquationSearch specialize to the type of parallelization.