### PR TITLE
Update Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ Optim = "0.19, 1.1"
 Pkg = "1"
 Reexport = "1"
 SpecialFunctions = "0.10.1, 1"
-SymbolicUtils = "0.18"
+SymbolicUtils = "0.16, 0.18"
 julia = "1.5"
 
 [extras]


### PR DESCRIPTION
To solve the incompatible versions between NeuralPDE and SymbolicRegression. Right now the NeuralPDE requires the SymbolicUtils of version 0.16. and as the SymbolicRegression is only set to 0.18, it can not be updated to the last version and is downgraded to version 0.2.0

(@v1.6) pkg> add https://github.com/MilesCranmer/SymbolicRegression.jl
    Updating git-repo `https://github.com/MilesCranmer/SymbolicRegression.jl`
   Resolving package versions...
ERROR: Unsatisfiable requirements detected for package SymbolicUtils [d1185830]:
 SymbolicUtils [d1185830] log:
 ├─possible versions are: 0.1.0-0.18.0 or uninstalled
 ├─restricted to versions 0.18 by SymbolicRegression [8254be44], leaving only versions 0.18.0
 │ └─SymbolicRegression [8254be44] log:
 │   ├─possible versions are: 0.6.15 or uninstalled
 │   └─SymbolicRegression [8254be44] is fixed to version 0.6.15
 └─restricted by compatibility requirements with ModelingToolkit [961ee093] to versions: [0.4.1-0.6.3, 0.7.4-0.13.5, 0.15.0-0.17.0] — no versions left
   └─ModelingToolkit [961ee093] log:
     ├─possible versions are: 0.0.1-6.7.1 or uninstalled
     ├─restricted to versions * by an explicit requirement, leaving only versions 0.0.1-6.7.1
     └─restricted by compatibility requirements with NeuralPDE [315f7962] to versions: 3.11.0-6.7.1
       └─NeuralPDE [315f7962] log:
         ├─possible versions are: 2.0.0-4.0.1 or uninstalled
         ├─restricted to versions * by an explicit requirement, leaving only versions 2.0.0-4.0.1
         └─restricted by compatibility requirements with Reexport [189a3867] to versions: 3.3.0-4.0.1 or uninstalled, leaving only versions: 3.3.0-4.0.1
           └─Reexport [189a3867] log:
             ├─possible versions are: 0.2.0-1.2.2 or uninstalled
             └─restricted to versions 1 by SymbolicRegression [8254be44], leaving only versions 1.0.0-1.2.2
               └─SymbolicRegression [8254be44] log: see above

Status `~/.julia/environments/v1.6/Project.toml`
  [6e4b80f9] BenchmarkTools v1.2.0
  [336ed68f] CSV v0.9.10
  [052768ef] CUDA v3.5.0
  [5ae59095] Colors v0.12.8
  [8a292aeb] Cuba v2.2.0
  [667455a9] Cubature v1.5.1
  [2445eb08] DataDrivenDiffEq v0.6.6
  [a93c6f00] DataFrames v1.2.2
  [aae7a2af] DiffEqFlux v1.44.0
  [071ae1c0] DiffEqGPU v1.15.0
  [0c46a032] DifferentialEquations v6.19.0
  [94bb4f33] DirectDependents v0.1.0 `https://github.com/daschw/DirectDependents.jl#master`
  [31c24e10] Distributions v0.25.24
  [587475ba] Flux v0.12.8
  [f6369f11] ForwardDiff v0.10.22
  [38e38edf] GLM v1.5.1
  [28b8d3ca] GR v0.62.1
  [a75be94c] GalacticOptim v2.2.0
  [09f84164] HypothesisTests v0.10.6
  [7073ff75] IJulia v1.23.2
  [615f187c] IfElse v0.1.1
  [82e4d734] ImageIO v0.5.9
  [4e3cecfd] ImageShow v0.3.3
  [7f56f5a3] LSODA v0.7.0
  [b964fa9f] LaTeXStrings v1.3.0
  [41aa4398] MagicUnderscores v0.1.0 `https://github.com/c42f/MagicUnderscores.jl#master`
  [442fdcdd] Measures v0.3.1
  [961ee093] ModelingToolkit v6.7.1
  [315f7962] NeuralPDE v4.0.1
  [429524aa] Optim v1.5.0
  [58dd65bb] Plotly v0.4.1
  [a03496cd] PlotlyBase v0.8.18
  [f0f68f2c] PlotlyJS v0.18.8
  [91a5bcdd] Plots v1.23.5
  [c3e4b0f8] Pluto v0.17.1
  [49802e3a] ProgressBars v1.4.0
  [438e738f] PyCall v1.92.5
  [d330b81b] PyPlot v2.10.0
  [67601950] Quadrature v1.12.0
  [8a4e6c94] QuasiMonteCarlo v0.2.3
  [90137ffa] StaticArrays v1.2.13
  [2913bbd2] StatsBase v0.33.12
  [f3b207a7] StatsPlots v0.14.28
  [8254be44] SymbolicRegression v0.2.0
  [d1185830] SymbolicUtils v0.16.0
  [0c5d862f] Symbolics v3.5.1
  [5d786b92] TerminalLoggers v0.1.5
  [1986cc42] Unitful v1.9.1
  [0f1e0344] WebIO v0.8.16
  [10745b16] Statistics