### PR TITLE
Allow infinities in recorder

### DIFF
--- a/src/Population.jl
+++ b/src/Population.jl
@@ -89,9 +89,8 @@ end
 
 
 function record_population(pop::Population{T}, options::Options)::RecordType where {T<:Real}
-    inf_to_num = x -> isinf(x) ? convert(T, 1e9) : x
     RecordType("population"=>[RecordType("tree"=>stringTree(member.tree, options),
-                                         "loss"=>inf_to_num(member.score),
+                                         "loss"=>member.score,
                                          "complexity"=>countNodes(member.tree),
                                          "birth"=>member.birth,
                                          "ref"=>member.ref,

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -569,7 +569,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
 
     @recorder begin
         open(options.recorder_file, "w") do io
-            JSON3.write(io, record)
+            JSON3.write(io, record, allow_inf = true)
         end
     end
 


### PR DESCRIPTION
The solution with checking the loss value for `Inf` https://github.com/MilesCranmer/SymbolicRegression.jl/commit/124020d79db1c766e6e35863b68bcc2608312a3d was failing, and I was testing with custom `println()` statements and couldn't find what was generating the `Inf`. But the JSON exporter allows to save Infinities with JS syntax.

Closes https://github.com/MilesCranmer/SymbolicRegression.jl/issues/33

