### PR TITLE
Expand compatibility to other SymbolicUtils.jl versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ Optim = "0.19, 1.1"
 Pkg = "1"
 Reexport = "1"
 SpecialFunctions = "0.10.1, 1"
-SymbolicUtils = "0.18"
+SymbolicUtils = "0.13 - 0.18"
 julia = "1.5"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.6.15"
+version = "0.6.16"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/CustomSymbolicUtilsSimplification.jl
+++ b/src/CustomSymbolicUtilsSimplification.jl
@@ -1,6 +1,14 @@
 using FromFile
 using SymbolicUtils
-using SymbolicUtils: Chain, If, RestartedChain, IfElse, Postwalk, Fixpoint, @ordered_acrule, isnotflat, flatten_term, needs_sorting, sort_args, is_literal_number, hasrepeats, merge_repeats, _isone, _iszero, _isinteger, istree, symtype, is_operation, has_trig_exp, expand
+using SymbolicUtils: Chain, If, RestartedChain, IfElse, Postwalk, Fixpoint, @ordered_acrule, isnotflat, flatten_term, needs_sorting, sort_args, is_literal_number, hasrepeats, merge_repeats, _isone, _iszero, _isinteger, istree, symtype, is_operation, expand
+
+try
+    using SymbolicUtils: has_trig_exp
+catch
+    using SymbolicUtils: has_trig
+    has_trig_exp = has_trig
+end
+
 @from "Core.jl" import Options
 @from "InterfaceSymbolicUtils.jl" import SYMBOLIC_UTILS_TYPES
 @from "Utils.jl" import isgood, @return_on_false


### PR DESCRIPTION
Keeps up with deprecated function name in SymbolicUtils.jl without needing to force version. Overrides #52.

Now works with 0.13 to 0.18.