### PR TITLE
Add constraints on the number of times operators can be nested

### DIFF
--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -61,6 +61,17 @@ function count_operators(tree::Node, ::Val{degree}, ::Val{op}, options::Options)
     return count
 end
 
+"""Count the max number of times an operator of a given degree is nested"""
+function count_max_nestedness(tree::Node, degree::Int, op::Int, options::Options)::Int
+    if tree.degree == 0
+        return 0
+    elseif tree.degree == 1
+        return Int(degree == 1 && tree.op == op) + count_max_nestedness(tree.l, degree, op, options)
+    else  # tree.degree == 2
+        return Int(degree == 2 && tree.op == op) + max(count_max_nestedness(tree.l, degree, op, options), count_max_nestedness(tree.r, degree, op, options))
+    end
+end
+
 
 """Check if there are any illegal combinations of operators"""
 function flag_illegal_nests(tree::Node, ::Val{degree}, ::Val{op}, options::Options)::Bool where {degree,op}

--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -47,21 +47,6 @@ function flagUnaOperatorComplexity(tree::Node, ::Val{op}, options::Options)::Boo
 end
 
 
-"""Count number of a specific operator in a tree"""
-function count_operators(tree::Node, ::Val{degree}, ::Val{op}, options::Options)::Int where {op,degree}
-    if tree.degree == 0
-        return 0
-    end
-
-    count = Int(tree.degree == degree && op == tree.op)
-    count += count_operators(tree.l, Val(degree), Val(op), options)
-    if tree.degree == 2
-        count += count_operators(tree.r, Val(degree), Val(op), options)
-    end
-    return count
-end
-
-
 """Count the max number of times an operator of a given degree is nested"""
 function count_max_nestedness(tree::Node, degree::Int, op::Int, options::Options)::Int
     if tree.degree == 0

--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -62,47 +62,59 @@ function count_operators(tree::Node, ::Val{degree}, ::Val{op}, options::Options)
 end
 
 """Count the max number of times an operator of a given degree is nested"""
-function count_max_nestedness(tree::Node, degree::Int, op::Int, options::Options)::Int
+function count_max_nestedness(tree::Node, ::Val{degree}, ::Val{op}, options::Options)::Int where {op,degree}
     if tree.degree == 0
         return 0
     elseif tree.degree == 1
-        return Int(degree == 1 && tree.op == op) + count_max_nestedness(tree.l, degree, op, options)
+        count = (degree == 1 && tree.op == op) ? 1 : 0
+        return count + count_max_nestedness(tree.l, Val(degree), Val(op), options)
     else  # tree.degree == 2
-        return Int(degree == 2 && tree.op == op) + max(count_max_nestedness(tree.l, degree, op, options), count_max_nestedness(tree.r, degree, op, options))
+        count = (degree == 2 && tree.op == op) ? 1 : 0
+        return count + max(
+            count_max_nestedness(tree.l, Val(degree), Val(op), options),
+            count_max_nestedness(tree.r, Val(degree), Val(op), options)
+        )
     end
 end
 
+# function fast_max_nestedness(tree::Node, degree::Int, op_idx::Int, nested_degree::Int, nested_op_idx::Int, options::Options)::Int
+function fast_max_nestedness(tree::Node, ::Val{degree}, ::Val{op_idx}, ::Val{nested_degree}, ::Val{nested_op_idx}, options::Options)::Int where {degree,op_idx,nested_degree,nested_op_idx}
+    # Don't need to branch - once you find operator, run
+    # count_max once, then return. Don't need to go deeper!
+    if tree.degree == 0
+        return 0
+    elseif tree.degree == 1
+        if degree != tree.degree || tree.op != op_idx
+            return fast_max_nestedness(tree.l, Val(degree), Val(op_idx), Val(nested_degree), Val(nested_op_idx), options)
+        end
+        return count_max_nestedness(tree.l, Val(nested_degree), Val(nested_op_idx), options)
+    else
+        if degree != tree.degree || tree.op != op_idx
+            return max(
+                fast_max_nestedness(tree.l, Val(degree), Val(op_idx), Val(nested_degree), Val(nested_op_idx), options),
+                fast_max_nestedness(tree.r, Val(degree), Val(op_idx), Val(nested_degree), Val(nested_op_idx), options)
+            )
+        end
+        return max(
+            count_max_nestedness(tree.l, Val(nested_degree), Val(nested_op_idx), options),
+            count_max_nestedness(tree.r, Val(nested_degree), Val(nested_op_idx), options)
+        )
+    end
+end
 
 """Check if there are any illegal combinations of operators"""
