### PR TITLE
Revert to SymbolicUtils.jl 0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.6.19"
+version = "0.7.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -26,7 +26,7 @@ Optim = "0.19, 1.1"
 Pkg = "1"
 Reexport = "1"
 SpecialFunctions = "0.10.1, 1"
-SymbolicUtils = "0.13 - 0.18"
+SymbolicUtils = "0.6"
 julia = "1.5"
 
 [extras]

--- a/src/CustomSymbolicUtilsSimplification.jl
+++ b/src/CustomSymbolicUtilsSimplification.jl
@@ -1,17 +1,73 @@
 using FromFile
 using SymbolicUtils
-using SymbolicUtils: Chain, If, RestartedChain, IfElse, Postwalk, Fixpoint, @ordered_acrule, isnotflat, flatten_term, needs_sorting, sort_args, is_literal_number, hasrepeats, merge_repeats, _isone, _iszero, _isinteger, istree, symtype, is_operation, expand
+using SymbolicUtils: Chain, If, RestartedChain, IfElse, Postwalk, Fixpoint, @ordered_acrule, isnotflat, flatten_term, needs_sorting, sort_args, is_literal_number, hasrepeats, merge_repeats, _isone, _iszero, _isinteger, istree, symtype, is_operation, has_trig, polynormalize
+@from "Core.jl" import Options
+@from "InterfaceSymbolicUtils.jl" import SYMBOLIC_UTILS_TYPES
+@from "Utils.jl" import isgood, @return_on_false
 
-try
-    using SymbolicUtils: has_trig_exp
-catch
-    using SymbolicUtils: has_trig
-    has_trig_exp = has_trig
+function multiply_powers(eqn::T)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {T<:Union{<:Number,SymbolicUtils.Sym{<:Number}}}
+	return eqn, true
 end
 
-@from "Core.jl" import Options
-@from "InterfaceSymbolicUtils.jl" import SYMBOLIC_UTILS_TYPES, multiply_powers
-@from "Utils.jl" import isgood, @return_on_false
+function multiply_powers(eqn::T, op::F)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {F,T<:SymbolicUtils.Term{<:Number}}
+	args = SymbolicUtils.arguments(eqn)
+	nargs = length(args)
+	if nargs == 1
+        l, complete = multiply_powers(args[1])
+        @return_on_false complete eqn
+        @return_on_false isgood(l) eqn
+		return op(l), true
+	elseif op == ^
+		l, complete = multiply_powers(args[1])
+        @return_on_false complete eqn
+        @return_on_false isgood(l) eqn
+		n = args[2]
+        if typeof(n) <: Int
+            if n == 1
+                return l, true
+            elseif n == -1
+                return 1.0 / l, true
+            elseif n > 1
+                return reduce(*, [l for i=1:n]), true
+            elseif n < -1
+                return reduce(/, vcat([1], [l for i=1:abs(n)])), true
+            else
+                return 1.0, true
+            end
+        else
+            r, complete2 = multiply_powers(args[2])
+            @return_on_false complete2 eqn
+            return l ^ r, true
+        end
+	elseif nargs == 2
+        l, complete = multiply_powers(args[1])
+        @return_on_false complete eqn
+        @return_on_false isgood(l) eqn
+        r, complete2 = multiply_powers(args[2])
+        @return_on_false complete2 eqn
+        @return_on_false isgood(r) eqn
+		return op(l, r), true
+	else
+		# return mapreduce(multiply_powers, op, args)
+        # ## reduce(op, map(multiply_powers, args))
+        out = map(multiply_powers, args) #vector of tuples
+        for i=1:size(out, 1)
+            @return_on_false out[i][2] eqn
+            @return_on_false isgood(out[i][1]) eqn
+        end
+        cumulator = out[1][1]
+        for i=2:size(out, 1)
+            cumulator = op(cumulator, out[i][1])
+            @return_on_false isgood(cumulator) eqn
+        end
+        return cumulator, true
+	end
+end
+
+function multiply_powers(eqn::T)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {T<:SymbolicUtils.Term{<:Number}}
+	op = SymbolicUtils.operation(eqn)
+	return multiply_powers(eqn, op)
+end
 
 # Operators required for each rule:
 function get_simplifier(binops::A, unaops::B) where {A,B}
