### PR TITLE
Switch from FromFile.jl to traditional module system

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.8.5"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-FromFile = "ff7dd447-1dcb-4ce3-b8ac-22a812192de7"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -20,7 +19,6 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-FromFile = "0.1.0"
 JSON3 = "1"
 LineSearches = "7"
 LossFunctions = "0.6, 0.7"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -2,7 +2,6 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-FromFile = "ff7dd447-1dcb-4ce3-b8ac-22a812192de7"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SymbolicRegression = "8254be44-1295-4e6a-a16d-46603ac705cb"

--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -1,6 +1,7 @@
-using FromFile
-@from "Core.jl" import Node, Options
-@from "EquationUtils.jl" import countNodes
+module CheckConstraintsModule
+
+import ..CoreModule: Node, Options
+import ..EquationUtilsModule: countNodes
 
 # Check if any binary operator are overly complex
 function flagBinOperatorComplexity(tree::Node, ::Val{op}, options::Options)::Bool where {op}
@@ -69,4 +70,6 @@ end
 
 function check_constraints(tree::Node, options::Options)::Bool
     check_constraints(tree, options, options.maxsize)
+end
+
 end

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -1,4 +1,4 @@
-@from "Core.jl" import RecordType
+import ..CoreModule: RecordType
 
 # Check for errors before they happen
 function testOptionConfiguration(T, options::Options)

--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -1,11 +1,12 @@
-using FromFile
+module ConstantOptimizationModule
+
 import LineSearches
 import Optim
