### PR TITLE
Refactoring PopMember + adding adaptive parsimony to tournament

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.7.14"
+version = "0.8.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ println("Complexity\tMSE\tEquation")
 
 for member in dominating
     size = countNodes(member.tree)
-    score = member.score
+    loss = member.loss
     string = stringTree(member.tree, options)
 
-    println("$(size)\t$(score)\t$(string)")
+    println("$(size)\t$(loss)\t$(string)")
 end
 ```
 

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -22,7 +22,7 @@ Node(op::Int, l::Union{AbstractFloat, Int}, r::Union{AbstractFloat, Int})
 ## Population
 
 Groups of equations are given as a population, which is
-an array of trees tagged with score and birthdate---these
+an array of trees tagged with score, loss, and birthdate---these
 values are given in the `PopMember`.
 
 ```@docs
@@ -39,7 +39,7 @@ Population(X::AbstractMatrix{T}, y::AbstractVector{T}, baseline::T;
 
 ## Population members
 ```@docs
-PopMember(t::Node, score::T) where {T<:Real}
+PopMember(t::Node, score::T, loss::T) where {T<:Real}
 PopMember(dataset::Dataset{T}, baseline::T, t::Node, options::Options) where {T<:Real}
 ```
 

--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -11,7 +11,8 @@ import Optim
 function optFunc(x::Vector{CONST_TYPE}, dataset::Dataset{T}, baseline::T,
                  tree::Node, options::Options; allow_diff=false)::T where {T<:Real}
     setConstants(tree, x)
-    return scoreFunc(dataset, baseline, tree, options; allow_diff=allow_diff)
+    loss = scoreFunc(dataset, baseline, tree, options; allow_diff=allow_diff)[2]
+    return loss
 end
 
 # Use Nelder-Mead to optimize the constants in an equation
@@ -60,7 +61,7 @@ function optimizeConstants(dataset::Dataset{T},
 
     if Optim.converged(result)
         setConstants(member.tree, result.minimizer)
-        member.score = convert(T, result.minimum)
+        member.score, member.loss = scoreFunc(dataset, baseline, member.tree, options)
         member.birth = getTime()
     else
         setConstants(member.tree, x0)

--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -24,7 +24,7 @@ has been instantiated or not.
 """
 function HallOfFame(options::Options)
     actualMaxsize = options.maxsize + MAX_DEGREE
-    HallOfFame([PopMember(Node(convert(CONST_TYPE, 1)), 1f9) for i=1:actualMaxsize], [false for i=1:actualMaxsize])
+    HallOfFame([PopMember(Node(convert(CONST_TYPE, 1)), 1f9, 1f9) for i=1:actualMaxsize], [false for i=1:actualMaxsize])
 end
 
 
@@ -51,7 +51,7 @@ function calculateParetoFrontier(dataset::Dataset{T},
                 continue
             end
             simpler_member = hallOfFame.members[i]
-            if (member.score - size*options.parsimony) >= (simpler_member.score - i*options.parsimony)
+            if member.loss >= simpler_member.loss
                 betterThanAllSmaller = false
                 break
             end
@@ -95,12 +95,12 @@ function string_dominating_pareto_curve(hallOfFame, baselineMSE,
     dominating = calculateParetoFrontier(dataset, hallOfFame, options)
     for member in dominating
         complexity = countNodes(member.tree)
-        if member.score < 0.0
-            throw(DomainError(member.score, "Your loss function must be non-negative."))
+        if member.loss < 0.0
+            throw(DomainError(member.loss, "Your loss function must be non-negative."))
         end
         # User higher precision when finding the original loss:
         relu(x) = x < 0 ? 0 : x
-        curMSE = relu(Float64(member.score) - Float64(complexity * options.parsimony)) * Float64(baselineMSE)
+        curMSE = member.loss
         
         delta_c = complexity - lastComplexity
         ZERO_POINT = 1e-10

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -40,9 +40,12 @@ function EvalLoss(tree::Node, dataset::Dataset{T}, options::Options;
     end
 end
 
+# Compute a score which includes a complexity penalty in the loss
 function lossToScore(loss::T, baseline::T, tree::Node, options::Options)::T where {T<:Real}
     normalized_loss_term = loss / baseline
-    parsimony_term = countNodes(tree)*options.parsimony
+    size = countNodes(tree)
+    parsimony_term = size*options.parsimony
+
     return normalized_loss_term + parsimony_term
 end
 

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -41,7 +41,9 @@ function EvalLoss(tree::Node, dataset::Dataset{T}, options::Options;
 end
 
 function lossToScore(loss::T, baseline::T, tree::Node, options::Options)::T where {T<:Real}
-    return loss / baseline + countNodes(tree)*options.parsimony
+    normalized_loss_term = loss / baseline
+    parsimony_term = countNodes(tree)*options.parsimony
+    return normalized_loss_term + parsimony_term
 end
 
 # Score an equation

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -40,12 +40,16 @@ function EvalLoss(tree::Node, dataset::Dataset{T}, options::Options;
     end
 end
 
+function lossToScore(loss::T, baseline::T, tree::Node, options::Options)::T where {T<:Real}
+    return loss / baseline + countNodes(tree)*options.parsimony
+end
+
 # Score an equation
 function scoreFunc(dataset::Dataset{T},
                    baseline::T, tree::Node,
                    options::Options; allow_diff=false)::Tuple{T,T} where {T<:Real}
     loss = EvalLoss(tree, dataset, options; allow_diff=allow_diff)
-    score = loss / baseline + countNodes(tree)*options.parsimony
+    score = lossToScore(loss, baseline, tree, options)
     return score, loss
 end
 
@@ -67,6 +71,6 @@ function scoreFuncBatch(dataset::Dataset{T}, baseline::T,
         batch_w = dataset.weights[batch_idx]
         loss = Loss(prediction, batch_y, batch_w, options)
     end
-    score = loss / baseline + countNodes(tree) * options.parsimony
+    score = lossToScore(loss, baseline, tree, options)
     return score, loss
 end

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -4,7 +4,7 @@ using FromFile
 @from "LossFunctions.jl" import scoreFunc, scoreFuncBatch
 @from "CheckConstraints.jl" import check_constraints
 @from "PopMember.jl" import PopMember
-@from "MutationFunctions.jl" import genRandomTree, mutateConstant, mutateOperator, appendRandomOp, prependRandomOp, insertRandomOp, deleteRandomOp, crossoverTrees
+@from "MutationFunctions.jl" import genRandomTreeFixedSize, mutateConstant, mutateOperator, appendRandomOp, prependRandomOp, insertRandomOp, deleteRandomOp, crossoverTrees
 @from "SimplifyEquation.jl" import simplifyTree, combineOperators, simplifyWithSymbolicUtils
 @from "Recorder.jl" import @recorder
 
@@ -110,7 +110,11 @@ function nextGeneration(dataset::Dataset{T},
             # to commutative operator...
 
         elseif mutationChoice < cweights[7]
-            tree = genRandomTree(5, options, nfeatures) # Sometimes we generate a new tree completely tree
+            # Sometimes we generate a new tree completely tree
+            # We select a random size, though the generated tree
+            # may have fewer nodes than we request.
+            tree_size_to_generate = rand(1:curmaxsize)
+            tree = genRandomTreeFixedSize(tree_size_to_generate, options, nfeatures)
             @recorder tmp_recorder["type"] = "regenerate"
 
             is_success_always_possible = true

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -177,6 +177,8 @@ Construct options for `EquationSearch` and other functions.
     relative proportion of equations at each complexity; this will
     ensure that there are a balanced number of equations considered
     for every complexity.
+- `useFrequencyInTournament=false`: Whether to use the adaptive parsimony described
+    above inside the score, rather than just at the mutation accept/reject stage.
 - `fast_cycle=false`: Whether to thread over subsamples of equations during
     regularized evolution. Slightly improves performance, but is a different
     algorithm.
@@ -242,6 +244,7 @@ function Options(;
     crossoverProbability=0.0f0,
     warmupMaxsizeBy=0f0,
     useFrequency=false,
+    useFrequencyInTournament=false,
     npop=1000,
     ncyclesperiteration=300,
     fractionReplaced=0.1f0,
@@ -360,7 +363,7 @@ function Options(;
         earlyStopCondition = (loss, complexity) -> loss < earlyStopCondition
     end
 
-    options = Options{typeof(binary_operators),typeof(unary_operators), typeof(loss)}(binary_operators, unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, crossoverProbability, warmupMaxsizeBy, useFrequency, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file, probPickFirst, earlyStopCondition, stateReturn, use_symbolic_utils, timeout_in_seconds, skip_mutation_failures)
+    options = Options{typeof(binary_operators),typeof(unary_operators), typeof(loss)}(binary_operators, unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, crossoverProbability, warmupMaxsizeBy, useFrequency, useFrequencyInTournament, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file, probPickFirst, earlyStopCondition, stateReturn, use_symbolic_utils, timeout_in_seconds, skip_mutation_failures)
 
     @eval begin
         Base.print(io::IO, tree::Node) = print(io, stringTree(tree, $options))

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -26,6 +26,7 @@ struct Options{A,B,C<:Union{SupervisedLoss,Function}}
     crossoverProbability::Float32
     warmupMaxsizeBy::Float32
     useFrequency::Bool
+    useFrequencyInTournament::Bool
     npop::Int
     ncyclesperiteration::Int
     fractionReplaced::Float32

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -6,7 +6,8 @@ using FromFile
 # Define a member of population by equation, score, and age
 mutable struct PopMember{T<:Real}
     tree::Node
-    score::T
+    score::T  # Inludes complexity penalty, normalization
+    loss::T  # Raw loss
     birth::Int
 
     # For recording history:
@@ -15,20 +16,21 @@ mutable struct PopMember{T<:Real}
 end
 
 """
-    PopMember(t::Node, score::T)
+    PopMember(t::Node, score::T, loss::T)
 
 Create a population member with a birth date at the current time.
 
 # Arguments
 
 - `t::Node`: The tree for the population member.
-- `score::T`: The loss to assign this member.
+- `score::T`: The score (normalized to a baseline, and offset by a complexity penalty)
+- `loss::T`: The raw loss to assign.
 """
-function PopMember(t::Node, score::T; ref::Int=-1, parent::Int=-1) where {T<:Real}
+function PopMember(t::Node, score::T, loss::T; ref::Int=-1, parent::Int=-1) where {T<:Real}
     if ref == -1
         ref = abs(rand(Int))
     end
-    PopMember{T}(t, score, getTime(), ref, parent)
+    PopMember{T}(t, score, loss, getTime(), ref, parent)
 end
 
 """
@@ -48,14 +50,16 @@ Automatically compute the score for this tree.
 function PopMember(dataset::Dataset{T},
                    baseline::T, t::Node,
                    options::Options; ref::Int=-1, parent::Int=-1) where {T<:Real}
-    PopMember(t, scoreFunc(dataset, baseline, t, options), ref=ref, parent=parent)
+    score, loss = scoreFunc(dataset, baseline, t, options)
+    PopMember(t, score, loss, ref=ref, parent=parent)
 end
 
 function copyPopMember(p::PopMember{T}) where {T<:Real}
     tree = copyNode(p.tree)
     score = copy(p.score)
+    loss = copy(p.loss)
     birth = copy(p.birth)
     ref = copy(p.ref)
     parent = copy(p.parent)
-    return PopMember{T}(tree, score, birth, ref, parent)
+    return PopMember{T}(tree, score, loss, birth, ref, parent)
 end

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -74,9 +74,11 @@ function finalizeScores(dataset::Dataset{T},
     need_recalculate = options.batching
     if need_recalculate
         @inbounds @simd for member=1:pop.n
-            pop.members[member].score = scoreFunc(dataset, baseline,
-                                                  pop.members[member].tree,
-                                                  options)
+            score, loss = scoreFunc(dataset, baseline,
+                                    pop.members[member].tree,
+                                    options)
+            pop.members[member].score = score
+            pop.members[member].loss = loss
         end
     end
     return pop
@@ -91,7 +93,8 @@ end
 
 function record_population(pop::Population{T}, options::Options)::RecordType where {T<:Real}
     RecordType("population"=>[RecordType("tree"=>stringTree(member.tree, options),
-                                         "loss"=>member.score,
+                                         "loss"=>member.loss,
+                                         "score"=>member.score,
                                          "complexity"=>countNodes(member.tree),
                                          "birth"=>member.birth,
                                          "ref"=>member.ref,

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -47,10 +47,23 @@ function samplePop(pop::Population, options::Options)::Population
 end
 
 # Sample the population, and get the best member from that sample
-function bestOfSample(pop::Population, options::Options)::PopMember
+function bestOfSample(pop::Population, frequencyComplexity::AbstractVector{T}, options::Options)::PopMember where {T<:Real}
     sample = samplePop(pop, options)
 
-    scores = [sample.members[member].score for member=1:options.ns]
+    if options.useFrequencyInTournament
+        # Score based on frequency of that size occuring.
+        # In the end, all sizes should be just as common in the population.
+        frequency_scaling = 20 
+        # e.g., for 100% occupied at one size, exp(-20*1) = 2.061153622438558e-9; which seems like a good punishment for dominating the population.
+
+        scores = [
+            sample.members[member].score * exp(frequency_scaling * frequencyComplexity[countNodes(sample.members[member].tree)])
+            for member=1:options.ns
+        ]
+    else
+        scores = [sample.members[member].score for member=1:options.ns]
+    end
+
     p = options.probPickFirst
 
     if p == 1.0

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -82,6 +82,7 @@ function regEvolCycle(dataset::Dataset{T},
                             record["mutations"]["$(member.ref)"] = RecordType("events"=>Vector{RecordType}(),
                                                                             "tree"=>stringTree(member.tree, options),
                                                                             "score"=>member.score,
+                                                                            "loss"=>member.loss,
                                                                             "parent"=>member.parent)
                         end
                     end

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -60,7 +60,7 @@ function regEvolCycle(dataset::Dataset{T},
     else
         for i=1:round(Int, pop.n/options.ns)
             if rand() > options.crossoverProbability
-                allstar = bestOfSample(pop, options)
+                allstar = bestOfSample(pop, frequencyComplexity, options)
                 mutation_recorder = RecordType()
                 baby, mutation_accepted = nextGeneration(dataset, baseline, allstar, temperature,
                                                          curmaxsize, frequencyComplexity, options,
@@ -97,8 +97,8 @@ function regEvolCycle(dataset::Dataset{T},
                 pop.members[oldest] = baby
 
             else # Crossover
-                allstar1 = bestOfSample(pop, options)
-                allstar2 = bestOfSample(pop, options)
+                allstar1 = bestOfSample(pop, frequencyComplexity, options)
+                allstar2 = bestOfSample(pop, frequencyComplexity, options)
 
                 baby1, baby2, crossover_accepted = crossoverGeneration(allstar1, allstar2, dataset, baseline,
                                                    curmaxsize, options)

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -40,13 +40,6 @@ function SRCycle(dataset::Dataset{T}, baseline::T,
                 best_examples_seen.members[size] = copyPopMember(member)
             end
         end
-
-        if verbosity > 0 && (temperature % verbosity == 0) # TODO: Remove this
-            bestPops = bestSubPop(pop)
-            bestCurScoreIdx = argmin([bestPops.members[member].score for member=1:bestPops.n])
-            bestCurScore = bestPops.members[bestCurScoreIdx].score
-            debug(verbosity, bestCurScore, " is the score for ", stringTree(bestPops.members[bestCurScoreIdx].tree, options, varMap=dataset.varMap))
-        end
     end
 
     return (pop, best_examples_seen)

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -701,9 +701,9 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                     @printf("==============================\n")
                     
                     # Debugging code for frequencyComplexities:
-                    for size_i=1:actualMaxsize
-                        @printf("frequencyComplexities size %d = %.2f\n", size_i, frequencyComplexities[j][size_i])
-                    end
+                    # for size_i=1:actualMaxsize
+                    #     @printf("frequencyComplexities size %d = %.2f\n", size_i, frequencyComplexities[j][size_i])
+                    # end
                 end
                 @printf("Press 'q' and then <enter> to stop execution early.\n")
             end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -307,8 +307,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
     actualMaxsize = options.maxsize + MAX_DEGREE
 
     # Make frequencyComplexities a moving average, rather than over all time:
-    n_cycles_before_frequency_refresh = 10
-    window_size = options.npopulations * options.npop * n_cycles_before_frequency_refresh
+    window_size = 100000
     smallest_frequency_allowed = 1
     # 3 here means this will last 3 cycles before being "refreshed"
     # We start out with even numbers at all frequencies.
@@ -654,12 +653,13 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                 # min(frequencyComplexities[j])
                 while difference_in_size > 0
                     indices_to_subtract = findall(frequencyComplexities[j] .> smallest_frequency_allowed)
+                    num_remaining = size(indices_to_subtract, 1)
                     amount_to_subtract = min(
-                        difference_in_size / actualMaxsize,
+                        difference_in_size / num_remaining,
                         min(frequencyComplexities[j][indices_to_subtract]...) - smallest_frequency_allowed
                     )
                     frequencyComplexities[j][indices_to_subtract] .-= amount_to_subtract
-                    difference_in_size -= amount_to_subtract * actualMaxsize
+                    difference_in_size -= amount_to_subtract * num_remaining
                 end
             end
 
@@ -701,9 +701,9 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                     @printf("==============================\n")
                     
                     # Debugging code for frequencyComplexities:
-                    # for size_i=1:actualMaxsize
-                    #     @printf("frequencyComplexities size %d = %.2f\n", size_i, frequencyComplexities[j][size_i])
-                    # end
+                    for size_i=1:actualMaxsize
+                        @printf("frequencyComplexities size %d = %.2f\n", size_i, frequencyComplexities[j][size_i])
+                    end
                 end
                 @printf("Press 'q' and then <enter> to stop execution early.\n")
             end

--- a/test/full.jl
+++ b/test/full.jl
@@ -94,7 +94,7 @@ for i=0:4
         residual = simplify(eqn - true_eqn) + x4 * 1e-10
 
         # Test the score
-        @test best.score < maximum_residual / 10
+        @test best.loss < maximum_residual / 10
         # Test the actual equation found:
         # eval evaluates inside global
         @test abs(eval(Meta.parse(string(residual)))) < maximum_residual
@@ -131,7 +131,7 @@ true_eqn = 2*cos(t4)
 residual = simplify(eqn - true_eqn) + t4 * 1e-10
 
 # Test the score
-@test best.score < maximum_residual / 10
+@test best.loss < maximum_residual / 10
 # Test the actual equation found:
 t1=0.1f0; t2=0.1f0; t3=0.1f0; t4=0.1f0; t5=0.1f0
 residual_value = abs(eval(Meta.parse(string(residual))))
@@ -151,7 +151,7 @@ printTree(best.tree, options)
 eqn = node_to_symbolic(best.tree, options;
                        evaluate_functions=true, varMap=varMap)
 residual = simplify(eqn - true_eqn) + t4 * 1e-10
-@test best.score < maximum_residual / 10
+@test best.loss < maximum_residual / 10
 
 println("Passed.")
 

--- a/test/full.jl
+++ b/test/full.jl
@@ -19,6 +19,8 @@ for i=0:4
     multithreading = false
     crossoverProbability = 0f0
     skip_mutation_failures = false
+    useFrequency = false
+    useFrequencyInTournament = false
     print("Testing with batching=$(batching) and weighted=$(weighted), ")
     if i == 0
         println("with serial & progress bar & warmup & BFGS")
@@ -28,17 +30,21 @@ for i=0:4
         optimizer_algorithm = "BFGS"
         probPickFirst = 0.8
     elseif i == 1
-        println("with multi-output.")
+        println("with multi-output and useFrequency.")
         multi = true
+        useFrequency = true
     elseif i == 3
-        println("with multi-threading and crossover")
+        println("with multi-threading and crossover and useFrequencyInTournament")
         multithreading = true
         numprocs = 0
         crossoverProbability = 0.02f0
+        useFrequencyInTournament = true
     elseif i == 4
-        println("with crossover and skip mutation failures")
+        println("with crossover and skip mutation failures and both frequencies options")
         crossoverProbability = 0.02f0
         skip_mutation_failures = true
+        useFrequency = true
+        useFrequencyInTournament = true
     end
     options = SymbolicRegression.Options(
         binary_operators=(+, *),
@@ -51,7 +57,9 @@ for i=0:4
         progress=progress,
         warmupMaxsizeBy=warmupMaxsizeBy,
         optimizer_algorithm=optimizer_algorithm,
-        probPickFirst=probPickFirst
+        probPickFirst=probPickFirst,
+        useFrequency=useFrequency,
+        useFrequencyInTournament=useFrequencyInTournament,
     )
     X = randn(MersenneTwister(0), Float32, 5, 100)
     if weighted

--- a/test/manual_distributed.jl
+++ b/test/manual_distributed.jl
@@ -27,4 +27,4 @@ rmprocs(procs)
 dominating = calculateParetoFrontier(X, y, hallOfFame, options)
 best = dominating[end]
 # Test the score
-@test best.score < maximum_residual / 10
+@test best.loss < maximum_residual / 10

--- a/test/test_prob_pick_first.jl
+++ b/test/test_prob_pick_first.jl
@@ -18,7 +18,8 @@ for reverse in [false, true]
         if reverse
             score = 1 - score
         end
-        push!(members, PopMember(tree, score))
+        loss = 1f0  # (arbitrary for this test)
+        push!(members, PopMember(tree, score, loss))
     end
 
     pop = Population(members, n)

--- a/test/test_prob_pick_first.jl
+++ b/test/test_prob_pick_first.jl
@@ -24,8 +24,9 @@ for reverse in [false, true]
 
     pop = Population(members, n)
 
+    dummy_frequencies = [0f-10 for i=1:100]
     best_pop_member = [
-        SymbolicRegression.bestOfSample(pop, options).score
+        SymbolicRegression.bestOfSample(pop, dummy_frequencies, options).score
         for j=1:100
     ]
 

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -63,12 +63,15 @@ for unaop in [cos, exp, log_abs, log2_abs, log10_abs, relu, gamma, acosh_abs]
             @test complete2 == true
             @test all(abs.(test_y2 .- y)/N .< zero_tolerance)
 
-            #Test Scoring
+            # Test loss:
             @test abs(EvalLoss(tree, dataset, make_options())) < zero_tolerance
-            @test abs(scoreFunc(dataset, one(T), tree, make_options(parsimony=0.0))) < zero_tolerance
-            @test scoreFunc(dataset, one(T), tree, make_options(parsimony=1.0)) > 1.0
-            @test scoreFunc(dataset, one(T), tree, make_options()) < scoreFunc(dataset, one(T), tree_bad, make_options())
-            @test scoreFunc(dataset, one(T)*10, tree_bad, make_options()) < scoreFunc(dataset, one(T), tree_bad, make_options())
+            @test EvalLoss(tree, dataset, make_options()) == scoreFunc(dataset, one(T), tree, make_options())[2]
+
+            #Test Scoring
+            @test abs(scoreFunc(dataset, one(T), tree, make_options(parsimony=0.0))[1]) < zero_tolerance
+            @test scoreFunc(dataset, one(T), tree, make_options(parsimony=1.0))[1] > 1.0
+            @test scoreFunc(dataset, one(T), tree, make_options())[1] < scoreFunc(dataset, one(T), tree_bad, make_options())[1]
+            @test scoreFunc(dataset, one(T)*10, tree_bad, make_options())[1] < scoreFunc(dataset, one(T), tree_bad, make_options())[1]
 
             # Test gradients:
             df_true = x -> ForwardDiff.derivative(f_true, x)

--- a/test/user_defined_operator.jl
+++ b/test/user_defined_operator.jl
@@ -17,4 +17,4 @@ dominating = calculateParetoFrontier(X, y, hallOfFame, options)
 
 best = dominating[end]
 # Test the score
-@test best.score < maximum_residual / 10
+@test best.loss < maximum_residual / 10


### PR DESCRIPTION
This PR includes both:

1. A refactor of PopMember to both include a score (which has the complexity penalty), and loss (the raw loss).
2. Incorporation of the adaptive parsimony strategy into the tournament scoring, rather than just the simulated annealing part of the pipeline.
3. Tweaking the adaptive parsimony to use a moving window (10 cycles window size), rather than accumulating over the entire search.