@@ -49,8 +105,7 @@ function get_simplifier(binops::A, unaops::B) where {A,B}
        ((*,), @rule((((~x)^(~p::_isinteger))^(~q::_isinteger)) => (~x)^((~p)*(~q)))),
        ((*,), @rule(^(~x, ~z::_iszero) => 1)),
        ((*,), @rule(^(~x, ~z::_isone) => ~x)),
-       ((*, /,), @rule(inv(~x) => ^(~x, -1) ))
-       ]
+       ((*, /,), @rule(inv(~x) => ~x ^ -1))]
        if all([(op in binops || op in unaops) for op in required_ops])
     ]
     ASSORTED_RULES =[
@@ -89,7 +144,7 @@ function get_simplifier(binops::A, unaops::B) where {A,B}
     end
     trig_simplifier(;kw...) = Chain(TRIG_RULES)
     function default_simplifier(; kw...)
-        IfElse(has_trig_exp,
+        IfElse(has_trig,
                Postwalk(Chain((number_simplifier(),
                                trig_simplifier())),
                         ; kw...),
@@ -97,13 +152,12 @@ function get_simplifier(binops::A, unaops::B) where {A,B}
                         ; kw...)
     end
     # reduce overhead of simplify by defining these as constant
-    # serial_simplifier = If(istree, Fixpoint(default_simplifier()))
+    serial_simplifier = If(istree, Fixpoint(default_simplifier()))
     serial_polynormal_simplifier = If(istree,
-                                      Fixpoint(Chain((expand,
+                                      Fixpoint(Chain((polynormalize,
                                                       Fixpoint(default_simplifier())))))
     return serial_polynormal_simplifier
 end
-
 
 function custom_simplify(init_eqn::T, options::Options)::Tuple{SYMBOLIC_UTILS_TYPES, Bool} where {T<:SYMBOLIC_UTILS_TYPES}
     if !istree(init_eqn) #simplifier will return nothing if not a tree.

--- a/src/InterfaceSymbolicUtils.jl
+++ b/src/InterfaceSymbolicUtils.jl
@@ -81,6 +81,12 @@ function Base.convert(::typeof(Node), x::SymbolicUtils.Symbolic, options::Option
         return Node(String(x.name), varMap)
     end
 
+    # First, we remove integer powers:
+    y, good_return = multiply_powers(x)
+    if good_return
+        x = y
+    end
+
     op = convert_to_function(SymbolicUtils.operation(x))
     args = SymbolicUtils.arguments(x)
 
@@ -132,4 +138,68 @@ function symbolic_to_node(eqn::T, options::Options;
                           varMap::Union{Array{String, 1}, Nothing}=nothing)::Node where {T<:SymbolicUtils.Symbolic}
 
     convert(Node, eqn, options; varMap=varMap)
+end
+
+function multiply_powers(eqn::T)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {T<:Union{<:Number,SymbolicUtils.Sym{<:Number}}}
+	return eqn, true
+end
+
+function multiply_powers(eqn::T, op::F)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {F,T<:Union{SymbolicUtils.Term{<:Number},SymbolicUtils.Symbolic{<:Number}}}
+	args = SymbolicUtils.arguments(eqn)
+	nargs = length(args)
+	if nargs == 1
+        l, complete = multiply_powers(args[1])
+        @return_on_false complete eqn
+        @return_on_false isgood(l) eqn
+		return op(l), true
+	elseif op == ^
+		l, complete = multiply_powers(args[1])
+        @return_on_false complete eqn
+        @return_on_false isgood(l) eqn
+		n = args[2]
+        if typeof(n) <: Int
+            if n == 1
+                return l, true
+            elseif n == -1
+                return 1.0 / l, true
+            elseif n > 1
+                return reduce(*, [l for i=1:n]), true
+            elseif n < -1
+                return reduce(/, vcat([1], [l for i=1:abs(n)])), true
+            else
+                return 1.0, true
+            end
+        else
+            r, complete2 = multiply_powers(args[2])
+            @return_on_false complete2 eqn
+            return l ^ r, true
+        end
+	elseif nargs == 2
+        l, complete = multiply_powers(args[1])
+        @return_on_false complete eqn
+        @return_on_false isgood(l) eqn
+        r, complete2 = multiply_powers(args[2])
+        @return_on_false complete2 eqn
+        @return_on_false isgood(r) eqn
+		return op(l, r), true
+	else
+		# return mapreduce(multiply_powers, op, args)
+        # ## reduce(op, map(multiply_powers, args))
+        out = map(multiply_powers, args) #vector of tuples
+        for i=1:size(out, 1)
+            @return_on_false out[i][2] eqn
+            @return_on_false isgood(out[i][1]) eqn
+        end
+        cumulator = out[1][1]
+        for i=2:size(out, 1)
+            cumulator = op(cumulator, out[i][1])
+            @return_on_false isgood(cumulator) eqn
+        end
+        return cumulator, true
+	end
+end
+
+function multiply_powers(eqn::T)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {T<:Union{SymbolicUtils.Term{<:Number},SymbolicUtils.Symbolic{<:Number}}}
+	op = SymbolicUtils.operation(eqn)
+	return multiply_powers(eqn, op)
 end

--- a/src/InterfaceSymbolicUtils.jl
+++ b/src/InterfaceSymbolicUtils.jl
@@ -3,98 +3,7 @@ using SymbolicUtils
 @from "Core.jl" import CONST_TYPE, Node, Options
 @from "Utils.jl" import isgood, isbad, @return_on_false
 
-const SYMBOLIC_UTILS_TYPES = Union{<:Number,SymbolicUtils.Symbolic{<:Number}}
-
-const SUPPORTED_OPS = (cos, sin, exp, cot, tan, csc, sec, +, -, *, /)
-
-isgood(x::SymbolicUtils.Symbolic) = SymbolicUtils.istree(x) ? all(isgood.([SymbolicUtils.operation(x);SymbolicUtils.arguments(x)])) : true
-subs_bad(x) = isgood(x) ? x : Inf
-
-function parse_tree_to_eqs(tree::Node, options::Options, index_functions::Bool=false, evaluate_functions::Bool=false)
-    if tree.degree == 0
-        # Return constant if needed
-        tree.constant && return subs_bad(tree.val)
-        return SymbolicUtils.Sym{Number}(Symbol("x$(tree.feature)"))
-    end
-    # Collect the next children
-    children = tree.degree >= 2 ? (tree.l, tree.r) : (tree.l,)
-    # Get the operation
-    op = tree.degree > 1 ? options.binops[tree.op] : options.unaops[tree.op]
-    # Create an N tuple of Numbers for each argument
-    dtypes = map(x->Number, 1:tree.degree)
-    #
-    if !(op ∈ SUPPORTED_OPS) && index_functions
-        op = SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{dtypes...}, Number}}(Symbol(op))
-    end
-
-    return subs_bad(op(map(x->parse_tree_to_eqs(x, options, index_functions, evaluate_functions), children)...))
-end
-
-## Convert symbolic function back
-convert_to_function(x, args...) = x
-
-function convert_to_function(x::SymbolicUtils.Sym{SymbolicUtils.FnType{T, Number}}, options::Options) where {T <: Tuple}
-    degree = length(T.types)
-    if degree == 1
-        ind = findoperation(x.name, options.unaops)
-        return options.unaops[ind]
-    elseif degree == 2
-        ind = findoperation(x.name, options.binops)
-        return options.binops[ind]
-    else
-        throw(AssertionError("Function $(String(x.name)) has degree > 2 !"))
-    end
-end
-
-# Split equation
-function split_eq(op, args, options::Options; varMap::Union{Array{String, 1}, Nothing}=nothing)
-    !(op ∈ (sum, prod, +, *)) && throw(error("Unsupported operation $op in expression!"))
-    if Symbol(op) == Symbol(sum)
-        ind = findoperation(+, options.binops)
-    elseif Symbol(op) == Symbol(prod)
-        ind = findoperation(*, options.binops)
-    else
-        ind = findoperation(op, options.binops)
-    end
-    return Node(ind, convert(Node, args[1], options; varMap=varMap), convert(Node, op(args[2:end]...), options; varMap=varMap))
-end
-
-function findoperation(op, ops)
-    for (i,oi) in enumerate(ops)
-        Symbol(oi) == Symbol(op) && return i
-    end
-    throw(error("Operation $(op) in expression not found in operations $(ops)!"))
-end
-
-function Base.convert(::typeof(Node), x::Number, options::Options; varMap::Union{Array{String, 1}, Nothing}=nothing)
-    return Node(CONST_TYPE(x))
-end
-
-function Base.convert(::typeof(Node), x::Symbol, options::Options; varMap::Union{Array{String, 1}, Nothing}=nothing)
-    varMap === nothing && return Node(String(x))
-    return Node(String(x), varMap)
-end
-
-function Base.convert(::typeof(Node), x::SymbolicUtils.Symbolic, options::Options; varMap::Union{Array{String, 1}, Nothing}=nothing)
-    if !SymbolicUtils.istree(x)
-        varMap === nothing && return Node(String(x.name))
-        return Node(String(x.name), varMap)
-    end
-
-    # First, we remove integer powers:
-    y, good_return = multiply_powers(x)
-    if good_return
-        x = y
-    end
-
-    op = convert_to_function(SymbolicUtils.operation(x))
-    args = SymbolicUtils.arguments(x)
-
-    length(args) > 2 && return split_eq(op, args, options; varMap=varMap)
-    ind = length(args) == 2 ? findoperation(op, options.binops) : findoperation(op, options.unaops)
-
-    return Node(ind, map(x->convert(Node, x, options, varMap=varMap), args)...)
-end
+const SYMBOLIC_UTILS_TYPES = Union{<:Number,SymbolicUtils.Sym{<:Number},SymbolicUtils.Term{<:Number}}
 
 """
     node_to_symbolic(tree::Node, options::Options;
@@ -117,89 +26,204 @@ will generate a symbolic equation in SymbolicUtils.jl format.
     operators, which then allows one to convert back to a `Node` format
     using `symbolic_to_node`.
 """
-function node_to_symbolic(tree::Node, options::Options;
+function node_to_symbolic(tree::Node, options::Options; 
                      varMap::Union{Array{String, 1}, Nothing}=nothing,
                      evaluate_functions::Bool=false,
-                     index_functions::Bool=true
-                     )
-    expr = subs_bad(parse_tree_to_eqs(tree, options, index_functions, evaluate_functions))
-    # Check for NaN and Inf
-    @assert isgood(expr) "The recovered equation contains NaN or Inf."
-    # Return if no varMap is given
-    varMap === nothing && return expr
-    # Create a substitution tuple
-    subs = Dict(
-        [SymbolicUtils.Sym{Number}(Symbol("x$(i)")) => SymbolicUtils.Sym{Number}(Symbol(varMap[i])) for i in 1:length(varMap)]...
-    )
-    return substitute(expr, subs)
-end
-
-function symbolic_to_node(eqn::T, options::Options;
-                          varMap::Union{Array{String, 1}, Nothing}=nothing)::Node where {T<:SymbolicUtils.Symbolic}
-
-    convert(Node, eqn, options; varMap=varMap)
-end
-
-function multiply_powers(eqn::T)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {T<:Union{<:Number,SymbolicUtils.Sym{<:Number}}}
-	return eqn, true
-end
-
-function multiply_powers(eqn::T, op::F)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {F,T<:Union{SymbolicUtils.Term{<:Number},SymbolicUtils.Symbolic{<:Number}}}
-	args = SymbolicUtils.arguments(eqn)
-	nargs = length(args)
-	if nargs == 1
-        l, complete = multiply_powers(args[1])
-        @return_on_false complete eqn
-        @return_on_false isgood(l) eqn
-		return op(l), true
-	elseif op == ^
-		l, complete = multiply_powers(args[1])
-        @return_on_false complete eqn
-        @return_on_false isgood(l) eqn
-		n = args[2]
-        if typeof(n) <: Int
-            if n == 1
-                return l, true
-            elseif n == -1
-                return 1.0 / l, true
-            elseif n > 1
-                return reduce(*, [l for i=1:n]), true
-            elseif n < -1
-                return reduce(/, vcat([1], [l for i=1:abs(n)])), true
-            else
-                return 1.0, true
-            end
+                     index_functions::Bool=false
+                     )::SYMBOLIC_UTILS_TYPES
+    if tree.degree == 0
+        if tree.constant
+            return tree.val
         else
-            r, complete2 = multiply_powers(args[2])
-            @return_on_false complete2 eqn
-            return l ^ r, true
+            if varMap == nothing
+                return SymbolicUtils.Sym{Real}(Symbol("x$(tree.feature)"))
+            else
+                return SymbolicUtils.Sym{Real}(Symbol(varMap[tree.feature]))
+            end
         end
-	elseif nargs == 2
-        l, complete = multiply_powers(args[1])
-        @return_on_false complete eqn
-        @return_on_false isgood(l) eqn
-        r, complete2 = multiply_powers(args[2])
-        @return_on_false complete2 eqn
-        @return_on_false isgood(r) eqn
-		return op(l, r), true
-	else
-		# return mapreduce(multiply_powers, op, args)
-        # ## reduce(op, map(multiply_powers, args))
-        out = map(multiply_powers, args) #vector of tuples
-        for i=1:size(out, 1)
-            @return_on_false out[i][2] eqn
-            @return_on_false isgood(out[i][1]) eqn
+    elseif tree.degree == 1
+        left_side = node_to_symbolic(tree.l, options, varMap=varMap, evaluate_functions=evaluate_functions, index_functions=index_functions)
+        op = options.unaops[tree.op]
+        if (op in (cos, sin, exp, cot, tan, csc, sec)) || evaluate_functions
+            return op(left_side)
+        else
+            if index_functions
+                dummy_op = SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{Number}, Real}}(Symbol("_unaop$(tree.op)"))
+            else
+                dummy_op = SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{Number}, Real}}(Symbol(op))
+            end
+            return dummy_op(left_side)
         end