-@from "Core.jl" import CONST_TYPE, Node, Options, Dataset
-@from "Utils.jl" import getTime
-@from "EquationUtils.jl" import getConstants, setConstants, countConstants
-@from "LossFunctions.jl" import scoreFunc, EvalLoss
-@from "PopMember.jl" import PopMember
+import ..CoreModule: CONST_TYPE, Node, Options, Dataset
+import ..UtilsModule: getTime
+import ..EquationUtilsModule: getConstants, setConstants, countConstants
+import ..LossFunctionsModule: scoreFunc, EvalLoss
+import ..PopMemberModule: PopMember
 
 # Proxy function for optimization
 function optFunc(x::Vector{CONST_TYPE}, dataset::Dataset{T}, baseline::T,
@@ -57,4 +58,6 @@ function optimizeConstants(dataset::Dataset{T},
         setConstants(member.tree, x0)
     end
     return member
+end
+
 end

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -2,12 +2,14 @@ module CoreModule
 
 include("ProgramConstants.jl")
 include("Dataset.jl")
+include("OptionsStruct.jl")
 include("Equation.jl")
 include("Operators.jl")
 include("Options.jl")
 
 import .ProgramConstantsModule: CONST_TYPE, MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType, SRConcurrency, SRSerial, SRThreaded, SRDistributed
 import .DatasetModule: Dataset
+import .OptionsStructModule: Options
 import .EquationModule: Node, copyNode, stringTree, printTree
 import .OptionsModule: Options
 import .OperatorsModule: plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,7 +1,15 @@
-using FromFile
+module CoreModule
 
-@from "ProgramConstants.jl" import CONST_TYPE, MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType, SRConcurrency, SRSerial, SRThreaded, SRDistributed
-@from "Dataset.jl" import Dataset
-@from "Equation.jl" import Node, copyNode, stringTree, printTree
-@from "Options.jl" import Options
-@from "Operators.jl" import plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip
+include("ProgramConstants.jl")
+include("Dataset.jl")
+include("Equation.jl")
+include("Operators.jl")
+include("Options.jl")
+
+import .ProgramConstantsModule: CONST_TYPE, MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType, SRConcurrency, SRSerial, SRThreaded, SRDistributed
+import .DatasetModule: Dataset
+import .EquationModule: Node, copyNode, stringTree, printTree
+import .OptionsModule: Options
+import .OperatorsModule: plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip
+
+end

--- a/src/CustomSymbolicUtilsSimplification.jl
+++ b/src/CustomSymbolicUtilsSimplification.jl
@@ -1,9 +1,10 @@
-using FromFile
+module CustomSymbolicUtilsSimplificationModule
+
 using SymbolicUtils
 using SymbolicUtils: Chain, If, RestartedChain, IfElse, Postwalk, Fixpoint, @ordered_acrule, isnotflat, flatten_term, needs_sorting, sort_args, is_literal_number, hasrepeats, merge_repeats, _isone, _iszero, _isinteger, istree, symtype, is_operation, has_trig, polynormalize
-@from "Core.jl" import Options
-@from "InterfaceSymbolicUtils.jl" import SYMBOLIC_UTILS_TYPES
-@from "Utils.jl" import isgood, @return_on_false
+import ..CoreModule: Options
+import ..InterfaceSymbolicUtilsModule: SYMBOLIC_UTILS_TYPES
+import ..UtilsModule: isgood, @return_on_false
 
 function multiply_powers(eqn::T)::Tuple{SYMBOLIC_UTILS_TYPES,Bool} where {T<:Union{<:Number,SymbolicUtils.Sym{<:Number}}}
 	return eqn, true
@@ -168,4 +169,6 @@ function custom_simplify(init_eqn::T, options::Options)::Tuple{SYMBOLIC_UTILS_TY
 
 	# Remove power laws
     return multiply_powers(eqn::SYMBOLIC_UTILS_TYPES)
+end
+
 end

--- a/src/Dataset.jl
+++ b/src/Dataset.jl
@@ -1,5 +1,6 @@
-using FromFile
-@from "ProgramConstants.jl" import BATCH_DIM, FEATURE_DIM
+module DatasetModule
+
+import ..ProgramConstantsModule: BATCH_DIM, FEATURE_DIM
 
 struct Dataset{T<:Real}
 
@@ -38,3 +39,5 @@ function Dataset(
 
 end
 
+
+end

--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -1,6 +1,9 @@
-using FromFile
-@from "ProgramConstants.jl" import CONST_TYPE
-@from "OptionsStruct.jl" import Options
+module EquationModule
+
+import ..ProgramConstantsModule: CONST_TYPE
+
+include("OptionsStruct.jl")
+import .OptionsStructModule: Options
 
 # Define a serialization format for the symbolic equations:
 mutable struct Node
@@ -153,4 +156,6 @@ end
 
 function printTree(tree::Node, options::Options; varMap::Union{Array{String, 1}, Nothing}=nothing)
     println(stringTree(tree, options, varMap=varMap))
+end
+
 end

--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -1,9 +1,7 @@
 module EquationModule
 
 import ..ProgramConstantsModule: CONST_TYPE
-
-include("OptionsStruct.jl")
-import .OptionsStructModule: Options
+import ..OptionsStructModule: Options
 
 # Define a serialization format for the symbolic equations:
 mutable struct Node

--- a/src/EquationUtils.jl
+++ b/src/EquationUtils.jl
@@ -1,5 +1,6 @@
-using FromFile
-@from "Core.jl" import CONST_TYPE, Node, copyNode, Options
+module EquationUtilsModule
+
+import ..CoreModule: CONST_TYPE, Node, copyNode, Options
 
 # Count the operators, constants, variables in an equation
 function countNodes(tree::Node)::Int
@@ -139,4 +140,6 @@ function indexConstants(tree::Node, index_tree::NodeIndex, left_index::Int)
         left_index_here = left_index + index_tree.constant_index
         indexConstants(tree.r, index_tree.r, left_index_here)
     end
+end
+
 end

--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -1,7 +1,8 @@
-using FromFile
+module EvaluateEquationModule
+
 using LinearAlgebra
-@from "Core.jl" import Node, Options
-@from "Utils.jl" import @return_on_false, is_bad_array
+import ..CoreModule: Node, Options
+import ..UtilsModule: @return_on_false, is_bad_array
 
 macro return_on_check(val, T, n)
     # This will generate the following code:
@@ -337,4 +338,6 @@ function deg2_diff_eval(tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, option
     out = op.(left, right)
     no_nans = !any(x -> (!isfinite(x)), out)
     return (out, no_nans)
+end
+
 end

--- a/src/EvaluateEquationDerivative.jl
+++ b/src/EvaluateEquationDerivative.jl
@@ -1,9 +1,10 @@
-using FromFile
+module EvaluateEquationDerivativeModule
+
 using LinearAlgebra
-@from "Core.jl" import Node, Options
-@from "Utils.jl" import @return_on_false2, is_bad_array
-@from "EquationUtils.jl" import countConstants, indexConstants, NodeIndex
-@from "EvaluateEquation.jl" import deg0_eval
+import ..CoreModule: Node, Options
+import ..UtilsModule: @return_on_false2, is_bad_array
+import ..EquationUtilsModule: countConstants, indexConstants, NodeIndex
+import ..EvaluateEquationModule: deg0_eval
 
 """
     evalDiffTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options, direction::Int)
@@ -185,3 +186,5 @@ function grad_deg2_eval(tree::Node, n::Int, n_gradients::Int, index_tree::NodeIn
 end
 
 
+
+end

--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -1,8 +1,9 @@
-using FromFile
-@from "Core.jl" import CONST_TYPE, MAX_DEGREE, Node, Options, Dataset, stringTree
-@from "EquationUtils.jl" import countNodes
-@from "PopMember.jl" import PopMember, copyPopMember
-@from "LossFunctions.jl" import EvalLoss
+module HallOfFameModule
+
+import ..CoreModule: CONST_TYPE, MAX_DEGREE, Node, Options, Dataset, stringTree
+import ..EquationUtilsModule: countNodes
+import ..PopMemberModule: PopMember, copyPopMember
+import ..LossFunctionsModule: EvalLoss
 using Printf: @sprintf
 
 """ List of the best members seen all time in `.members` """
@@ -112,4 +113,6 @@ function string_dominating_pareto_curve(hallOfFame, baselineMSE,
     end
     output *= "\n"
     return output
+end
+
 end

--- a/src/InterfaceSymbolicUtils.jl
+++ b/src/InterfaceSymbolicUtils.jl
@@ -1,7 +1,8 @@
-using FromFile
+module InterfaceSymbolicUtilsModule
+
 using SymbolicUtils
-@from "Core.jl" import CONST_TYPE, Node, Options
-@from "Utils.jl" import isgood, isbad, @return_on_false
+import ..CoreModule: CONST_TYPE, Node, Options
+import ..UtilsModule: isgood, isbad, @return_on_false
 
 const SYMBOLIC_UTILS_TYPES = Union{<:Number,SymbolicUtils.Sym{<:Number},SymbolicUtils.Term{<:Number}}
 
@@ -226,4 +227,6 @@ end
 
 function varMap_to_index(var::Symbol, varMap::Nothing)::Int
     return parse(Int, string(var)[2:end])
+end
+
 end

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -1,9 +1,10 @@
-using FromFile
+module LossFunctionsModule
+
 using Random: randperm
 using LossFunctions
-@from "Core.jl" import Options, Dataset, Node
-@from "EquationUtils.jl" import countNodes
-@from "EvaluateEquation.jl" import evalTreeArray, differentiableEvalTreeArray
+import ..CoreModule: Options, Dataset, Node
+import ..EquationUtilsModule: countNodes
+import ..EvaluateEquationModule: evalTreeArray, differentiableEvalTreeArray
 
 
 function Loss(x::AbstractArray{T}, y::AbstractArray{T}, options::Options{A,B,dA,dB,C})::T where {T<:Real,A,B,dA,dB,C<:SupervisedLoss}
@@ -72,4 +73,6 @@ function scoreFuncBatch(dataset::Dataset{T}, baseline::T,
     end
     score = lossToScore(loss, baseline, tree, options)
     return score, loss
+end
+
 end

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -1,12 +1,13 @@
-using FromFile
-@from "Core.jl" import Node, copyNode, Options, Dataset, RecordType
-@from "EquationUtils.jl" import countNodes, countConstants, countDepth
-@from "LossFunctions.jl" import scoreFunc, scoreFuncBatch
-@from "CheckConstraints.jl" import check_constraints
-@from "PopMember.jl" import PopMember
-@from "MutationFunctions.jl" import genRandomTreeFixedSize, mutateConstant, mutateOperator, appendRandomOp, prependRandomOp, insertRandomOp, deleteRandomOp, crossoverTrees
-@from "SimplifyEquation.jl" import simplifyTree, combineOperators, simplifyWithSymbolicUtils
-@from "Recorder.jl" import @recorder
+module MutateModule
+
+import ..CoreModule: Node, copyNode, Options, Dataset, RecordType
+import ..EquationUtilsModule: countNodes, countConstants, countDepth
+import ..LossFunctionsModule: scoreFunc, scoreFuncBatch
+import ..CheckConstraintsModule: check_constraints
+import ..PopMemberModule: PopMember
+import ..MutationFunctionsModule: genRandomTreeFixedSize, mutateConstant, mutateOperator, appendRandomOp, prependRandomOp, insertRandomOp, deleteRandomOp, crossoverTrees
+import ..SimplifyEquationModule: simplifyTree, combineOperators, simplifyWithSymbolicUtils
+import ..RecorderModule: @recorder
 
 # Go through one simulated options.annealing mutation cycle
 #  exp(-delta/T) defines probability of accepting a change
@@ -223,4 +224,6 @@ function crossoverGeneration(member1::PopMember, member2::PopMember, dataset::Da
 
     crossover_accepted = true
     return baby1, baby2, crossover_accepted
+end
+
 end

--- a/src/MutationFunctions.jl
+++ b/src/MutationFunctions.jl
@@ -1,6 +1,7 @@
-using FromFile
-@from "Core.jl" import CONST_TYPE, Node, copyNode, Options
-@from "EquationUtils.jl" import countNodes, countConstants, countOperators, countDepth
+module MutationFunctionsModule
+
+import ..CoreModule: CONST_TYPE, Node, copyNode, Options
+import ..EquationUtilsModule: countNodes, countConstants, countOperators, countDepth
 
 # Return a random node from the tree
 function randomNode(tree::Node)::Node
@@ -320,4 +321,6 @@ function crossoverTrees(tree1::Node, tree2::Node)::Tuple{Node, Node}
         tree2 = node1
     end
     return tree1, tree2
+end
+
 end

--- a/src/Operators.jl
+++ b/src/Operators.jl
@@ -1,3 +1,5 @@
+module OperatorsModule
+
 import SpecialFunctions
 import SpecialFunctions: erf, erfc
 #TODO - actually add these operators to the module!
@@ -94,4 +96,6 @@ end
 # (Just use multiplication normally)
 function logical_and(x::T, y::T)::T where {T}
     return convert(T, (x > convert(T, 0) && y > convert(T, 0)))
+end
+
 end

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -1,13 +1,17 @@
-using FromFile
+module OptionsModule
+
 using Distributed
 using LossFunctions
 using Zygote: gradient
 #TODO - eventually move some of these
 # into the SR call itself, rather than
 # passing huge options at once.
-@from "Operators.jl" import plus, pow, mult, sub, div, log_abs, log10_abs, log2_abs, log1p_abs, sqrt_abs, acosh_abs, atanh_clip
-@from "Equation.jl" import Node, stringTree
-@from "OptionsStruct.jl" import Options
+import ..OperatorsModule: plus, pow, mult, sub, div, log_abs, log10_abs, log2_abs, log1p_abs, sqrt_abs, acosh_abs, atanh_clip
+import ..EquationModule: Node, stringTree
+
+
+include("OptionsStruct.jl")
+import .OptionsStructModule: Options
 
 """
          build_constraints(una_constraints, bin_constraints,
@@ -424,3 +428,5 @@ function Options(;
     return options
 end
 
+
+end

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -8,10 +8,7 @@ using Zygote: gradient
 # passing huge options at once.
 import ..OperatorsModule: plus, pow, mult, sub, div, log_abs, log10_abs, log2_abs, log1p_abs, sqrt_abs, acosh_abs, atanh_clip
 import ..EquationModule: Node, stringTree
-
-
-include("OptionsStruct.jl")
-import .OptionsStructModule: Options
+import ..OptionsStructModule: Options
 
 """
          build_constraints(una_constraints, bin_constraints,

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -1,3 +1,5 @@
+module OptionsStructModule
+
 using LossFunctions
 
 struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
@@ -84,3 +86,5 @@ Base.print(io::IO, options::Options) = print(io, """Options(
     earlyStopCondition=$(options.earlyStopCondition), timeout_in_seconds=$(options.timeout_in_seconds),
 )""")
 Base.show(io::IO, options::Options) = Base.print(io, options)
+
+end

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -1,7 +1,8 @@
-using FromFile
-@from "Core.jl" import Options, Dataset, Node, copyNode
-@from "Utils.jl" import getTime
-@from "LossFunctions.jl" import scoreFunc
+module PopMemberModule
+
+import ..CoreModule: Options, Dataset, Node, copyNode
+import ..UtilsModule: getTime
+import ..LossFunctionsModule: scoreFunc
 
 # Define a member of population by equation, score, and age
 mutable struct PopMember{T<:Real}
@@ -62,4 +63,6 @@ function copyPopMember(p::PopMember{T}) where {T<:Real}
     ref = copy(p.ref)
     parent = copy(p.parent)
     return PopMember{T}(tree, score, loss, birth, ref, parent)
+end
+
 end

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -1,10 +1,11 @@
+module PopulationModule
+
 using Random
-using FromFile
-@from "Core.jl" import Options, Dataset, RecordType, stringTree
-@from "EquationUtils.jl" import countNodes
-@from "LossFunctions.jl" import scoreFunc
-@from "MutationFunctions.jl" import genRandomTree
-@from "PopMember.jl" import PopMember
+import ..CoreModule: Options, Dataset, RecordType, stringTree
+import ..EquationUtilsModule: countNodes
+import ..LossFunctionsModule: scoreFunc
+import ..MutationFunctionsModule: genRandomTree
+import ..PopMemberModule: PopMember
 # A list of members of the population, with easy constructors,
 #  which allow for random generation of new populations
 mutable struct Population{T<:Real}
@@ -123,4 +124,6 @@ function record_population(pop::Population{T}, options::Options)::RecordType whe
                              for member in pop.members],
                "time"=>time()
     )
+end
+
 end

--- a/src/ProgramConstants.jl
+++ b/src/ProgramConstants.jl
@@ -1,3 +1,5 @@
+module ProgramConstantsModule
+
 const MAX_DEGREE = 2
 const CONST_TYPE = Float32
 const BATCH_DIM = 2
@@ -9,3 +11,5 @@ abstract type SRConcurrency end
 struct SRSerial <: SRConcurrency end
 struct SRThreaded <: SRConcurrency end
 struct SRDistributed <: SRConcurrency end
+
+end

--- a/src/ProgressBars.jl
+++ b/src/ProgressBars.jl
@@ -1,3 +1,5 @@
+module ProgressBarsModule
+
 """
 Customisable progressbar decorator for iterators.
 Copied from https://github.com/cloud-oak/ProgressBars.jl to allow for custom modifications.
@@ -334,3 +336,5 @@ function newline_to_spaces(string, terminal_width)
 end
 
 # end
+
+end

--- a/src/README.md
+++ b/src/README.md
@@ -1,4 +1,5 @@
-If you are looking for the main loop, start with `function _EquationSearch` in `SymbolicRegression.jl`. You can proceed from there. All functions are imported at the top using `@from` syntax, which should help you navigate the codebase.
+If you are looking for the main loop, start with `function _EquationSearch` in `SymbolicRegression.jl`. You can proceed from there.
+All functions are imported at the top using `import {filename}Module` syntax, which should help you navigate the codebase.
 
 The file system is structured as follows. Indentation
 shows dependencies.
@@ -8,8 +9,8 @@ shows dependencies.
 ProgramConstants.jl (`maxdegree, CONST_TYPE`)
 OptionsStruct.jl
 Operators.jl
-Equation.jl (`Node`)
 Dataset.jl (`Dataset`)
+    Equation.jl (`Node`)
     Options.jl
 =============================================/ Core.jl
 Core.jl

--- a/src/Recorder.jl
+++ b/src/Recorder.jl
@@ -1,5 +1,6 @@
-using FromFile
-@from "Core.jl" import RecordType
+module RecorderModule
+
+import ..CoreModule: RecordType
 
 "Assumes that `options` holds the user options::Options"
 macro recorder(ex)
@@ -16,4 +17,6 @@ function find_iteration_from_record(key::String, record::RecordType)
         iteration += 1
     end
     return iteration - 1
+end
+
 end

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -1,10 +1,11 @@
-using FromFile
+module RegularizedEvolutionModule
+
 using Random: shuffle!
-@from "Core.jl" import Options, Dataset, RecordType, stringTree
-@from "PopMember.jl" import PopMember
-@from "Population.jl" import Population, bestOfSample
-@from "Mutate.jl" import nextGeneration, crossoverGeneration
-@from "Recorder.jl" import @recorder
+import ..CoreModule: Options, Dataset, RecordType, stringTree
+import ..PopMemberModule: PopMember
+import ..PopulationModule: Population, bestOfSample
+import ..MutateModule: nextGeneration, crossoverGeneration
+import ..RecorderModule: @recorder
 
 # Pass through the population several times, replacing the oldest
 # with the fittest of a small subsample
@@ -117,4 +118,6 @@ function regEvolCycle(dataset::Dataset{T},
     end
 
     return pop
+end
+
 end

--- a/src/SimplifyEquation.jl
+++ b/src/SimplifyEquation.jl
@@ -1,10 +1,11 @@
-using FromFile
-@from "Core.jl" import CONST_TYPE, Node, copyNode, Options
-@from "EquationUtils.jl" import countNodes
-@from "CustomSymbolicUtilsSimplification.jl" import custom_simplify
-@from "InterfaceSymbolicUtils.jl" import node_to_symbolic_safe, symbolic_to_node
-@from "CheckConstraints.jl" import check_constraints
-@from "Utils.jl" import isbad, isgood
+module SimplifyEquationModule
+
+import ..CoreModule: CONST_TYPE, Node, copyNode, Options
+import ..EquationUtilsModule: countNodes
+import ..CustomSymbolicUtilsSimplificationModule: custom_simplify
+import ..InterfaceSymbolicUtilsModule: node_to_symbolic_safe, symbolic_to_node
+import ..CheckConstraintsModule: check_constraints
+import ..UtilsModule: isbad, isgood
 
 # Simplify tree
 function combineOperators(tree::Node, options::Options)::Node
@@ -156,4 +157,6 @@ end
 
 function simplifyWithSymbolicUtils(tree::Node, options::Options)::Node
     simplifyWithSymbolicUtils(tree, options, options.maxsize)
+end
+
 end

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -1,13 +1,14 @@
-using FromFile
-@from "Core.jl" import Options, Dataset, RecordType, stringTree
-@from "EquationUtils.jl" import countNodes
-@from "Utils.jl" import debug
-@from "SimplifyEquation.jl" import simplifyTree, combineOperators, simplifyWithSymbolicUtils
-@from "PopMember.jl" import copyPopMember
-@from "Population.jl" import Population, finalizeScores, bestSubPop
-@from "HallOfFame.jl" import HallOfFame
-@from "RegularizedEvolution.jl" import regEvolCycle
-@from "ConstantOptimization.jl" import optimizeConstants
+module SingleIterationModule
+
+import ..CoreModule: Options, Dataset, RecordType, stringTree
+import ..EquationUtilsModule: countNodes
+import ..UtilsModule: debug
+import ..SimplifyEquationModule: simplifyTree, combineOperators, simplifyWithSymbolicUtils
+import ..PopMemberModule: copyPopMember
+import ..PopulationModule: Population, finalizeScores, bestSubPop
+import ..HallOfFameModule: HallOfFame
+import ..RegularizedEvolutionModule: regEvolCycle
+import ..ConstantOptimizationModule: optimizeConstants
 
 
 # Cycle through regularized evolution many times,
@@ -63,4 +64,6 @@ function OptimizeAndSimplifyPopulation(
     end
     pop = finalizeScores(dataset, baseline, pop, options)
     return pop
+end
+
 end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -58,27 +58,47 @@ import JSON3
 using Printf: @printf, @sprintf
 using Pkg
 using Random: seed!, shuffle!
-using FromFile
 using Reexport
 @reexport using LossFunctions
 
-@from "Core.jl" import CONST_TYPE, MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType, Dataset, Node, copyNode, Options, plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip, SRConcurrency, SRSerial, SRThreaded, SRDistributed, stringTree, printTree
-@from "Utils.jl" import debug, debug_inline, is_anonymous_function, recursive_merge, next_worker, @sr_spawner
-@from "EquationUtils.jl" import countNodes, getConstants, setConstants, indexConstants, NodeIndex
-@from "EvaluateEquation.jl" import evalTreeArray, differentiableEvalTreeArray
-@from "EvaluateEquationDerivative.jl" import evalDiffTreeArray, evalGradTreeArray
-@from "CheckConstraints.jl" import check_constraints
-@from "MutationFunctions.jl" import genRandomTree, genRandomTreeFixedSize, randomNode, randomNodeAndParent, crossoverTrees
-@from "LossFunctions.jl" import EvalLoss, Loss, scoreFunc
-@from "PopMember.jl" import PopMember, copyPopMember
-@from "Population.jl" import Population, bestSubPop, record_population, bestOfSample
-@from "HallOfFame.jl" import HallOfFame, calculateParetoFrontier, string_dominating_pareto_curve
-@from "SingleIteration.jl" import SRCycle, OptimizeAndSimplifyPopulation
-@from "InterfaceSymbolicUtils.jl" import node_to_symbolic, symbolic_to_node
-@from "CustomSymbolicUtilsSimplification.jl" import custom_simplify
-@from "SimplifyEquation.jl" import simplifyWithSymbolicUtils, combineOperators, simplifyTree
-@from "ProgressBars.jl" import ProgressBar, set_multiline_postfix
-@from "Recorder.jl" import @recorder, find_iteration_from_record
+include("Core.jl")
+include("Recorder.jl")
+include("Utils.jl")
+include("EquationUtils.jl")
+include("EvaluateEquation.jl")
+include("EvaluateEquationDerivative.jl")
+include("CheckConstraints.jl")
+include("MutationFunctions.jl")
+include("LossFunctions.jl")
+include("PopMember.jl")
+include("ConstantOptimization.jl")
+include("Population.jl")
+include("HallOfFame.jl")
+include("InterfaceSymbolicUtils.jl")
+include("CustomSymbolicUtilsSimplification.jl")
+include("SimplifyEquation.jl")
+include("Mutate.jl")
+include("RegularizedEvolution.jl")
+include("SingleIteration.jl")
+include("ProgressBars.jl")
+
+import .CoreModule: CONST_TYPE, MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType, Dataset, Node, copyNode, Options, plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip, SRConcurrency, SRSerial, SRThreaded, SRDistributed, stringTree, printTree
+import .UtilsModule: debug, debug_inline, is_anonymous_function, recursive_merge, next_worker, @sr_spawner
+import .EquationUtilsModule: countNodes, getConstants, setConstants, indexConstants, NodeIndex
+import .EvaluateEquationModule: evalTreeArray, differentiableEvalTreeArray
+import .EvaluateEquationDerivativeModule: evalDiffTreeArray, evalGradTreeArray
+import .CheckConstraintsModule: check_constraints
+import .MutationFunctionsModule: genRandomTree, genRandomTreeFixedSize, randomNode, randomNodeAndParent, crossoverTrees
+import .LossFunctionsModule: EvalLoss, Loss, scoreFunc
+import .PopMemberModule: PopMember, copyPopMember
+import .PopulationModule: Population, bestSubPop, record_population, bestOfSample
+import .HallOfFameModule: HallOfFame, calculateParetoFrontier, string_dominating_pareto_curve
+import .SingleIterationModule: SRCycle, OptimizeAndSimplifyPopulation
+import .InterfaceSymbolicUtilsModule: node_to_symbolic, symbolic_to_node
+import .CustomSymbolicUtilsSimplificationModule: custom_simplify
+import .SimplifyEquationModule: simplifyWithSymbolicUtils, combineOperators, simplifyTree
+import .ProgressBarsModule: ProgressBar, set_multiline_postfix
+import .RecorderModule: @recorder, find_iteration_from_record
 
 include("Configure.jl")
 include("Deprecates.jl")

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,7 +1,8 @@
+module UtilsModule
+
 import Printf: @printf
 using Distributed
-using FromFile
-@from "Core.jl" import SRThreaded, SRSerial, SRDistributed
+import ..CoreModule: SRThreaded, SRSerial, SRDistributed
 
 function debug(verbosity, string...)
     if verbosity > 0
@@ -25,8 +26,8 @@ function check_numeric(n)
 end
 
 function is_anonymous_function(op)
-	op_string = string(nameof(op))
-	return length(op_string) > 1 && op_string[1] == '#' && check_numeric(op_string[2:2])
+    op_string = string(nameof(op))
+    return length(op_string) > 1 && op_string[1] == '#' && check_numeric(op_string[2:2])
 end
 
 function recursive_merge(x::AbstractVector...)
@@ -92,3 +93,5 @@ end
 # Fastest way to check for NaN in an array.
 # (due to optimizations in sum())
 is_bad_array(array) = !isfinite(sum(array))
+
+end

--- a/src/scripts/fromfile_to_modules.sh
+++ b/src/scripts/fromfile_to_modules.sh
@@ -7,7 +7,7 @@ FILES=$@
 # Loop through files:
 for file in $FILES; do
     base=$(basename ${file%.*})
-    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import ..\1:/g' -e 'using FromFile' 'dd' -s "Omodule ${base}\<enter>" 'Go\<enter>end' > tmp.jl
+    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import .._\1:/g' -e 'using FromFile' 'dd' -s "Omodule _${base}\<enter>" 'Go\<enter>end' > tmp.jl
     mv tmp.jl $file
 done
 

--- a/src/scripts/fromfile_to_modules.sh
+++ b/src/scripts/fromfile_to_modules.sh
@@ -10,3 +10,10 @@ for file in $FILES; do
     cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import ..\1:/g' -e 'using FromFile' 'dd' -s "Omodule ${base}\<enter>" 'Go\<enter>end' > tmp.jl
     mv tmp.jl $file
 done
+
+
+# Changes to make:
+# - Run this file on everything.
+# - Change `import ..` to `import .` in SymbolicRegression.jl
+# - Rename module that have same name as existing variables:
+    # - All files are mapped to _{file}.jl, and modules as well.

--- a/src/scripts/fromfile_to_modules.sh
+++ b/src/scripts/fromfile_to_modules.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Requires vim-stream (https://github.com/MilesCranmer/vim-stream)
+
+# The user passes files as arguments:
+FILES=$@
+
+# Loop through files:
+for file in $FILES; do
+    base=$(basename ${file%.*})
+    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import .\1:/g' -e 'using FromFile' 'dd' -s "Omodule ${base}\<enter>" 'Go\<enter>end' > tmp.jl
+    mv tmp.jl $file
+done

--- a/src/scripts/fromfile_to_modules.sh
+++ b/src/scripts/fromfile_to_modules.sh
@@ -7,6 +7,6 @@ FILES=$@
 # Loop through files:
 for file in $FILES; do
     base=$(basename ${file%.*})
-    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import .\1:/g' -e 'using FromFile' 'dd' -s "Omodule ${base}\<enter>" 'Go\<enter>end' > tmp.jl
+    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import ..\1:/g' -e 'using FromFile' 'dd' -s "Omodule ${base}\<enter>" 'Go\<enter>end' > tmp.jl
     mv tmp.jl $file
 done

--- a/src/scripts/fromfile_to_modules.sh
+++ b/src/scripts/fromfile_to_modules.sh
@@ -7,7 +7,7 @@ FILES=$@
 # Loop through files:
 for file in $FILES; do
     base=$(basename ${file%.*})
-    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import .._\1:/g' -e 'using FromFile' 'dd' -s "Omodule _${base}\<enter>" 'Go\<enter>end' | sed "s/^ $//g" > tmp.jl
+    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import .._\1:/g' -e 'using FromFile' 'dd' -s "Omodule ${base}Module\<enter>" 'Go\<enter>end' | sed "s/^ $//g" > tmp.jl
     mv tmp.jl $file
 done
 

--- a/src/scripts/fromfile_to_modules.sh
+++ b/src/scripts/fromfile_to_modules.sh
@@ -7,7 +7,7 @@ FILES=$@
 # Loop through files:
 for file in $FILES; do
     base=$(basename ${file%.*})
-    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import .._\1:/g' -e 'using FromFile' 'dd' -s "Omodule ${base}Module\<enter>" 'Go\<enter>end' | sed "s/^ $//g" > tmp.jl
+    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import ..\1Module:/g' -e 'using FromFile' 'dd' -s "Omodule ${base}Module\<enter>" 'Go\<enter>end' | sed "s/^ $//g" > tmp.jl
     mv tmp.jl $file
 done
 

--- a/src/scripts/fromfile_to_modules.sh
+++ b/src/scripts/fromfile_to_modules.sh
@@ -7,7 +7,7 @@ FILES=$@
 # Loop through files:
 for file in $FILES; do
     base=$(basename ${file%.*})
-    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import .._\1:/g' -e 'using FromFile' 'dd' -s "Omodule _${base}\<enter>" 'Go\<enter>end' > tmp.jl
+    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import .._\1:/g' -e 'using FromFile' 'dd' -s "Omodule _${base}\<enter>" 'Go\<enter>end' | sed "s/^ $//g" > tmp.jl
     mv tmp.jl $file
 done
 

--- a/test/full.jl
+++ b/test/full.jl
@@ -1,5 +1,4 @@
-using FromFile
-@from "test_params.jl" import maximum_residual, default_params
+include("test_params.jl")
 using SymbolicRegression, SymbolicUtils
 using Test
 using SymbolicRegression: stringTree

--- a/test/manual_distributed.jl
+++ b/test/manual_distributed.jl
@@ -1,5 +1,4 @@
-using FromFile
-@from "test_params.jl" import maximum_residual, default_params
+include("test_params.jl")
 
 using Distributed
 procs = addprocs(4)

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -1,7 +1,7 @@
 using Test
 using SymbolicRegression
 
-@from "test_params.jl" import default_params
+include("test_params.jl")
 
 ## Test Base.print
 options = Options(;

--- a/test/test_prob_pick_first.jl
+++ b/test/test_prob_pick_first.jl
@@ -1,5 +1,4 @@
-using FromFile
-@from "test_params.jl" import default_params
+include("test_params.jl")
 using SymbolicRegression, Test
 
 n = 10

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -1,5 +1,4 @@
-using FromFile
-@from "test_params.jl" import default_params
+include("test_params.jl")
 using SymbolicRegression, Test
 
 binary_operators = (+, -, /, *)

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -1,5 +1,4 @@
-using FromFile
-@from "test_params.jl" import default_params
+include("test_params.jl")
 using SymbolicRegression, SymbolicUtils, Test, Random, ForwardDiff
 using SymbolicRegression: Options, stringTree, evalTreeArray, Dataset, differentiableEvalTreeArray
 using SymbolicRegression: printTree, pow, EvalLoss, scoreFunc, Node

--- a/test/user_defined_operator.jl
+++ b/test/user_defined_operator.jl
@@ -1,6 +1,5 @@
-using FromFile
 using SymbolicRegression, Test
-@from "test_params.jl" import maximum_residual, default_params
+include("test_params.jl")
 
 _inv(x::Float32)::Float32 = 1f0/x
 X = rand(Float32, 5, 100) .+ 1


### PR DESCRIPTION
This is a partially-automated bulk change away from FromFile.jl to the more standard `module {name} ... end` system.

I think FromFile.jl is awesome and I hope the syntax gets adopted eventually by Julia. As can be seen from the changes, this version is nearly identical in terms of structure: every single file is encapsulated with a `module ... end`, and all the `@from "File.jl" import ...` are converted to `import FileModule: ...`. So I am still basically using FromFile.jl, in spirit, where I have "pre-expanded" the `@from` macro.

Due to FromFile's nature as a third-party library, using it throughout SymbolicRegression.jl has made it hard to take advantage of code analysis libraries, such as Documenter.jl (which appends module names to documentation), or even code IDEs. Code IDEs like VS Code don't seem to know how to parse my codebase and find references to a particular symbol, or append documentation when I hover over a variable. I don't have time to fix the IDEs themselves so its easiest to simply hardcode expand the macros.

The script to do this is as follows:
```bash
for file in $FILES; do
    base=$(basename ${file%.*})
    cat $file | vims -t '%g/^@from/s/@from "\(.\{-}\)\.jl" import/import ..\1Module:/g' -e 'using FromFile' 'dd' -s "Omodule ${base}Module\<enter>" 'Go\<enter>end' | sed "s/^ $//g" > tmp.jl
    mv tmp.jl $file
done
```
where `vims` is a call to [vim-stream](https://github.com/MilesCranmer/vim-stream).

This will turn every file into a module, and switch `@from "File.jl" import` into `import FileModule:`. You have to do by-hand work at the end to add the includes in the right order.


If the IDEs/Documenter.jl get fixed, or syntax is adopted by Julia, I can switch back.