### PR TITLE
fix worker connection timeout error

### DIFF
--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -330,12 +330,12 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
     if ConcurrencyType == SRDistributed
         if numprocs === nothing && procs === nothing
             numprocs = 4
-            procs = addprocs(4)
+            procs = addprocs(4, lazy=false)
             we_created_procs = true
         elseif numprocs === nothing
             numprocs = length(procs)
         elseif procs === nothing
-            procs = addprocs(numprocs)
+            procs = addprocs(numprocs, lazy=false)
             we_created_procs = true
         end
 


### PR DESCRIPTION
**The bug:**  Workers will sometimes fail to connect to each other after initialization.  If a task for a worker is longer than the default connection timeout (60s) and another worker tries to connect to the first, they will fail.  

**The fix:**  Setting `lazy=false` forces all connections to be created when workers are, meaning they do not need to be created while things are running and the above error cannot happen.  While this does add some work to startup, added computation time is negligible unless running with a very large number of workers.