### PR TITLE
Automatic multi-node compute setup by passing custom `addprocs`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"


### PR DESCRIPTION
By passing, e.g., `addprocs_slurm` or `addprocs_pbs` (for more options, see https://github.com/JuliaParallel/ClusterManagers.jl#currently-supported-job-queue-systems), you can have `SymbolicRegression.jl` automatically set up multi-node compute for you: both creating processes and tearing them down.