### PR TITLE
Fix index functions in SymbolicUtils

### DIFF
--- a/src/CustomSymbolicUtilsSimplification.jl
+++ b/src/CustomSymbolicUtilsSimplification.jl
@@ -9,7 +9,7 @@ function multiply_powers(eqn::T)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {T<:Uni
 	return eqn, true
 end
 
-function multiply_powers(eqn::T, op::F)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {F,T<:SymbolicUtils.Term{<:Number}}
+function multiply_powers(eqn::T, op::F)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {F,T<:Union{SymbolicUtils.Term{<:Number},SymbolicUtils.Symbolic{<:Number}}}
 	args = SymbolicUtils.arguments(eqn)
 	nargs = length(args)
 	if nargs == 1
@@ -64,7 +64,7 @@ function multiply_powers(eqn::T, op::F)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where 
 	end
 end
 
-function multiply_powers(eqn::T)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {T<:SymbolicUtils.Term{<:Number}}
+function multiply_powers(eqn::T)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {T<:Union{SymbolicUtils.Term{<:Number},SymbolicUtils.Symbolic{<:Number}}}
 	op = SymbolicUtils.operation(eqn)
 	return multiply_powers(eqn, op)
 end

--- a/src/InterfaceSymbolicUtils.jl
+++ b/src/InterfaceSymbolicUtils.jl
@@ -3,7 +3,7 @@ using SymbolicUtils
 @from "Core.jl" import CONST_TYPE, Node, Options
 @from "Utils.jl" import isgood, isbad, @return_on_false
 
-const SYMBOLIC_UTILS_TYPES = Union{<:Number,SymbolicUtils.Sym{<:Number},SymbolicUtils.Term{<:Number}}
+const SYMBOLIC_UTILS_TYPES = Union{<:Number,SymbolicUtils.Symbolic{<:Number}}
 
 const SUPPORTED_OPS = (cos, sin, exp, cot, tan, csc, sec, +, -, *, /)
 
@@ -23,11 +23,10 @@ function parse_tree_to_eqs(tree::Node, options::Options, index_functions::Bool=f
     # Create an N tuple of Numbers for each argument
     dtypes = map(x->Number, 1:tree.degree)
     #
-    if index_functions
+    if !(op ∈ SUPPORTED_OPS) && index_functions
         op = SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{dtypes...}, Number}}(Symbol(op))
-    else
-        op = ((op ∈ SUPPORTED_OPS) || evaluate_functions) ? op : SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{dtypes...}, Number}}(Symbol(op))
     end
+
     return subs_bad(op(map(x->parse_tree_to_eqs(x, options, index_functions, evaluate_functions), children)...))
 end
 

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -1,0 +1,11 @@
+using SymbolicRegression, Test
+
+options = Options(binary_operators=(+, -, /, *))
+
+tree = Node("x1") + Node("x1")
+
+# Should simplify to 2*x1:
+eqn = node_to_symbolic(tree, options; index_functions=true)
+eqn2 = custom_simplify(eqn, options)
+
+@test "$(eqn2[1])" == "2x1"

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -152,3 +152,5 @@ for (loss, evaluator) in [(L1DistLoss(), testl1), (customloss, customloss)]
     @test abs(Loss(x, y, options) - sum(evaluator.(x, y))/length(x)) < 1e-6
     @test abs(Loss(x, y, w, options) - sum(evaluator.(x, y, w))/sum(w)) < 1e-6
 end
+
+include("test_simplification.jl")


### PR DESCRIPTION
The SymbolicUtils interface isn't correctly simplifying equations. It seems every operator gets redefined as a new function, and thus the simplification backend does not recognize them.

`parse_tree_to_eqs(..., index_functions=true)` *should* still use the `SUPPORTED_OPS`. It only creates new function objects when they are not recognized. I think this behaviour was changed in #37.

cc @kazewong