### PR TITLE
SymbolicUtils v0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ Optim = "0.19, 1.1"
 Pkg = "1"
 Reexport = "1"
 SpecialFunctions = "0.10.1, 1"
-SymbolicUtils = "0.13"
+SymbolicUtils = "0.18"
 julia = "1.5"
 
 [extras]

--- a/src/CustomSymbolicUtilsSimplification.jl
+++ b/src/CustomSymbolicUtilsSimplification.jl
@@ -1,6 +1,6 @@
 using FromFile
 using SymbolicUtils
-using SymbolicUtils: Chain, If, RestartedChain, IfElse, Postwalk, Fixpoint, @ordered_acrule, isnotflat, flatten_term, needs_sorting, sort_args, is_literal_number, hasrepeats, merge_repeats, _isone, _iszero, _isinteger, istree, symtype, is_operation, has_trig, expand
+using SymbolicUtils: Chain, If, RestartedChain, IfElse, Postwalk, Fixpoint, @ordered_acrule, isnotflat, flatten_term, needs_sorting, sort_args, is_literal_number, hasrepeats, merge_repeats, _isone, _iszero, _isinteger, istree, symtype, is_operation, has_trig_exp, expand
 @from "Core.jl" import Options
 @from "InterfaceSymbolicUtils.jl" import SYMBOLIC_UTILS_TYPES
 @from "Utils.jl" import isgood, @return_on_false
@@ -105,7 +105,8 @@ function get_simplifier(binops::A, unaops::B) where {A,B}
        ((*,), @rule((((~x)^(~p::_isinteger))^(~q::_isinteger)) => (~x)^((~p)*(~q)))),
        ((*,), @rule(^(~x, ~z::_iszero) => 1)),
        ((*,), @rule(^(~x, ~z::_isone) => ~x)),
-       ((*, /,), @rule(inv(~x) => ~x ^ -1))]
+       ((*, /,), @rule(inv(~x) => ^(~x, -1) ))
+       ]
        if all([(op in binops || op in unaops) for op in required_ops])
     ]
     ASSORTED_RULES =[
@@ -144,7 +145,7 @@ function get_simplifier(binops::A, unaops::B) where {A,B}
     end
     trig_simplifier(;kw...) = Chain(TRIG_RULES)
     function default_simplifier(; kw...)
-        IfElse(has_trig,
+        IfElse(has_trig_exp,
                Postwalk(Chain((number_simplifier(),
                                trig_simplifier())),
                         ; kw...),


### PR DESCRIPTION
Updates for usage with `SymbolicUtils` from `v0.18`. 

I've adapted one simplification rule, which errored during precompilation and substituted `has_trig` with `has_trig_exp`.

Locally, the tests work except for one issue with an unsafe stream ( possible M1 related 😅 ).