-function flag_illegal_nests(tree::Node, options::Options)::Bool
-    if tree.degree == 0
-        return false
-    end
-
+function flag_illegal_nests(tree::Node, options::Options{A,B,dA,dB,S})::Bool where {A,B,dA,dB,S}
     # We search from the top first, then from child nodes at end.
-    op = tree.degree == 1 ? options.unaops[tree.op] : options.binops[tree.op]
     nested_constraints = options.nested_constraints
-
-    if haskey(nested_constraints, op)
-        # Now, we count max nesting of any operator specified.
-        for (nest_op, max_nesting) ∈ nested_constraints[op]
-            nest_op_degree = nest_op ∈ options.unaops ? 1 : 2
-            nest_op_idx = nest_op_degree == 1 ? findfirst(isequal(nest_op), options.unaops) : findfirst(isequal(nest_op), options.binops)
-            nestedness = count_max_nestedness(tree.l, nest_op_degree, nest_op_idx, options)
-            if tree.degree == 2
-                nestedness = max(nestedness, count_max_nestedness(tree.r, nest_op_degree, nest_op_idx, options))
-            end
-            if nestedness > max_nesting
+    for (degree, op_idx, nested_constraint) ∈ nested_constraints
+        for (nested_degree, nested_op_idx, max_nestedness) ∈ nested_constraint
+            nestedness = fast_max_nestedness(tree, Val(degree), Val(op_idx), Val(nested_degree), Val(nested_op_idx), options)
+            if nestedness > max_nestedness
                 return true
             end
         end
     end
-
-    if tree.degree == 1
-        return flag_illegal_nests(tree.l, options)
-    else  # tree.degree == 2
-        return (flag_illegal_nests(tree.l, options) || flag_illegal_nests(tree.r, options))
-    end
+    return false
 end
 
 """Check if user-passed constraints are violated or not"""
@@ -124,7 +136,7 @@ function check_constraints(tree::Node, options::Options, maxsize::Int)::Bool
             return false
         end
     end
-    if flag_illegal_nests(tree, options)
+    if options.nested_constraints !== nothing && flag_illegal_nests(tree, options)
         return false
     end
 

--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -63,9 +63,15 @@ end
 
 """Check if there are any illegal combinations of operators"""
 function flag_illegal_nests(tree::Node, ::Val{degree}, ::Val{op}, options::Options)::Bool where {degree,op}
+    if degree == 0 || tree.degree == 0
+        return false
+    end
+
+    # No checking binary operators, so skip it:
     if degree == 2
         return false
     end
+
     if options.unaops[op] in [sin, cos]
         count_of_nested_sin_cos = 0
         if sin in options.unaops