-        cumulator = out[1][1]
-        for i=2:size(out, 1)
-            cumulator = op(cumulator, out[i][1])
-            @return_on_false isgood(cumulator) eqn
+    else
+        left_side = node_to_symbolic(tree.l, options, varMap=varMap, evaluate_functions=evaluate_functions, index_functions=index_functions)
+        right_side = node_to_symbolic(tree.r, options, varMap=varMap, evaluate_functions=evaluate_functions, index_functions=index_functions)
+        op = options.binops[tree.op]
+        if (op in (+, -, *, /)) || evaluate_functions
+            return op(left_side, right_side)
+        else
+            if index_functions
+                dummy_op = SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{Number,Number}, Real}}(Symbol("_binop$(tree.op)"))
+            else
+                dummy_op = SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{Number,Number}, Real}}(Symbol(op))
+            end
+            return dummy_op(left_side, right_side)
         end
-        return cumulator, true
-	end
+    end
 end
 
-function multiply_powers(eqn::T)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {T<:Union{SymbolicUtils.Term{<:Number},SymbolicUtils.Symbolic{<:Number}}}
-	op = SymbolicUtils.operation(eqn)
-	return multiply_powers(eqn, op)
+function node_to_symbolic_safe(tree::Node, options::Options; 
+                     varMap::Union{Array{String, 1}, Nothing}=nothing,
+                     evaluate_functions::Bool=false,
+                     index_functions::Bool=false
+                     )::Tuple{SYMBOLIC_UTILS_TYPES,Bool}
+    if tree.degree == 0
+        if tree.constant
+            return tree.val, true
+        else
+            if varMap == nothing
+                return SymbolicUtils.Sym{Real}(Symbol("x$(tree.feature)")), true
+            else
+                return SymbolicUtils.Sym{Real}(Symbol(varMap[tree.feature])), true
+            end
+        end
+    elseif tree.degree == 1
+        left_side, complete = node_to_symbolic_safe(tree.l, options, varMap=varMap, evaluate_functions=evaluate_functions, index_functions=index_functions)
+        @return_on_false complete Inf
+        @return_on_false isgood(left_side) Inf
+        op = options.unaops[tree.op]
+        if (op in (cos, sin, exp, cot, tan, csc, sec)) || evaluate_functions
+            out = op(left_side)
+            @return_on_false isgood(out) Inf
+            return out, true
+        else
+            if index_functions
+                dummy_op = SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{Number}, Real}}(Symbol("_unaop$(tree.op)"))
+            else
+                dummy_op = SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{Number}, Real}}(Symbol(op))
+            end
+            out = dummy_op(left_side)
+            #TODO: Can probably delete this check:
+            @return_on_false isgood(out) Inf
+            return out, true
+        end
+    else
+        left_side, complete  = node_to_symbolic_safe(tree.l, options, varMap=varMap, evaluate_functions=evaluate_functions, index_functions=index_functions)
+        @return_on_false complete Inf
+        @return_on_false isgood(left_side) Inf
+        right_side, complete2 = node_to_symbolic_safe(tree.r, options, varMap=varMap, evaluate_functions=evaluate_functions, index_functions=index_functions)
+        @return_on_false complete2 Inf
+        @return_on_false isgood(right_side) Inf
+        op = options.binops[tree.op]
+        if (op in (+, -, *, /)) || evaluate_functions
+            out = op(left_side, right_side)
+            @return_on_false isgood(out) Inf
+            return out, true
+        else
+            if index_functions
+                dummy_op = SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{Number,Number}, Real}}(Symbol("_binop$(tree.op)"))
+            else
+                dummy_op = SymbolicUtils.Sym{(SymbolicUtils.FnType){Tuple{Number,Number}, Real}}(Symbol(op))
+            end
+            out = dummy_op(left_side, right_side)
+            # Can probably delete this check TODO
+            @return_on_false isgood(out) Inf
+            return out, true
+        end
+    end
+end
+
+# Just constant
+function symbolic_to_node(eqn::T, options::Options;
+                     varMap::Union{Array{String, 1}, Nothing}=nothing)::Node where {T<:Number}
+    return Node(convert(CONST_TYPE, eqn))
+end
+
+# Just variable
+function symbolic_to_node(eqn::T, options::Options;
+                     varMap::Union{Array{String, 1}, Nothing}=nothing)::Node where {T<:SymbolicUtils.Sym{<:Number}}
+    return Node(varMap_to_index(eqn.name, varMap))
+end
+
+function _multiarg_split(op_idx::Int, eqn::Array{Any, 1},
+                        options::Options, varMap::Union{Array{String, 1}, Nothing}
+                       )::Node
+    if length(eqn) == 2
+        return Node(op_idx,
+                    symbolic_to_node(eqn[1], options, varMap=varMap),
+                    symbolic_to_node(eqn[2], options, varMap=varMap))
+    elseif length(eqn) == 3
+        return Node(op_idx,
+                    symbolic_to_node(eqn[1], options, varMap=varMap),
+                    _multiarg_split(op_idx, eqn[2:3], options, varMap))
+    else
+        # Minimize depth:
+        split_point = round(Int, length(eqn) // 2)
+        return Node(op_idx,
+                    _multiarg_split(op_idx, eqn[1:split_point], options, varMap),
+                    _multiarg_split(op_idx, eqn[split_point+1:end], options, varMap))
+    end
+end
+
+# Equation:
+function symbolic_to_node(eqn::T, options::Options;
+                       varMap::Union{Array{String, 1}, Nothing}=nothing
+                  )::Node where {T<:SymbolicUtils.Term{<:Number}}
+    args = SymbolicUtils.arguments(eqn)
+    l = symbolic_to_node(args[1], options, varMap=varMap)
+    nargs = length(args)
+    op = SymbolicUtils.operation(eqn)
+    if nargs == 1
+        op_idx = unaop_to_index(op, options)
+        return Node(op_idx, l)
+    else
+        op_idx = binop_to_index(op, options)
+        if nargs == 2
+            r = symbolic_to_node(args[2], options, varMap=varMap)
+            return Node(op_idx, l, r)
+        else
+            # TODO: Assert operator is +, *
+            return _multiarg_split(op_idx, args, options, varMap)
+        end
+    end
+end
+
+function unaop_to_index(op::F, options::Options)::Int where {F<:SymbolicUtils.Sym}
+    # In format _unaop1
+    parse(Int, string(op.name)[7:end])
+end
+
+function binop_to_index(op::F, options::Options)::Int where {F<:SymbolicUtils.Sym}
+    # In format _binop1
+    parse(Int, string(op.name)[7:end])
+end
+
+function unaop_to_index(op::F, options::Options)::Int where {F<:Function}
+    for i=1:options.nuna
+        if op == options.unaops[i]
+            return i
+        end
+    end
+    error("Operator $(op) in simplified expression not found in options $(options.unaops)!")
+end
+
+function binop_to_index(op::F, options::Options)::Int where {F<:Function}
+    for i=1:options.nbin
+        if op == options.binops[i]
+            return i
+        end
+    end
+    error("Operator $(op) in simplified expression not found in options $(options.binops)!")
+end
+
+function varMap_to_index(var::Symbol, varMap::Array{String, 1})::Int
+    str = string(var)
+    for i=1:length(varMap)
+        if str == varMap[i]
+            return i
+        end
+    end
+end
+
+function varMap_to_index(var::Symbol, varMap::Nothing)::Int
+    return parse(Int, string(var)[2:end])
 end

--- a/src/InterfaceSymbolicUtils.jl
+++ b/src/InterfaceSymbolicUtils.jl
@@ -51,7 +51,7 @@ function split_eq(op, args, options::Options; varMap::Union{Array{String, 1}, No
     !(op ∈ (sum, prod, +, *)) && throw(error("Unsupported operation $op in expression!"))
     if Symbol(op) == Symbol(sum)
         ind = findoperation(+, options.binops)
-    elseif Symbol(op) === Symbol(prod)
+    elseif Symbol(op) == Symbol(prod)
         ind = findoperation(*, options.binops)
     else
         ind = findoperation(op, options.binops)
@@ -63,7 +63,7 @@ function findoperation(op, ops)
     for (i,oi) in enumerate(ops)
         Symbol(oi) == Symbol(op) && return i
     end
-    throw(error("Operation $op in expression not found in operationrs $ops!"))
+    throw(error("Operation $(op) in expression not found in operations $(ops)!"))
 end
 
 function Base.convert(::typeof(Node), x::Number, options::Options; varMap::Union{Array{String, 1}, Nothing}=nothing)

--- a/src/SimplifyEquation.jl
+++ b/src/SimplifyEquation.jl
@@ -1,6 +1,7 @@
 using FromFile
+import Logging: @warn
 @from "Core.jl" import CONST_TYPE, Node, copyNode, Options
-@from "EquationUtils.jl" import countNodes
+@from "EquationUtils.jl" import countNodes, stringTree
 @from "CustomSymbolicUtilsSimplification.jl" import custom_simplify
 @from "InterfaceSymbolicUtils.jl" import node_to_symbolic, symbolic_to_node
 @from "CheckConstraints.jl" import check_constraints
@@ -148,9 +149,9 @@ function simplifyWithSymbolicUtils(tree::Node, options::Options, curmaxsize::Int
         final_size = countNodes(tree)
         did_simplification_improve = (final_size <= init_size) && (check_constraints(final_node, options, curmaxsize))
         output = did_simplification_improve ? final_node : init_node
-
         return output
     catch e
+        @warn "Error in symbolic_util simplify: $(e)\nFrom initial equation: $(stringTree(init_node, options))"
         return init_node
     end
 end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -24,7 +24,7 @@ export Population,
     combineOperators,
     genRandomTree,
 
-    #Operators:
+    #Operators
     plus,
     sub,
     mult,

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -1,6 +1,10 @@
 using SymbolicRegression, Test
 
-options = Options(binary_operators=(+, -, /, *))
+binary_operators = (+, -, /, *)
+
+index_of_mult = [i for (i, op) in enumerate(binary_operators) if op == *][1]
+
+options = Options(binary_operators=binary_operators)
 
 tree = Node("x1") + Node("x1")
 
@@ -9,3 +13,9 @@ eqn = node_to_symbolic(tree, options; index_functions=true)
 eqn2 = custom_simplify(eqn, options)
 
 @test "$(eqn2[1])" == "2x1"
+
+# Repeat test with simplifyWithSymbolicUtils:
+simple_tree = simplifyWithSymbolicUtils(tree, options, 5)
+
+# Check that the first operator is *, for 2 * x1:
+@test simple_tree.op == index_of_mult

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -19,3 +19,8 @@ simple_tree = simplifyWithSymbolicUtils(tree, options, 5)
 
 # Check that the first operator is *, for 2 * x1:
 @test simple_tree.op == index_of_mult
+
+tree = Node("x1") * Node("x1") + Node("x1") * Node("x1")
+
+# Should not convert this to power:
+@test !occursin("^", stringTree(simplifyWithSymbolicUtils(tree, options), options))

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -12,7 +12,7 @@ tree = Node("x1") + Node("x1")
 eqn = node_to_symbolic(tree, options; index_functions=true)
 eqn2 = custom_simplify(eqn, options)
 
-@test "$(eqn2[1])" == "2x1"
+@test occursin("2", "$(eqn2[1])")
 
 # Repeat test with simplifyWithSymbolicUtils:
 simple_tree = simplifyWithSymbolicUtils(tree, options, 5)


### PR DESCRIPTION
This bumps SymbolicRegression.jl to v0.7.0, and downgrades SymbolicUtils.jl to v0.6 to get around an issue I discovered today which caused the entire simplification backend of EquationSearch to be skipped. I will make PySR update to SymbolicRegression.jl v0.7.0, so that downstream users can have a more efficient search code. SymbolicUtils.jl users should stay with SymbolicRegression.jl v0.6.* until a future version is released that updates SymbolicUtils.jl again.

As discussed on #59, it seems like the current SymbolicUtils.jl has an auto-simplification feature, rather than taking expressions literally. For example:
```julia
julia> using SymbolicUtils
julia> @syms x
julia> operation(x * x)
^ (generic function with 82 methods)
```
whereas the old SymbolicUtils would take these literally:
```julia
julia> SymbolicUtils.operation(x * x)
* (generic function with 444 methods)
```
The new method of auto-simplifying regardless of the rules I define is incompatible with SymbolicRegression.jl as we need to only simplify based on the user-provided operators. So for now I unfortunately need to downgrade until a workaround is found or a literal module is provided https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/340.

Also see issued raised https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/428.

This PR will likely be reverted in the future once this issue is fixed.