@@ -81,6 +87,7 @@ function flag_illegal_nests(tree::Node, ::Val{degree}, ::Val{op}, options::Optio
             return true # flag!
         end
     end
+    return false
 end
 
 

--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -61,54 +61,55 @@ function count_operators(tree::Node, ::Val{degree}, ::Val{op}, options::Options)
     return count
 end
 
+
 """Count the max number of times an operator of a given degree is nested"""
-function count_max_nestedness(tree::Node, ::Val{degree}, ::Val{op}, options::Options)::Int where {op,degree}
+function count_max_nestedness(tree::Node, degree::Int, op::Int, options::Options)::Int
     if tree.degree == 0
         return 0
     elseif tree.degree == 1
         count = (degree == 1 && tree.op == op) ? 1 : 0
-        return count + count_max_nestedness(tree.l, Val(degree), Val(op), options)
+        return count + count_max_nestedness(tree.l, degree, op, options)
     else  # tree.degree == 2
         count = (degree == 2 && tree.op == op) ? 1 : 0
         return count + max(
-            count_max_nestedness(tree.l, Val(degree), Val(op), options),
-            count_max_nestedness(tree.r, Val(degree), Val(op), options)
+            count_max_nestedness(tree.l, degree, op, options),
+            count_max_nestedness(tree.r, degree, op, options)
         )
     end
 end
 
 # function fast_max_nestedness(tree::Node, degree::Int, op_idx::Int, nested_degree::Int, nested_op_idx::Int, options::Options)::Int
-function fast_max_nestedness(tree::Node, ::Val{degree}, ::Val{op_idx}, ::Val{nested_degree}, ::Val{nested_op_idx}, options::Options)::Int where {degree,op_idx,nested_degree,nested_op_idx}
+function fast_max_nestedness(tree::Node, degree::Int, op_idx::Int, nested_degree::Int, nested_op_idx::Int, options::Options)::Int
     # Don't need to branch - once you find operator, run
     # count_max once, then return. Don't need to go deeper!
     if tree.degree == 0
         return 0
     elseif tree.degree == 1
         if degree != tree.degree || tree.op != op_idx
-            return fast_max_nestedness(tree.l, Val(degree), Val(op_idx), Val(nested_degree), Val(nested_op_idx), options)
+            return fast_max_nestedness(tree.l, degree, op_idx, nested_degree, nested_op_idx, options)
         end
-        return count_max_nestedness(tree.l, Val(nested_degree), Val(nested_op_idx), options)
+        return count_max_nestedness(tree.l, nested_degree, nested_op_idx, options)
     else
         if degree != tree.degree || tree.op != op_idx
             return max(
-                fast_max_nestedness(tree.l, Val(degree), Val(op_idx), Val(nested_degree), Val(nested_op_idx), options),
-                fast_max_nestedness(tree.r, Val(degree), Val(op_idx), Val(nested_degree), Val(nested_op_idx), options)
+                fast_max_nestedness(tree.l, degree, op_idx, nested_degree, nested_op_idx, options),
+                fast_max_nestedness(tree.r, degree, op_idx, nested_degree, nested_op_idx, options)
             )
         end
         return max(
-            count_max_nestedness(tree.l, Val(nested_degree), Val(nested_op_idx), options),
-            count_max_nestedness(tree.r, Val(nested_degree), Val(nested_op_idx), options)
+            count_max_nestedness(tree.l, nested_degree, nested_op_idx, options),
+            count_max_nestedness(tree.r, nested_degree, nested_op_idx, options)
         )
     end
 end
 
 """Check if there are any illegal combinations of operators"""
-function flag_illegal_nests(tree::Node, options::Options{A,B,dA,dB,S})::Bool where {A,B,dA,dB,S}
+function flag_illegal_nests(tree::Node, options::Options)::Bool
     # We search from the top first, then from child nodes at end.
     nested_constraints = options.nested_constraints
-    for (degree, op_idx, nested_constraint) ∈ nested_constraints
-        for (nested_degree, nested_op_idx, max_nestedness) ∈ nested_constraint
-            nestedness = fast_max_nestedness(tree, Val(degree), Val(op_idx), Val(nested_degree), Val(nested_op_idx), options)
+    for (degree, op_idx, op_constraint) ∈ nested_constraints
+        for (nested_degree, nested_op_idx, max_nestedness) ∈ op_constraint
+            nestedness = fast_max_nestedness(tree, degree, op_idx, nested_degree, nested_op_idx, options)
             if nestedness > max_nestedness
                 return true
             end

--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -107,6 +107,9 @@ end
 function flag_illegal_nests(tree::Node, options::Options)::Bool
     # We search from the top first, then from child nodes at end.
     nested_constraints = options.nested_constraints
+    if nested_constraints === nothing
+        return false
+    end
     for (degree, op_idx, op_constraint) ∈ nested_constraints
         for (nested_degree, nested_op_idx, max_nestedness) ∈ op_constraint
             nestedness = fast_max_nestedness(tree, degree, op_idx, nested_degree, nested_op_idx, options)
@@ -137,7 +140,7 @@ function check_constraints(tree::Node, options::Options, maxsize::Int)::Bool
             return false
         end
     end
-    if options.nested_constraints !== nothing && flag_illegal_nests(tree, options)
+    if flag_illegal_nests(tree, options)
         return false
     end
 

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -324,6 +324,30 @@ function Options(;
             end
         end
 
+        # Lastly, we clean it up into a dict of (degree,op_idx) => max_nesting.
+        new_nested_constraints = []
+        # Dict()
+        for (op, nested_constraint) ∈ nested_constraints
+            (degree, idx) = if op ∈ binary_operators
+                2, findfirst(isequal(op), binary_operators)
+            else
+                1, findfirst(isequal(op), unary_operators)
+            end
+            new_max_nesting_dict = []
+            # Dict()
+            for (nested_op, max_nesting) ∈ nested_constraint
+                (nested_degree, nested_idx) = if nested_op ∈ binary_operators
+                    2, findfirst(isequal(nested_op), binary_operators)
+                else
+                    1, findfirst(isequal(nested_op), unary_operators)
+                end
+                # new_max_nesting_dict[(nested_degree, nested_idx)] = max_nesting
+                push!(new_max_nesting_dict, (nested_degree, nested_idx, max_nesting))
+            end
+            # new_nested_constraints[(degree, idx)] = new_max_nesting_dict
+            push!(new_nested_constraints, (degree, idx, new_max_nesting_dict))
+        end
+        nested_constraints = new_nested_constraints
     end
 
 

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -225,6 +225,14 @@ https://github.com/MilesCranmer/PySR/discussions/115.
     expression with the original expression and proceed normally.
 - `enable_autodiff`: Whether to enable automatic differentiation functionality. This is turned off by default.
     If turned on, this will be turned off if one of the operators does not have well-defined gradients.
+- `nested_constraints`: Specifies how many times a combination of operators can be nested. For example,
+    `[sin => [cos => 0, sin => -1], cos => [cos => 2]]` specifies that `cos` may never appear within a `sin`,
+    but `sin` can be nested with itself an unlimited number of times. The second term specifies that `cos`
+    can be nested up to 2 times within a `cos`, so that `cos(cos(cos(x)))` is allowed (as well as any combination
+    of `+` or `-` within it), but `cos(cos(cos(cos(x))))` is not allowed. When an operator is not specified,
+    it is assumed that it can be nested an unlimited number of times. This requires that there is no operator
+    which is used both in the unary operators and the binary operators (e.g., `-` could be both subtract, and negation).
+    For binary operators, both arguments are treated the same way, and the max of each argument is constrained.
 """
 function Options(;
     binary_operators::NTuple{nbin, Any}=(+, -, /, *),
@@ -277,6 +285,7 @@ function Options(;
     timeout_in_seconds=nothing,
     skip_mutation_failures::Bool=true,
     enable_autodiff::Bool=false,
+    nested_constraints=nothing,
    ) where {nuna,nbin}
 
     if warmupMaxsize !== nothing
@@ -289,6 +298,33 @@ function Options(;
 
     @assert maxsize > 3
     @assert warmupMaxsizeBy >= 0f0
+
+    # Make sure nested_constraints contains functions within our operator set:
+    if nested_constraints !== nothing
+        # Check that intersection of binary operators and unary operators is empty:
+        for op ∈ binary_operators
+            if op ∈ unary_operators
+                error("Operator " + op + " is both a binary and unary operator. You can't use nested constraints.")
+            end
+        end
+
+        # Convert to dict:
+        if !(typeof(nested_constraints) <: Dict)
+            # Convert to dict:
+            nested_constraints = Dict([
+                cons[1] => Dict(cons[2]...)
+                for cons in nested_constraints
+            ]...)
+        end
+        for (op, nested_constraint) ∈ nested_constraints
+            @assert op ∈ binary_operators || op ∈ unary_operators
+            for (nested_op, max_nesting) ∈ nested_constraint
+                @assert nested_op ∈ binary_operators || nested_op ∈ unary_operators
+                @assert max_nesting >= -1 && typeof(max_nesting) <: Int
+            end
+        end
+
+    end
 
 
     if typeof(constraints) <: Tuple
@@ -415,7 +451,7 @@ function Options(;
         earlyStopCondition = (loss, complexity) -> loss < earlyStopCondition
     end
 
-    options = Options{typeof(binary_operators),typeof(unary_operators), typeof(diff_binary_operators), typeof(diff_unary_operators), typeof(loss)}(binary_operators, unary_operators, diff_binary_operators, diff_unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, crossoverProbability, warmupMaxsizeBy, useFrequency, useFrequencyInTournament, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file, probPickFirst, earlyStopCondition, stateReturn, use_symbolic_utils, timeout_in_seconds, skip_mutation_failures, enable_autodiff)
+    options = Options{typeof(binary_operators),typeof(unary_operators), typeof(diff_binary_operators), typeof(diff_unary_operators), typeof(loss)}(binary_operators, unary_operators, diff_binary_operators, diff_unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, crossoverProbability, warmupMaxsizeBy, useFrequency, useFrequencyInTournament, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file, probPickFirst, earlyStopCondition, stateReturn, use_symbolic_utils, timeout_in_seconds, skip_mutation_failures, enable_autodiff, nested_constraints)
 
     @eval begin
         Base.print(io::IO, tree::Node) = print(io, stringTree(tree, $options))

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -8,8 +8,8 @@ struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
     unaops::B
     diff_binops::dA
     diff_unaops::dB
-    bin_constraints::Array{Tuple{Int,Int}, 1}
-    una_constraints::Array{Int, 1}
+    bin_constraints::Vector{Tuple{Int,Int}}
+    una_constraints::Vector{Int}
     ns::Int
     parsimony::Float32
     alpha::Float32
@@ -56,6 +56,7 @@ struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
     timeout_in_seconds::Union{Float64, Nothing}
     skip_mutation_failures::Bool
     enable_autodiff::Bool
+    nested_constraints::Union{Dict{Function, Dict{Function, Int64}},Nothing}
 
 end
 

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -56,7 +56,7 @@ struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
     timeout_in_seconds::Union{Float64, Nothing}
     skip_mutation_failures::Bool
     enable_autodiff::Bool
-    nested_constraints::Union{Dict{Function, Dict{Function, Int64}},Nothing}
+    nested_constraints::Union{Vector{Tuple{Int,Int,Vector{Tuple{Int,Int,Int}}}},Nothing}
 
 end
 

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -318,20 +318,42 @@ output, flag = evalTreeArray(tree, X, options)
 println("Passed.")
 
 
-println("Test operator nesting.")
+println("Test operator nesting and flagging.")
 import SymbolicRegression
-tree = cos(exp(exp(exp(exp(Node("x1"))))))
 
+# Count max nests:
+tree = cos(exp(exp(exp(exp(Node("x1"))))))
 degree_of_exp = 1
 index_of_exp = findfirst(isequal(exp), options.unaops)
-@test 4 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, Val(degree_of_exp), Val(index_of_exp), options)
+@test 4 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, degree_of_exp, index_of_exp, options)
 
 tree = cos(exp(Node("x1")) + exp(exp(exp(exp(Node("x1"))))))
-@test 4 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, Val(degree_of_exp), Val(index_of_exp), options)
+@test 4 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, degree_of_exp, index_of_exp, options)
 
 degree_of_plus = 2
 index_of_plus = findfirst(isequal(+), options.binops)
 tree = cos(exp(Node("x1")) + exp(exp(Node("x1") + exp(exp(exp(Node("x1")))))))
-@test 2 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, Val(degree_of_plus), Val(index_of_plus), options)
+@test 2 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, degree_of_plus, index_of_plus, options)
+
+
+# Test checking for illegal nests:
+create_options(nested_constraints) = Options(binary_operators = (+, *, /, -), unary_operators = (cos, exp), nested_constraints = nested_constraints)
+
+x1 = Node("x1")
+options = create_options(nothing)
+tree = cos(cos(x1)) + cos(x1) + exp(cos(x1))
+@test !SymbolicRegression.CheckConstraintsModule.flag_illegal_nests(tree, options)
+
+options = create_options([cos => [cos => 0]])
+@test SymbolicRegression.CheckConstraintsModule.flag_illegal_nests(tree, options)
+
+options = create_options([cos => [cos => 1]])
+@test !SymbolicRegression.CheckConstraintsModule.flag_illegal_nests(tree, options)
+
+options = create_options([cos => [exp => 0]])
+@test !SymbolicRegression.CheckConstraintsModule.flag_illegal_nests(tree, options)
+
+options = create_options([exp => [cos => 0]])
+@test SymbolicRegression.CheckConstraintsModule.flag_illegal_nests(tree, options)
 
 println("Passed.")

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -356,4 +356,7 @@ options = create_options([cos => [exp => 0]])
 options = create_options([exp => [cos => 0]])
 @test SymbolicRegression.CheckConstraintsModule.flag_illegal_nests(tree, options)
 
+options = create_options([(+) => [(+) => 0]])
+@test SymbolicRegression.CheckConstraintsModule.flag_illegal_nests(tree, options)
+
 println("Passed.")

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -324,14 +324,14 @@ tree = cos(exp(exp(exp(exp(Node("x1"))))))
 
 degree_of_exp = 1
 index_of_exp = findfirst(isequal(exp), options.unaops)
-@test 4 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, degree_of_exp, index_of_exp, options)
+@test 4 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, Val(degree_of_exp), Val(index_of_exp), options)
 
 tree = cos(exp(Node("x1")) + exp(exp(exp(exp(Node("x1"))))))
-@test 4 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, degree_of_exp, index_of_exp, options)
+@test 4 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, Val(degree_of_exp), Val(index_of_exp), options)
 
 degree_of_plus = 2
 index_of_plus = findfirst(isequal(+), options.binops)
 tree = cos(exp(Node("x1")) + exp(exp(Node("x1") + exp(exp(exp(Node("x1")))))))
-@test 2 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, degree_of_plus, index_of_plus, options)
+@test 2 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, Val(degree_of_plus), Val(index_of_plus), options)
 
 println("Passed.")

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -316,3 +316,22 @@ output, flag = evalTreeArray(tree, X, options)
 @test !flag
 
 println("Passed.")
+
+
+println("Test operator nesting.")
+import SymbolicRegression
+tree = cos(exp(exp(exp(exp(Node("x1"))))))
+
+degree_of_exp = 1
+index_of_exp = findfirst(isequal(exp), options.unaops)
+@test 4 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, degree_of_exp, index_of_exp, options)
+
+tree = cos(exp(Node("x1")) + exp(exp(exp(exp(Node("x1"))))))
+@test 4 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, degree_of_exp, index_of_exp, options)
+
+degree_of_plus = 2
+index_of_plus = findfirst(isequal(+), options.binops)
+tree = cos(exp(Node("x1")) + exp(exp(Node("x1") + exp(exp(exp(Node("x1")))))))
+@test 2 == SymbolicRegression.CheckConstraintsModule.count_max_nestedness(tree, degree_of_plus, index_of_plus, options)
+
+println("Passed.")


### PR DESCRIPTION
This constraint eliminates equations which violate how many times you can nest one operator within another.

Here is an example of its use:
```julia
options = Options(
    ...,
    nested_constraints=[sin => [cos => 0, sin => 0], (+) => [log => 1]]
)
```
This states that within any `sin` operator, you can have *zero* `cos` or `sin` operators. i.e., no nesting these operators. However, since `cos` is not given in the outer array, you can technically have `cos(sin(x))` or `cos(cos(cos(x) + x))`. This also gives a constraint on `+`. This says that inside a `+` operator, you can have `log(x) + log(x) + log(x)`, but you cannot have `log(log(x)) + x`, for example, since this is more than 1 `log` within another `log` inside the `+` operator. 

Here, binary and unary operators are treated the same, and the max nests of an operator in *either* of a binary operator's arguments is used.