### PR TITLE
Apply Blue formatting + change all internal methods to snake_case

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "blue"

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,0 +1,43 @@
+# Taken from https://github.com/julia-actions/julia-format
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1.3.0]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+
+      - uses: actions/checkout@v1
+      - name: Install JuliaFormatter and format
+        # This will use the latest version by default but you can set the version like so:
+        #
+        # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
+        run: |
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
+          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
+      - name: Format check
+        run: |
+          julia -e '
+          out = Cmd(`git diff --name-only`) |> read |> String
+          if out == ""
+              exit(0)
+          else
+              @error "Some files have not been formatted !!!"
+              write(stdout, out)
+              exit(1)
+          end'

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -37,7 +37,7 @@ jobs:
           if out == ""
               exit(0)
           else
-              @error "Some files have not been formatted !!!"
+              @error "Some files have not been formatted. Please run JuliaFormatter.format(\".\") from the repository root."
               write(stdout, out)
               exit(1)
           end'

--- a/.github/workflows/fix-format.yml
+++ b/.github/workflows/fix-format.yml
@@ -1,0 +1,30 @@
+name: format-pr
+# Taken from https://github.com/julia-actions/julia-format
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install JuliaFormatter and format
+        run: |
+          julia  -e 'import Pkg; Pkg.add("JuliaFormatter")'
+          julia  -e 'using JuliaFormatter; format(".")'
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Format .jl files
+          title: 'Automatic JuliaFormatter.jl run'
+          branch: auto-juliaformatter-pr
+          delete-branch: true
+          labels: formatting, automated pr, no changelog
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ y = 2 * cos.(X[4, :]) + X[1, :] .^ 2 .- 2
 options = SymbolicRegression.Options(
     binary_operators=(+, *, /, -),
     unary_operators=(cos, exp),
-    npopulations=20
+    npopulations=40
 )
 
-hallOfFame = EquationSearch(X, y, niterations=5, options=options, numprocs=4)
+hall_of_fame = EquationSearch(X, y, niterations=50, options=options, numprocs=4)
 ```
 We can view the equations in the dominating
 Pareto frontier with:
 ```julia
-dominating = calculateParetoFrontier(X, y, hallOfFame, options)
+dominating = calculate_pareto_frontier(X, y, hall_of_fame, options)
 ```
 We can convert the best equation
 to [SymbolicUtils.jl](https://github.com/JuliaSymbolics/SymbolicUtils.jl)
@@ -60,9 +60,9 @@ We can also print out the full pareto frontier like so:
 println("Complexity\tMSE\tEquation")
 
 for member in dominating
-    size = countNodes(member.tree)
+    size = count_nodes(member.tree)
     loss = member.loss
-    string = stringTree(member.tree, options)
+    string = string_tree(member.tree, options)
 
     println("$(size)\t$(loss)\t$(string)")
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,5 +1,5 @@
 using SymbolicRegression, BenchmarkTools, Random
-using SymbolicRegression: evalTreeArray
+using SymbolicRegression: eval_tree_array
 
 const SUITE = BenchmarkGroup()
 
@@ -23,6 +23,6 @@ _X = randn(MersenneTwister(0), Float32, 5, 1000)
 SUITE["evaluation"] = BenchmarkGroup()
 for T in [Float32, Float64, BigFloat]
     X = map(x -> convert(T, x), _X)
-    f = evalTreeArray
+    f = eval_tree_array
     SUITE["evaluation"][string(T)] = @benchmarkable ($f)(tree, $X, options)
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -3,30 +3,26 @@ using SymbolicRegression: evalTreeArray
 
 const SUITE = BenchmarkGroup()
 
-options = Options(binary_operators=(+, -, /, *),
-                  unary_operators=(cos, exp))
-tree = Node(2,
-    Node(1,
-        Node(3,
-            Node(1, Node(1f0), Node(2)),
-            Node(2, Node(-1f0))
-       ),
-        Node(1, Node(3), Node(4))
+options = Options(; binary_operators=(+, -, /, *), unary_operators=(cos, exp))
+tree = Node(
+    2,
+    Node(
+        1,
+        Node(3, Node(1, Node(1.0f0), Node(2)), Node(2, Node(-1.0f0))),
+        Node(1, Node(3), Node(4)),
     ),
-    Node(4,
-        Node(3,
-            Node(1, Node(1f0), Node(2)),
-            Node(2, Node(-1f0))
-       ),
-        Node(1, Node(3), Node(4))
-    )
+    Node(
+        4,
+        Node(3, Node(1, Node(1.0f0), Node(2)), Node(2, Node(-1.0f0))),
+        Node(1, Node(3), Node(4)),
+    ),
 )
 
 _X = randn(MersenneTwister(0), Float32, 5, 1000)
 
 SUITE["evaluation"] = BenchmarkGroup()
 for T in [Float32, Float64, BigFloat]
-    X = map(x->convert(T, x), _X)
+    X = map(x -> convert(T, x), _X)
     f = evalTreeArray
     SUITE["evaluation"][string(T)] = @benchmarkable ($f)(tree, $X, options)
 end

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -2,14 +2,19 @@ using PkgBenchmark
 using DataFrames
 using CSV
 using Statistics: median
-import SymbolicRegression
-config = BenchmarkConfig(;juliacmd=`julia -O3`,
-                          env=Dict("JULIA_NUM_THREADS" => 4))
+using SymbolicRegression: SymbolicRegression
+config = BenchmarkConfig(; juliacmd=`julia -O3`, env=Dict("JULIA_NUM_THREADS" => 4))
 _results = benchmarkpkg(SymbolicRegression, config; script="benchmark/.benchmarks.jl")
-results = vcat([[["evaluation_"*k, median(v.times)] for (k, v) in bigV]
-      for (bigK, bigV) in _results.benchmarkgroup.data]...)
-df = DataFrame(commit=_results.commit,
-               name=[results[i][1] for i=1:length(results)],
-               time=[results[i][2] for i=1:length(results)])
+results = vcat(
+    [
+        [["evaluation_" * k, median(v.times)] for (k, v) in bigV] for
+        (bigK, bigV) in _results.benchmarkgroup.data
+    ]...,
+)
+df = DataFrame(;
+    commit=_results.commit,
+    name=[results[i][1] for i in 1:length(results)],
+    time=[results[i][2] for i in 1:length(results)],
+)
 
 CSV.write("output.csv", df; append=true)

--- a/benchmark/single_eval.jl
+++ b/benchmark/single_eval.jl
@@ -22,7 +22,7 @@ tree = (
 )
 
 function testfunc()
-    out = evalTreeArray(tree, X, options)
+    out = eval_tree_array(tree, X, options)
     return nothing
 end
 @btime testfunc()

--- a/benchmark/single_eval.jl
+++ b/benchmark/single_eval.jl
@@ -3,14 +3,23 @@ using SymbolicRegression
 
 nfeatures = 3
 X = randn(nfeatures, 200)
-options = Options(binary_operators=(+, *, /, -), unary_operators=(cos, sin))
+options = Options(; binary_operators=(+, *, /, -), unary_operators=(cos, sin))
 
 x1 = Node("x1")
 x2 = Node("x2")
 x3 = Node("x3")
 
 # 48 nodes in this tree:
-tree = (((x2 + x2) * ((-0.5982493 / x1) / -0.54734415)) + (sin(cos(sin(1.2926733 - 1.6606787) / sin(((0.14577048 * x1) + ((0.111149654 + x1) - -0.8298334)) - -1.2071426)) * (cos(x3 - 2.3201916) + ((x1 - (x1 * x2)) / x2))) / (0.14854191 - ((cos(x2) * -1.6047639) - 0.023943262))))
+tree = (
+    ((x2 + x2) * ((-0.5982493 / x1) / -0.54734415)) + (
+        sin(
+            cos(
+                sin(1.2926733 - 1.6606787) /
+                sin(((0.14577048 * x1) + ((0.111149654 + x1) - -0.8298334)) - -1.2071426),
+            ) * (cos(x3 - 2.3201916) + ((x1 - (x1 * x2)) / x2)),
+        ) / (0.14854191 - ((cos(x2) * -1.6047639) - 0.023943262))
+    )
+)
 
 function testfunc()
     out = evalTreeArray(tree, X, options)

--- a/coverage.jl
+++ b/coverage.jl
@@ -5,11 +5,15 @@ coverage = process_folder() # defaults to src/; alternatively, supply the folder
 LCOV.writefile("coverage-lcov.info", coverage)
 
 # process '*.info' files
-coverage = merge_coverage_counts(coverage, filter!(
-    let prefixes = (joinpath(pwd(), "src", ""),)
-        c -> any(p -> startswith(c.filename, p), prefixes)
-    end,
-    LCOV.readfolder("test")))
+coverage = merge_coverage_counts(
+    coverage,
+    filter!(
+        let prefixes = (joinpath(pwd(), "src", ""),)
+            c -> any(p -> startswith(c.filename, p), prefixes)
+        end,
+        LCOV.readfolder("test"),
+    ),
+)
 # Get total coverage for all Julia files
 covered_lines, total_lines = get_summary(coverage)
 @show covered_lines, total_lines

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,13 @@
 using Documenter, SymbolicRegression
 using SymbolicRegression:
-    Node, PopMember, Population, eval_tree_array, Dataset, HallOfFame, CONST_TYPE, string_tree
+    Node,
+    PopMember,
+    Population,
+    eval_tree_array,
+    Dataset,
+    HallOfFame,
+    CONST_TYPE,
+    string_tree
 
 makedocs(;
     sitename="SymbolicRegression.jl",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Documenter, SymbolicRegression
 using SymbolicRegression:
-    Node, PopMember, Population, evalTreeArray, Dataset, HallOfFame, CONST_TYPE, stringTree
+    Node, PopMember, Population, eval_tree_array, Dataset, HallOfFame, CONST_TYPE, string_tree
 
 makedocs(;
     sitename="SymbolicRegression.jl",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,10 +1,15 @@
 using Documenter, SymbolicRegression
-using SymbolicRegression: Node, PopMember, Population, evalTreeArray, Dataset, HallOfFame, CONST_TYPE, stringTree
+using SymbolicRegression:
+    Node, PopMember, Population, evalTreeArray, Dataset, HallOfFame, CONST_TYPE, stringTree
 
-makedocs(sitename="SymbolicRegression.jl",
-         authors="Miles Cranmer",
-         doctest=false, clean=true,
-         format=Documenter.HTML(canonical="https://astroautomata.com/SymbolicRegression.jl/stable")
-         )
+makedocs(;
+    sitename="SymbolicRegression.jl",
+    authors="Miles Cranmer",
+    doctest=false,
+    clean=true,
+    format=Documenter.HTML(;
+        canonical="https://astroautomata.com/SymbolicRegression.jl/stable"
+    ),
+)
 
-deploydocs(repo="github.com/MilesCranmer/SymbolicRegression.jl.git")
+deploydocs(; repo="github.com/MilesCranmer/SymbolicRegression.jl.git")

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -54,11 +54,11 @@ Options(;
 ## Printing and Evaluation
 
 ```@docs
-stringTree(tree::Node, options::Options)
+string_tree(tree::Node, options::Options)
 ```
 
 ```@docs
-evalTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options) where {T<:Real}
+eval_tree_array(tree::Node, cX::AbstractMatrix{T}, options::Options) where {T<:Real}
 ```
 
 ## SymbolicUtils.jl interface
@@ -73,9 +73,9 @@ node_to_symbolic(tree::Node, options::Options;
 
 
 ```@docs
-calculateParetoFrontier(X::AbstractMatrix{T}, y::AbstractVector{T},
+calculate_pareto_frontier(X::AbstractMatrix{T}, y::AbstractVector{T},
                         hallOfFame::HallOfFame, options::Options;
                         weights=nothing, varMap=nothing) where {T<:Real}
-calculateParetoFrontier(dataset::Dataset{T}, hallOfFame::HallOfFame,
+calculate_pareto_frontier(dataset::Dataset{T}, hallOfFame::HallOfFame,
                         options::Options) where {T<:Real}
 ```

--- a/example.jl
+++ b/example.jl
@@ -3,11 +3,10 @@ using SymbolicRegression
 X = randn(Float32, 5, 100)
 y = 2 * cos.(X[4, :]) + X[1, :] .^ 2 .- 2
 
-options = SymbolicRegression.Options(
-    binary_operators = (+, *, /, -),
-    unary_operators = (cos, exp),
-    npopulations = 8
+options = SymbolicRegression.Options(;
+    binary_operators=(+, *, /, -), unary_operators=(cos, exp), npopulations=8
 )
 
 hallOfFame = EquationSearch(
-    X, y, niterations = 5, options = options, numprocs = 0, multithreading = true)
+    X, y; niterations=5, options=options, numprocs=0, multithreading=true
+)

--- a/example.jl
+++ b/example.jl
@@ -1,12 +1,25 @@
-using SymbolicRegression
+using SymbolicRegression, SymbolicUtils
 
 X = randn(Float32, 5, 100)
 y = 2 * cos.(X[4, :]) + X[1, :] .^ 2 .- 2
 
 options = SymbolicRegression.Options(;
-    binary_operators=(+, *, /, -), unary_operators=(cos, exp), npopulations=8
+    binary_operators=(+, *, /, -), unary_operators=(cos, exp), npopulations=40
 )
 
-hallOfFame = EquationSearch(
-    X, y; niterations=5, options=options, numprocs=0, multithreading=true
-)
+hall_of_fame = EquationSearch(X, y; niterations=50, options=options, numprocs=4)
+
+dominating = calculate_pareto_frontier(X, y, hall_of_fame, options)
+
+eqn = node_to_symbolic(dominating[end].tree, options)
+println(simplify(eqn * 5 + 3))
+
+println("Complexity\tMSE\tEquation")
+
+for member in dominating
+    size = count_nodes(member.tree)
+    loss = member.loss
+    string = string_tree(member.tree, options)
+
+    println("$(size)\t$(loss)\t$(string)")
+end

--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -4,7 +4,9 @@ import ..CoreModule: Node, Options
 import ..EquationUtilsModule: count_nodes
 
 # Check if any binary operator are overly complex
-function flag_bin_operator_complexity(tree::Node, ::Val{op}, options::Options)::Bool where {op}
+function flag_bin_operator_complexity(
+    tree::Node, ::Val{op}, options::Options
+)::Bool where {op}
     if tree.degree == 0
         return false
     elseif tree.degree == 1
@@ -32,7 +34,9 @@ function flag_bin_operator_complexity(tree::Node, ::Val{op}, options::Options)::
 end
 
 # Check if any unary operators are overly complex
-function flag_una_operator_complexity(tree::Node, ::Val{op}, options::Options)::Bool where {op}
+function flag_una_operator_complexity(
+    tree::Node, ::Val{op}, options::Options
+)::Bool where {op}
     if tree.degree == 0
         return false
     elseif tree.degree == 1

--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -1,23 +1,23 @@
 module CheckConstraintsModule
 
 import ..CoreModule: Node, Options
-import ..EquationUtilsModule: countNodes
+import ..EquationUtilsModule: count_nodes
 
 # Check if any binary operator are overly complex
-function flagBinOperatorComplexity(tree::Node, ::Val{op}, options::Options)::Bool where {op}
+function flag_bin_operator_complexity(tree::Node, ::Val{op}, options::Options)::Bool where {op}
     if tree.degree == 0
         return false
     elseif tree.degree == 1
-        return flagBinOperatorComplexity(tree.l, Val(op), options)
+        return flag_bin_operator_complexity(tree.l, Val(op), options)
     else
         if tree.op == op
             overly_complex::Bool = (
                 (
                     (options.bin_constraints[op][1]::Int > -1) &&
-                    (countNodes(tree.l) > options.bin_constraints[op][1]::Int)
+                    (count_nodes(tree.l) > options.bin_constraints[op][1]::Int)
                 ) || (
                     (options.bin_constraints[op][2]::Int > -1) &&
-                    (countNodes(tree.r) > options.bin_constraints[op][2]::Int)
+                    (count_nodes(tree.r) > options.bin_constraints[op][2]::Int)
                 )
             )
             if overly_complex
@@ -25,31 +25,31 @@ function flagBinOperatorComplexity(tree::Node, ::Val{op}, options::Options)::Boo
             end
         end
         return (
-            flagBinOperatorComplexity(tree.l, Val(op), options) ||
-            flagBinOperatorComplexity(tree.r, Val(op), options)
+            flag_bin_operator_complexity(tree.l, Val(op), options) ||
+            flag_bin_operator_complexity(tree.r, Val(op), options)
         )
     end
 end
 
 # Check if any unary operators are overly complex
-function flagUnaOperatorComplexity(tree::Node, ::Val{op}, options::Options)::Bool where {op}
+function flag_una_operator_complexity(tree::Node, ::Val{op}, options::Options)::Bool where {op}
     if tree.degree == 0
         return false
     elseif tree.degree == 1
         if tree.op == op
             overly_complex::Bool = (
                 (options.una_constraints[op]::Int > -1) &&
-                (countNodes(tree.l) > options.una_constraints[op]::Int)
+                (count_nodes(tree.l) > options.una_constraints[op]::Int)
             )
             if overly_complex
                 return true
             end
         end
-        return flagUnaOperatorComplexity(tree.l, Val(op), options)
+        return flag_una_operator_complexity(tree.l, Val(op), options)
     else
         return (
-            flagUnaOperatorComplexity(tree.l, Val(op), options) ||
-            flagUnaOperatorComplexity(tree.r, Val(op), options)
+            flag_una_operator_complexity(tree.l, Val(op), options) ||
+            flag_una_operator_complexity(tree.r, Val(op), options)
         )
     end
 end
@@ -130,20 +130,20 @@ end
 
 """Check if user-passed constraints are violated or not"""
 function check_constraints(tree::Node, options::Options, maxsize::Int)::Bool
-    if countNodes(tree) > maxsize
+    if count_nodes(tree) > maxsize
         return false
     end
     for i in 1:(options.nbin)
         if options.bin_constraints[i] == (-1, -1)
             continue
-        elseif flagBinOperatorComplexity(tree, Val(i), options)
+        elseif flag_bin_operator_complexity(tree, Val(i), options)
             return false
         end
     end
     for i in 1:(options.nuna)
         if options.una_constraints[i] == -1
             continue
-        elseif flagUnaOperatorComplexity(tree, Val(i), options)
+        elseif flag_una_operator_complexity(tree, Val(i), options)
             return false
         end
     end

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -1,7 +1,7 @@
 import ..CoreModule: RecordType
 
 # Check for errors before they happen
-function testOptionConfiguration(T, options::Options)
+function test_option_configuration(T, options::Options)
     for op in (options.binops..., options.unaops...)
         if is_anonymous_function(op)
             throw(
@@ -47,7 +47,7 @@ function testOptionConfiguration(T, options::Options)
 end
 
 # Check for errors before they happen
-function testDatasetConfiguration(dataset::Dataset{T}, options::Options) where {T<:Real}
+function test_dataset_configuration(dataset::Dataset{T}, options::Options) where {T<:Real}
     n = dataset.n
     if n != size(dataset.X, 2) || n != size(dataset.y, 1)
         throw(
@@ -201,7 +201,7 @@ function test_module_on_workers(procs, options::Options)
     )
     futures = []
     for proc in procs
-        push!(futures, @spawnat proc SymbolicRegression.genRandomTree(3, options, 5))
+        push!(futures, @spawnat proc SymbolicRegression.gen_random_tree(3, options, 5))
     end
     for future in futures
         fetch(future)
@@ -226,7 +226,7 @@ function test_entire_pipeline(procs, dataset::Dataset{T}, options::Options) wher
                     options=options,
                     nfeatures=dataset.nfeatures,
                 )
-                tmp_pop = SRCycle(
+                tmp_pop = s_r_cycle(
                     dataset,
                     convert(T, 1),
                     tmp_pop,
@@ -237,7 +237,7 @@ function test_entire_pipeline(procs, dataset::Dataset{T}, options::Options) wher
                     options=options,
                     record=RecordType(),
                 )[1]
-                tmp_pop = OptimizeAndSimplifyPopulation(
+                tmp_pop = optimize_and_simplify_population(
                     dataset, T(1.0), tmp_pop, options, options.maxsize, RecordType()
                 )
             end

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -2,35 +2,46 @@ import ..CoreModule: RecordType
 
 # Check for errors before they happen
 function testOptionConfiguration(T, options::Options)
-    
     for op in (options.binops..., options.unaops...)
-		if is_anonymous_function(op)
-			throw(AssertionError("Anonymous functions can't be used as operators for SymbolicRegression.jl"))
+        if is_anonymous_function(op)
+            throw(
+                AssertionError(
+                    "Anonymous functions can't be used as operators for SymbolicRegression.jl",
+                ),
+            )
         end
     end
 
-	test_input = map(x->convert(T, x), LinRange(-100, 100, 99))
-	cur_op = nothing
+    test_input = map(x -> convert(T, x), LinRange(-100, 100, 99))
+    cur_op = nothing
     try
         for left in test_input
             for right in test_input
                 for binop in options.binops
-					cur_op = binop
+                    cur_op = binop
                     test_output = binop.(left, right)
                 end
             end
             for unaop in options.unaops
-				cur_op = unaop
+                cur_op = unaop
                 test_output = unaop.(left)
             end
         end
     catch error
-        throw(AssertionError("Your configuration is invalid - one of your operators ($cur_op) is not well-defined over the real line."))
+        throw(
+            AssertionError(
+                "Your configuration is invalid - one of your operators ($cur_op) is not well-defined over the real line.",
+            ),
+        )
     end
 
     for binop in options.binops
         if binop in options.unaops
-            throw(AssertionError("Your configuration is invalid - one operator ($binop) appears in both the binary operators and unary operators."))
+            throw(
+                AssertionError(
+                    "Your configuration is invalid - one operator ($binop) appears in both the binary operators and unary operators.",
+                ),
+            )
         end
     end
 end
@@ -39,19 +50,30 @@ end
 function testDatasetConfiguration(dataset::Dataset{T}, options::Options) where {T<:Real}
     n = dataset.n
     if n != size(dataset.X, 2) || n != size(dataset.y, 1)
-        throw(AssertionError("Dataset dimensions are invalid. Make sure X is of shape [features, rows], y is of shape [rows] and if there are weights, they are of shape [rows]."))
+        throw(
+            AssertionError(
+                "Dataset dimensions are invalid. Make sure X is of shape [features, rows], y is of shape [rows] and if there are weights, they are of shape [rows].",
+            ),
+        )
     end
 
     if size(dataset.X, 2) > 10000
         if !options.batching
-            debug((options.verbosity > 0 || options.progress), "Note: you are running with more than 10,000 datapoints. You should consider turning on batching (`options.batching`), and also if you need that many datapoints. Unless you have a large amount of noise (in which case you should smooth your dataset first), generally < 10,000 datapoints is enough to find a functional form.")
+            debug(
+                (options.verbosity > 0 || options.progress),
+                "Note: you are running with more than 10,000 datapoints. You should consider turning on batching (`options.batching`), and also if you need that many datapoints. Unless you have a large amount of noise (in which case you should smooth your dataset first), generally < 10,000 datapoints is enough to find a functional form.",
+            )
         end
     end
 
     if !(typeof(options.loss) <: SupervisedLoss)
         if dataset.weighted
             if !(3 in [m.nargs - 1 for m in methods(options.loss)])
-                throw(AssertionError("When you create a custom loss function, and are using weights, you need to define your loss function with three scalar arguments: f(prediction, target, weight)."))
+                throw(
+                    AssertionError(
+                        "When you create a custom loss function, and are using weights, you need to define your loss function with three scalar arguments: f(prediction, target, weight).",
+                    ),
+                )
             end
         end
     end
@@ -59,7 +81,7 @@ end
 
 """ Move custom operators and loss functions to workers, if undefined """
 function move_functions_to_workers(procs, options::Options, dataset::Dataset{T}) where {T}
-    for function_set=1:5
+    for function_set in 1:5
         if function_set == 1
             ops = options.unaops
             nargs = 1
@@ -103,28 +125,28 @@ end
 
 function copy_definition_to_workers(op, procs, options::Options)
     name = nameof(op)
-    debug_inline((options.verbosity > 0 || options.progress), "Copying definition of $op to workers...")
+    debug_inline(
+        (options.verbosity > 0 || options.progress),
+        "Copying definition of $op to workers...",
+    )
     src_ms = methods(op).ms
     # Thanks https://discourse.julialang.org/t/easy-way-to-send-custom-function-to-distributed-workers/22118/2
     @everywhere procs @eval function $name end
     for m in src_ms
         @everywhere procs @eval $m
     end
-    debug((options.verbosity > 0 || options.progress), "Finished!")
+    return debug((options.verbosity > 0 || options.progress), "Finished!")
 end
 
 function test_function_on_workers(T, nargs, op, procs)
     futures = []
     for proc in procs
         if nargs == 1
-            push!(futures,
-                  @spawnat proc op(convert(T, 0)))
+            push!(futures, @spawnat proc op(convert(T, 0)))
         elseif nargs == 2 #2D ops, and loss function
-            push!(futures,
-                  @spawnat proc op(convert(T, 0), convert(T, 0)))
+            push!(futures, @spawnat proc op(convert(T, 0), convert(T, 0)))
         elseif nargs == 3 #weighted loss function
-            push!(futures,
-                  @spawnat proc op(convert(T, 0), convert(T, 0), convert(T, 0)))
+            push!(futures, @spawnat proc op(convert(T, 0), convert(T, 0), convert(T, 0)))
         end
     end
     for future in futures
@@ -135,27 +157,37 @@ end
 function activate_env_on_workers(procs, project_path::String, options::Options)
     debug((options.verbosity > 0 || options.progress), "Activating environment on workers.")
     @everywhere procs begin
-        Base.MainInclude.eval(quote
-            using Pkg
-            Pkg.activate($$project_path)
-        end)
+        Base.MainInclude.eval(
+            quote
+                using Pkg
+                Pkg.activate($$project_path)
+            end,
+        )
     end
 end
 
 function import_module_on_workers(procs, filename::String, options::Options)
     included_local = !("SymbolicRegression" in [k.name for (k, v) in Base.loaded_modules])
     if included_local
-        debug_inline((options.verbosity > 0 || options.progress), "Importing local module ($filename) on workers...")
+        debug_inline(
+            (options.verbosity > 0 || options.progress),
+            "Importing local module ($filename) on workers...",
+        )
         @everywhere procs begin
             # Parse functions on every worker node
-            Base.MainInclude.eval(quote
-                include($$filename)
-                using .SymbolicRegression
-            end)
+            Base.MainInclude.eval(
+                quote
+                    include($$filename)
+                    using .SymbolicRegression
+                end,
+            )
         end
         debug((options.verbosity > 0 || options.progress), "Finished!")
     else
-        debug_inline((options.verbosity > 0 || options.progress), "Importing installed module on workers...")
+        debug_inline(
+            (options.verbosity > 0 || options.progress),
+            "Importing installed module on workers...",
+        )
         @everywhere procs begin
             Base.MainInclude.eval(using SymbolicRegression)
         end
@@ -164,30 +196,55 @@ function import_module_on_workers(procs, filename::String, options::Options)
 end
 
 function test_module_on_workers(procs, options::Options)
-    debug_inline((options.verbosity > 0 || options.progress), "Testing module on workers...")
+    debug_inline(
+        (options.verbosity > 0 || options.progress), "Testing module on workers..."
+    )
     futures = []
     for proc in procs
-        push!(futures,
-              @spawnat proc SymbolicRegression.genRandomTree(3, options, 5))
+        push!(futures, @spawnat proc SymbolicRegression.genRandomTree(3, options, 5))
     end
     for future in futures
         fetch(future)
     end
-    debug((options.verbosity > 0 || options.progress), "Finished!")
+    return debug((options.verbosity > 0 || options.progress), "Finished!")
 end
 
 function test_entire_pipeline(procs, dataset::Dataset{T}, options::Options) where {T<:Real}
     futures = []
-    debug_inline((options.verbosity > 0 || options.progress), "Testing entire pipeline on workers...")
+    debug_inline(
+        (options.verbosity > 0 || options.progress), "Testing entire pipeline on workers..."
+    )
     for proc in procs
-        push!(futures, @spawnat proc begin
-            tmp_pop = Population(dataset, convert(T, 1), npop=20, nlength=3, options=options, nfeatures=dataset.nfeatures)
-            tmp_pop = SRCycle(dataset, convert(T, 1), tmp_pop, 5, 5, ones(T, options.maxsize), verbosity=options.verbosity, options=options, record=RecordType())[1]
-            tmp_pop = OptimizeAndSimplifyPopulation(dataset, T(1.0), tmp_pop, options, options.maxsize, RecordType())
-        end)
+        push!(
+            futures,
+            @spawnat proc begin
+                tmp_pop = Population(
+                    dataset,
+                    convert(T, 1);
+                    npop=20,
+                    nlength=3,
+                    options=options,
+                    nfeatures=dataset.nfeatures,
+                )
+                tmp_pop = SRCycle(
+                    dataset,
+                    convert(T, 1),
+                    tmp_pop,
+                    5,
+                    5,
+                    ones(T, options.maxsize);
+                    verbosity=options.verbosity,
+                    options=options,
+                    record=RecordType(),
+                )[1]
+                tmp_pop = OptimizeAndSimplifyPopulation(
+                    dataset, T(1.0), tmp_pop, options, options.maxsize, RecordType()
+                )
+            end
+        )
     end
     for future in futures
         fetch(future)
     end
-    debug((options.verbosity > 0 || options.progress), "Finished!")
+    return debug((options.verbosity > 0 || options.progress), "Finished!")
 end

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -7,11 +7,43 @@ include("Equation.jl")
 include("Operators.jl")
 include("Options.jl")
 
-import .ProgramConstantsModule: CONST_TYPE, MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType, SRConcurrency, SRSerial, SRThreaded, SRDistributed
+import .ProgramConstantsModule:
+    CONST_TYPE,
+    MAX_DEGREE,
+    BATCH_DIM,
+    FEATURE_DIM,
+    RecordType,
+    SRConcurrency,
+    SRSerial,
+    SRThreaded,
+    SRDistributed
 import .DatasetModule: Dataset
 import .OptionsStructModule: Options
 import .EquationModule: Node, copyNode, stringTree, printTree
 import .OptionsModule: Options
-import .OperatorsModule: plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip
+import .OperatorsModule:
+    plus,
+    sub,
+    mult,
+    square,
+    cube,
+    pow,
+    div,
+    log_abs,
+    log2_abs,
+    log10_abs,
+    log1p_abs,
+    sqrt_abs,
+    acosh_abs,
+    neg,
+    greater,
+    greater,
+    relu,
+    logical_or,
+    logical_and,
+    gamma,
+    erf,
+    erfc,
+    atanh_clip
 
 end

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -19,7 +19,7 @@ import .ProgramConstantsModule:
     SRDistributed
 import .DatasetModule: Dataset
 import .OptionsStructModule: Options
-import .EquationModule: Node, copyNode, stringTree, printTree
+import .EquationModule: Node, copy_node, string_tree, print_tree
 import .OptionsModule: Options
 import .OperatorsModule:
     plus,

--- a/src/Dataset.jl
+++ b/src/Dataset.jl
@@ -3,15 +3,13 @@ module DatasetModule
 import ..ProgramConstantsModule: BATCH_DIM, FEATURE_DIM
 
 struct Dataset{T<:Real}
-
     X::AbstractMatrix{T}
     y::AbstractVector{T}
     n::Int
     nfeatures::Int
     weighted::Bool
-    weights::Union{AbstractVector{T}, Nothing}
-    varMap::Array{String, 1}
-
+    weights::Union{AbstractVector{T},Nothing}
+    varMap::Array{String,1}
 end
 
 """
@@ -22,22 +20,19 @@ end
 Construct a dataset to pass between internal functions.
 """
 function Dataset(
-        X::AbstractMatrix{T},
-        y::AbstractVector{T};
-        weights::Union{AbstractVector{T}, Nothing}=nothing,
-        varMap::Union{Array{String, 1}, Nothing}=nothing
-       ) where {T<:Real}
-
+    X::AbstractMatrix{T},
+    y::AbstractVector{T};
+    weights::Union{AbstractVector{T},Nothing}=nothing,
+    varMap::Union{Array{String,1},Nothing}=nothing,
+) where {T<:Real}
     n = size(X, BATCH_DIM)
     nfeatures = size(X, FEATURE_DIM)
     weighted = weights !== nothing
     if varMap === nothing
-        varMap = ["x$(i)" for i=1:nfeatures]
+        varMap = ["x$(i)" for i in 1:nfeatures]
     end
 
     return Dataset{T}(X, y, n, nfeatures, weighted, weights, varMap)
-
 end
-
 
 end

--- a/src/Deprecates.jl
+++ b/src/Deprecates.jl
@@ -1,9 +1,60 @@
-# Will be included explicitly
 using Base: @deprecate
 
-# Now the batch dimension is the last axis!
-@deprecate RunSR(X, y; kw...) EquationSearch(copy(transpose(X)), y; kw...)
-@deprecate sqrtm(x) sqrt_abs(x)
-@deprecate logm(x) log_abs(x)
-@deprecate logm2(x) log2_abs(x)
-@deprecate logm10(x) log10_abs(x)
+
+@deprecate EvalLoss eval_loss
+@deprecate Loss loss
+@deprecate OptimizeAndSimplifyPopulation optimize_and_simplify_population
+@deprecate SRCycle s_r_cycle
+@deprecate _evalDiffTreeArray _eval_diff_tree_array
+@deprecate _evalGradTreeArray _eval_grad_tree_array
+@deprecate _evalTreeArray _eval_tree_array
+@deprecate appendRandomOp append_random_op
+@deprecate bestOfSample best_of_sample
+@deprecate bestSubPop best_sub_pop
+@deprecate calculateParetoFrontier calculate_pareto_frontier
+@deprecate combineOperators combine_operators
+@deprecate copyNode copy_node
+@deprecate copyPopMember copy_pop_member
+@deprecate countBinaryOperators count_binary_operators
+@deprecate countConstants count_constants
+@deprecate countDepth count_depth
+@deprecate countNodes count_nodes
+@deprecate countOperators count_operators
+@deprecate countUnaryOperators count_unary_operators
+@deprecate crossoverGeneration crossover_generation
+@deprecate crossoverTrees crossover_trees
+@deprecate deleteRandomOp delete_random_op
+@deprecate differentiableEvalTreeArray differentiable_eval_tree_array
+@deprecate evalDiffTreeArray eval_diff_tree_array
+@deprecate evalGradTreeArray eval_grad_tree_array
+@deprecate evalTreeArray eval_tree_array
+@deprecate finalizeScores finalize_scores
+@deprecate flagBinOperatorComplexity flag_bin_operator_complexity
+@deprecate flagUnaOperatorComplexity flag_una_operator_complexity
+@deprecate genRandomTree gen_random_tree
+@deprecate genRandomTreeFixedSize gen_random_tree_fixed_size
+@deprecate getConstants get_constants
+@deprecate getTime get_time
+@deprecate indexConstants index_constants
+@deprecate insertRandomOp insert_random_op
+@deprecate lossToScore loss_to_score
+@deprecate makeRandomLeaf make_random_leaf
+@deprecate mutateConstant mutate_constant
+@deprecate mutateOperator mutate_operator
+@deprecate nextGeneration next_generation
+@deprecate optFunc opt_func
+@deprecate optimizeConstants optimize_constants
+@deprecate prependRandomOp prepend_random_op
+@deprecate printTree print_tree
+@deprecate randomNode random_node
+@deprecate randomNodeAndParent random_node_and_parent
+@deprecate regEvolCycle reg_evol_cycle
+@deprecate samplePop sample_pop
+@deprecate scoreFunc score_func
+@deprecate scoreFuncBatch score_func_batch
+@deprecate setConstants set_constants
+@deprecate simplifyTree simplify_tree
+@deprecate stringOp string_op
+@deprecate stringTree string_tree
+@deprecate testDatasetConfiguration test_dataset_configuration
+@deprecate testOptionConfiguration test_option_configuration

--- a/src/Deprecates.jl
+++ b/src/Deprecates.jl
@@ -1,6 +1,5 @@
 using Base: @deprecate
 
-
 @deprecate EvalLoss eval_loss
 @deprecate Loss loss
 @deprecate OptimizeAndSimplifyPopulation optimize_and_simplify_population

--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -18,101 +18,118 @@ mutable struct Node
     Node(d::Int, c::Bool, v::CONST_TYPE) = new(d, c, v)
     Node(d::Int, c::Bool, v::CONST_TYPE, f::Int) = new(d, c, v, f)
     Node(d::Int, c::Bool, v::CONST_TYPE, f::Int, o::Int, l::Node) = new(d, c, v, f, o, l)
-    Node(d::Int, c::Bool, v::CONST_TYPE, f::Int, o::Int, l::Node, r::Node) = new(d, c, v, f, o, l, r)
+    function Node(d::Int, c::Bool, v::CONST_TYPE, f::Int, o::Int, l::Node, r::Node)
+        return new(d, c, v, f, o, l, r)
+    end
 end
 
-Node(val::CONST_TYPE) =                                                     Node(0, true,                       val                                     ) #Leave other values undefined
+Node(val::CONST_TYPE) = Node(0, true, val) #Leave other values undefined
 """
     Node(feature::Int)
 
 Create a variable node using feature `feature::Int`
 """
-Node(feature::Int) =                                                        Node(0, false, convert(CONST_TYPE, 0f0), feature                            )
+Node(feature::Int) = Node(0, false, convert(CONST_TYPE, 0.0f0), feature)
 """
     Node(op::Int, l::Node)
 
 Apply unary operator `op` (enumerating over the order given) to `Node` `l`
 """
-Node(op::Int, l::Node) =                                                    Node(1, false, convert(CONST_TYPE, 0f0),       0,      op,        l         )
+Node(op::Int, l::Node) = Node(1, false, convert(CONST_TYPE, 0.0f0), 0, op, l)
 """
     Node(op::Int, l::Union{AbstractFloat, Int})
 
 Short-form for creating a scalar/variable node, and applying a unary operator
 """
-Node(op::Int, l::Union{AbstractFloat, Int}) =                               Node(1, false, convert(CONST_TYPE, 0f0),       0,      op,  Node(l)         )
+function Node(op::Int, l::Union{AbstractFloat,Int})
+    return Node(1, false, convert(CONST_TYPE, 0.0f0), 0, op, Node(l))
+end
 """
     Node(op::Int, l::Node, r::Node)
 
 Apply binary operator `op` (enumerating over the order given) to `Node`s `l` and `r`
 """
-Node(op::Int, l::Node, r::Node) =                                           Node(2, false, convert(CONST_TYPE, 0f0),       0,      op,        l,       r)
+Node(op::Int, l::Node, r::Node) = Node(2, false, convert(CONST_TYPE, 0.0f0), 0, op, l, r)
 """
     Node(op::Int, l::Union{AbstractFloat, Int}, r::Node)
 
 Short-form to create a scalar/variable node, and apply a binary operator
 """
-Node(op::Int, l::Union{AbstractFloat, Int}, r::Node) =                      Node(2, false, convert(CONST_TYPE, 0f0),       0,      op,  Node(l),       r)
+function Node(op::Int, l::Union{AbstractFloat,Int}, r::Node)
+    return Node(2, false, convert(CONST_TYPE, 0.0f0), 0, op, Node(l), r)
+end
 """
     Node(op::Int, l::Node, r::Union{AbstractFloat, Int})
 
 Short-form to create a scalar/variable node, and apply a binary operator
 """
-Node(op::Int, l::Node, r::Union{AbstractFloat, Int}) =                      Node(2, false, convert(CONST_TYPE, 0f0),       0,      op,        l, Node(r))
+function Node(op::Int, l::Node, r::Union{AbstractFloat,Int})
+    return Node(2, false, convert(CONST_TYPE, 0.0f0), 0, op, l, Node(r))
+end
 """
     Node(op::Int, l::Union{AbstractFloat, Int}, r::Union{AbstractFloat, Int})
 
 Short-form for creating two scalar/variable node, and applying a binary operator
 """
-Node(op::Int, l::Union{AbstractFloat, Int}, r::Union{AbstractFloat, Int}) = Node(2, false, convert(CONST_TYPE, 0f0),       0,      op,  Node(l), Node(r))
+function Node(op::Int, l::Union{AbstractFloat,Int}, r::Union{AbstractFloat,Int})
+    return Node(2, false, convert(CONST_TYPE, 0.0f0), 0, op, Node(l), Node(r))
+end
 """
     Node(val::AbstractFloat)
 
 Create a scalar constant node
 """
-Node(val::AbstractFloat) =                                                  Node(convert(CONST_TYPE, val))
+Node(val::AbstractFloat) = Node(convert(CONST_TYPE, val))
 """
     Node(var_string::String)
 
 Create a variable node, using the format `"x1"` to mean feature 1
 """
-Node(var_string::String) =                                                  Node(parse(Int, var_string[2:end]))
+Node(var_string::String) = Node(parse(Int, var_string[2:end]))
 """
     Node(var_string::String, varMap::Array{String, 1})
 
 Create a variable node, using a user-passed format
 """
-Node(var_string::String, varMap::Array{String, 1}) =                        Node([i for (i, _variable) in enumerate(varMap) if _variable==var_string][1]::Int)
-
+function Node(var_string::String, varMap::Array{String,1})
+    return Node(
+        [i for (i, _variable) in enumerate(varMap) if _variable == var_string][1]::Int
+    )
+end
 
 # Copy an equation (faster than deepcopy)
 function copyNode(tree::Node)::Node
-   if tree.degree == 0
-       if tree.constant
-           return Node(copy(tree.val))
+    if tree.degree == 0
+        if tree.constant
+            return Node(copy(tree.val))
         else
-           return Node(copy(tree.feature))
+            return Node(copy(tree.feature))
         end
-   elseif tree.degree == 1
-       return Node(copy(tree.op), copyNode(tree.l))
+    elseif tree.degree == 1
+        return Node(copy(tree.op), copyNode(tree.l))
     else
         return Node(copy(tree.op), copyNode(tree.l), copyNode(tree.r))
-   end
+    end
 end
 
-function stringOp(op::F, tree::Node, options::Options;
-                  bracketed::Bool=false,
-                  varMap::Union{Array{String, 1}, Nothing}=nothing)::String where {F}
+function stringOp(
+    op::F,
+    tree::Node,
+    options::Options;
+    bracketed::Bool=false,
+    varMap::Union{Array{String,1},Nothing}=nothing,
+)::String where {F}
     if op in [+, -, *, /, ^]
-        l = stringTree(tree.l, options, bracketed=false, varMap=varMap)
-        r = stringTree(tree.r, options, bracketed=false, varMap=varMap)
+        l = stringTree(tree.l, options; bracketed=false, varMap=varMap)
+        r = stringTree(tree.r, options; bracketed=false, varMap=varMap)
         if bracketed
             return "$l $(string(op)) $r"
         else
             return "($l $(string(op)) $r)"
         end
     else
-        l = stringTree(tree.l, options, bracketed=true, varMap=varMap)
-        r = stringTree(tree.r, options, bracketed=true, varMap=varMap)
+        l = stringTree(tree.l, options; bracketed=true, varMap=varMap)
+        r = stringTree(tree.r, options; bracketed=true, varMap=varMap)
         return "$(string(op))($l, $r)"
     end
 end
@@ -127,9 +144,12 @@ Convert an equation to a string.
 - `varMap::Union{Array{String, 1}, Nothing}=nothing`: what variables
     to print for each feature.
 """
-function stringTree(tree::Node, options::Options;
-                    bracketed::Bool=false,
-                    varMap::Union{Array{String, 1}, Nothing}=nothing)::String
+function stringTree(
+    tree::Node,
+    options::Options;
+    bracketed::Bool=false,
+    varMap::Union{Array{String,1},Nothing}=nothing,
+)::String
     if tree.degree == 0
         if tree.constant
             return string(tree.val)
@@ -143,17 +163,23 @@ function stringTree(tree::Node, options::Options;
     elseif tree.degree == 1
         return "$(options.unaops[tree.op])($(stringTree(tree.l, options, bracketed=true, varMap=varMap)))"
     else
-        return stringOp(options.binops[tree.op], tree, options, bracketed=bracketed, varMap=varMap)
+        return stringOp(
+            options.binops[tree.op], tree, options; bracketed=bracketed, varMap=varMap
+        )
     end
 end
 
 # Print an equation
-function printTree(io::IO, tree::Node, options::Options; varMap::Union{Array{String, 1}, Nothing}=nothing)
-    println(io, stringTree(tree, options, varMap=varMap))
+function printTree(
+    io::IO, tree::Node, options::Options; varMap::Union{Array{String,1},Nothing}=nothing
+)
+    return println(io, stringTree(tree, options; varMap=varMap))
 end
 
-function printTree(tree::Node, options::Options; varMap::Union{Array{String, 1}, Nothing}=nothing)
-    println(stringTree(tree, options, varMap=varMap))
+function printTree(
+    tree::Node, options::Options; varMap::Union{Array{String,1},Nothing}=nothing
+)
+    return println(stringTree(tree, options; varMap=varMap))
 end
 
 end

--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -98,7 +98,7 @@ function Node(var_string::String, varMap::Array{String,1})
 end
 
 # Copy an equation (faster than deepcopy)
-function copyNode(tree::Node)::Node
+function copy_node(tree::Node)::Node
     if tree.degree == 0
         if tree.constant
             return Node(copy(tree.val))
@@ -106,13 +106,13 @@ function copyNode(tree::Node)::Node
             return Node(copy(tree.feature))
         end
     elseif tree.degree == 1
-        return Node(copy(tree.op), copyNode(tree.l))
+        return Node(copy(tree.op), copy_node(tree.l))
     else
-        return Node(copy(tree.op), copyNode(tree.l), copyNode(tree.r))
+        return Node(copy(tree.op), copy_node(tree.l), copy_node(tree.r))
     end
 end
 
-function stringOp(
+function string_op(
     op::F,
     tree::Node,
     options::Options;
@@ -120,22 +120,22 @@ function stringOp(
     varMap::Union{Array{String,1},Nothing}=nothing,
 )::String where {F}
     if op in [+, -, *, /, ^]
-        l = stringTree(tree.l, options; bracketed=false, varMap=varMap)
-        r = stringTree(tree.r, options; bracketed=false, varMap=varMap)
+        l = string_tree(tree.l, options; bracketed=false, varMap=varMap)
+        r = string_tree(tree.r, options; bracketed=false, varMap=varMap)
         if bracketed
             return "$l $(string(op)) $r"
         else
             return "($l $(string(op)) $r)"
         end
     else
-        l = stringTree(tree.l, options; bracketed=true, varMap=varMap)
-        r = stringTree(tree.r, options; bracketed=true, varMap=varMap)
+        l = string_tree(tree.l, options; bracketed=true, varMap=varMap)
+        r = string_tree(tree.r, options; bracketed=true, varMap=varMap)
         return "$(string(op))($l, $r)"
     end
 end
 
 """
-    stringTree(tree::Node, options::Options; kws...)
+    string_tree(tree::Node, options::Options; kws...)
 
 Convert an equation to a string.
 
@@ -144,7 +144,7 @@ Convert an equation to a string.
 - `varMap::Union{Array{String, 1}, Nothing}=nothing`: what variables
     to print for each feature.
 """
-function stringTree(
+function string_tree(
     tree::Node,
     options::Options;
     bracketed::Bool=false,
@@ -161,25 +161,25 @@ function stringTree(
             end
         end
     elseif tree.degree == 1
-        return "$(options.unaops[tree.op])($(stringTree(tree.l, options, bracketed=true, varMap=varMap)))"
+        return "$(options.unaops[tree.op])($(string_tree(tree.l, options, bracketed=true, varMap=varMap)))"
     else
-        return stringOp(
+        return string_op(
             options.binops[tree.op], tree, options; bracketed=bracketed, varMap=varMap
         )
     end
 end
 
 # Print an equation
-function printTree(
+function print_tree(
     io::IO, tree::Node, options::Options; varMap::Union{Array{String,1},Nothing}=nothing
 )
-    return println(io, stringTree(tree, options; varMap=varMap))
+    return println(io, string_tree(tree, options; varMap=varMap))
 end
 
-function printTree(
+function print_tree(
     tree::Node, options::Options; varMap::Union{Array{String,1},Nothing}=nothing
 )
-    return println(stringTree(tree, options; varMap=varMap))
+    return println(string_tree(tree, options; varMap=varMap))
 end
 
 end

--- a/src/EquationUtils.jl
+++ b/src/EquationUtils.jl
@@ -1,58 +1,58 @@
 module EquationUtilsModule
 
-import ..CoreModule: CONST_TYPE, Node, copyNode, Options
+import ..CoreModule: CONST_TYPE, Node, copy_node, Options
 
 # Count the operators, constants, variables in an equation
-function countNodes(tree::Node)::Int
+function count_nodes(tree::Node)::Int
     if tree.degree == 0
         return 1
     elseif tree.degree == 1
-        return 1 + countNodes(tree.l)
+        return 1 + count_nodes(tree.l)
     else
-        return 1 + countNodes(tree.l) + countNodes(tree.r)
+        return 1 + count_nodes(tree.l) + count_nodes(tree.r)
     end
 end
 
 # Count the max depth of a tree
-function countDepth(tree::Node)::Int
+function count_depth(tree::Node)::Int
     if tree.degree == 0
         return 1
     elseif tree.degree == 1
-        return 1 + countDepth(tree.l)
+        return 1 + count_depth(tree.l)
     else
-        return 1 + max(countDepth(tree.l), countDepth(tree.r))
+        return 1 + max(count_depth(tree.l), count_depth(tree.r))
     end
 end
 
 # Count the number of unary operators in the equation
-function countUnaryOperators(tree::Node)::Int
+function count_unary_operators(tree::Node)::Int
     if tree.degree == 0
         return 0
     elseif tree.degree == 1
-        return 1 + countUnaryOperators(tree.l)
+        return 1 + count_unary_operators(tree.l)
     else
-        return 0 + countUnaryOperators(tree.l) + countUnaryOperators(tree.r)
+        return 0 + count_unary_operators(tree.l) + count_unary_operators(tree.r)
     end
 end
 
 # Count the number of binary operators in the equation
-function countBinaryOperators(tree::Node)::Int
+function count_binary_operators(tree::Node)::Int
     if tree.degree == 0
         return 0
     elseif tree.degree == 1
-        return 0 + countBinaryOperators(tree.l)
+        return 0 + count_binary_operators(tree.l)
     else
-        return 1 + countBinaryOperators(tree.l) + countBinaryOperators(tree.r)
+        return 1 + count_binary_operators(tree.l) + count_binary_operators(tree.r)
     end
 end
 
 # Count the number of operators in the equation
-function countOperators(tree::Node)::Int
-    return countUnaryOperators(tree) + countBinaryOperators(tree)
+function count_operators(tree::Node)::Int
+    return count_unary_operators(tree) + count_binary_operators(tree)
 end
 
 # Count the number of constants in an equation
-function countConstants(tree::Node)::Int
+function count_constants(tree::Node)::Int
     if tree.degree == 0
         if tree.constant
             return 1
@@ -60,14 +60,14 @@ function countConstants(tree::Node)::Int
             return 0
         end
     elseif tree.degree == 1
-        return 0 + countConstants(tree.l)
+        return 0 + count_constants(tree.l)
     else
-        return 0 + countConstants(tree.l) + countConstants(tree.r)
+        return 0 + count_constants(tree.l) + count_constants(tree.r)
     end
 end
 
 # Get all the constants from a tree
-function getConstants(tree::Node)::AbstractVector{CONST_TYPE}
+function get_constants(tree::Node)::AbstractVector{CONST_TYPE}
     if tree.degree == 0
         if tree.constant
             return [tree.val]
@@ -75,25 +75,25 @@ function getConstants(tree::Node)::AbstractVector{CONST_TYPE}
             return CONST_TYPE[]
         end
     elseif tree.degree == 1
-        return getConstants(tree.l)
+        return get_constants(tree.l)
     else
-        both = [getConstants(tree.l), getConstants(tree.r)]
+        both = [get_constants(tree.l), get_constants(tree.r)]
         return [constant for subtree in both for constant in subtree]
     end
 end
 
 # Set all the constants inside a tree
-function setConstants(tree::Node, constants::AbstractVector{T}) where {T<:Real}
+function set_constants(tree::Node, constants::AbstractVector{T}) where {T<:Real}
     if tree.degree == 0
         if tree.constant
             tree.val = convert(CONST_TYPE, constants[1])
         end
     elseif tree.degree == 1
-        setConstants(tree.l, constants)
+        set_constants(tree.l, constants)
     else
-        numberLeft = countConstants(tree.l)
-        setConstants(tree.l, constants)
-        setConstants(tree.r, constants[(numberLeft + 1):end])
+        numberLeft = count_constants(tree.l)
+        set_constants(tree.l, constants)
+        set_constants(tree.r, constants[(numberLeft + 1):end])
     end
 end
 
@@ -108,33 +108,33 @@ mutable struct NodeIndex
     NodeIndex() = new()
 end
 
-function indexConstants(tree::Node)::NodeIndex
-    return indexConstants(tree, 0)
+function index_constants(tree::Node)::NodeIndex
+    return index_constants(tree, 0)
 end
 
-function indexConstants(tree::Node, left_index::Int)::NodeIndex
+function index_constants(tree::Node, left_index::Int)::NodeIndex
     index_tree = NodeIndex()
-    indexConstants(tree, index_tree, left_index)
+    index_constants(tree, index_tree, left_index)
     return index_tree
 end
 
 # Count how many constants to the left of this node, and put them in a tree
-function indexConstants(tree::Node, index_tree::NodeIndex, left_index::Int)
+function index_constants(tree::Node, index_tree::NodeIndex, left_index::Int)
     if tree.degree == 0
         if tree.constant
             index_tree.constant_index = left_index + 1
         end
     elseif tree.degree == 1
-        index_tree.constant_index = countConstants(tree.l)
+        index_tree.constant_index = count_constants(tree.l)
         index_tree.l = NodeIndex()
-        indexConstants(tree.l, index_tree.l, left_index)
+        index_constants(tree.l, index_tree.l, left_index)
     else
         index_tree.l = NodeIndex()
         index_tree.r = NodeIndex()
-        indexConstants(tree.l, index_tree.l, left_index)
-        index_tree.constant_index = countConstants(tree.l)
+        index_constants(tree.l, index_tree.l, left_index)
+        index_tree.constant_index = count_constants(tree.l)
         left_index_here = left_index + index_tree.constant_index
-        indexConstants(tree.r, index_tree.r, left_index_here)
+        index_constants(tree.r, index_tree.r, left_index_here)
     end
 end
 

--- a/src/EquationUtils.jl
+++ b/src/EquationUtils.jl
@@ -24,7 +24,6 @@ function countDepth(tree::Node)::Int
     end
 end
 
-
 # Count the number of unary operators in the equation
 function countUnaryOperators(tree::Node)::Int
     if tree.degree == 0
@@ -52,7 +51,6 @@ function countOperators(tree::Node)::Int
     return countUnaryOperators(tree) + countBinaryOperators(tree)
 end
 
-
 # Count the number of constants in an equation
 function countConstants(tree::Node)::Int
     if tree.degree == 0
@@ -67,7 +65,6 @@ function countConstants(tree::Node)::Int
         return 0 + countConstants(tree.l) + countConstants(tree.r)
     end
 end
-
 
 # Get all the constants from a tree
 function getConstants(tree::Node)::AbstractVector{CONST_TYPE}
@@ -96,10 +93,9 @@ function setConstants(tree::Node, constants::AbstractVector{T}) where {T<:Real}
     else
         numberLeft = countConstants(tree.l)
         setConstants(tree.l, constants)
-        setConstants(tree.r, constants[numberLeft+1:end])
+        setConstants(tree.r, constants[(numberLeft + 1):end])
     end
 end
-
 
 ## Assign index to nodes of a tree
 # This will mirror a Node struct, rather
@@ -113,7 +109,7 @@ mutable struct NodeIndex
 end
 
 function indexConstants(tree::Node)::NodeIndex
-    indexConstants(tree, 0)
+    return indexConstants(tree, 0)
 end
 
 function indexConstants(tree::Node, left_index::Int)::NodeIndex

--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -25,7 +25,7 @@ macro return_on_nonfinite_array(array, T, n)
 end
 
 """
-    evalTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options)
+    eval_tree_array(tree::Node, cX::AbstractMatrix{T}, options::Options)
 
 Evaluate a binary tree (equation) over a given input data matrix. The
 options contain all of the operators used. This function fuses doublets
@@ -53,17 +53,17 @@ which speed up evaluation significantly.
     or nan was encountered, and a large loss should be assigned
     to the equation.
 """
-function evalTreeArray(
+function eval_tree_array(
     tree::Node, cX::AbstractMatrix{T}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real}
     n = size(cX, 2)
-    result, finished = _evalTreeArray(tree, cX, options)
+    result, finished = _eval_tree_array(tree, cX, options)
     @return_on_false finished result
     @return_on_nonfinite_array result T n
     return result, finished
 end
 
-function _evalTreeArray(
+function _eval_tree_array(
     tree::Node, cX::AbstractMatrix{T}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real}
     if tree.degree == 0
@@ -106,10 +106,10 @@ function deg2_eval(
     tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx}
     n = size(cX, 2)
-    (cumulator, complete) = _evalTreeArray(tree.l, cX, options)
+    (cumulator, complete) = _eval_tree_array(tree.l, cX, options)
     @return_on_false complete cumulator
     @return_on_nonfinite_array cumulator T n
-    (array2, complete2) = _evalTreeArray(tree.r, cX, options)
+    (array2, complete2) = _eval_tree_array(tree.r, cX, options)
     @return_on_false complete2 cumulator
     @return_on_nonfinite_array array2 T n
     op = options.binops[op_idx]
@@ -127,7 +127,7 @@ function deg1_eval(
     tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx}
     n = size(cX, 2)
-    (cumulator, complete) = _evalTreeArray(tree.l, cX, options)
+    (cumulator, complete) = _eval_tree_array(tree.l, cX, options)
     @return_on_false complete cumulator
     @return_on_nonfinite_array cumulator T n
     op = options.unaops[op_idx]
@@ -172,7 +172,7 @@ function deg1_l2_ll0_lr0_eval(
         cumulator = Array{T,1}(undef, n)
         @inbounds @simd for j in 1:n
             x_l = op_l(val_ll, cX[feature_lr, j])::T
-            x = isfinite(x_l) ? op(x_l)::T : T(Inf) # These will get discovered by _evalTreeArray at end.
+            x = isfinite(x_l) ? op(x_l)::T : T(Inf) # These will get discovered by _eval_tree_array at end.
             cumulator[j] = x
         end
         return (cumulator, true)
@@ -274,7 +274,7 @@ function deg2_l0_eval(
     tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx}
     n = size(cX, 2)
-    (cumulator, complete) = _evalTreeArray(tree.r, cX, options)
+    (cumulator, complete) = _eval_tree_array(tree.r, cX, options)
     @return_on_false complete cumulator
     @return_on_nonfinite_array cumulator T n
     op = options.binops[op_idx]
@@ -299,7 +299,7 @@ function deg2_r0_eval(
     tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx}
     n = size(cX, 2)
-    (cumulator, complete) = _evalTreeArray(tree.l, cX, options)
+    (cumulator, complete) = _eval_tree_array(tree.l, cX, options)
     @return_on_false complete cumulator
     @return_on_nonfinite_array cumulator T n
     op = options.binops[op_idx]
@@ -322,7 +322,7 @@ end
 
 # Evaluate an equation over an array of datapoints
 # This one is just for reference. The fused one should be faster.
-function differentiableEvalTreeArray(
+function differentiable_eval_tree_array(
     tree::Node, cX::AbstractMatrix{T}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real}
     n = size(cX, 2)
@@ -343,7 +343,7 @@ function deg1_diff_eval(
     tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx}
     n = size(cX, 2)
-    (left, complete) = differentiableEvalTreeArray(tree.l, cX, options)
+    (left, complete) = differentiable_eval_tree_array(tree.l, cX, options)
     @return_on_false complete left
     op = options.unaops[op_idx]
     out = op.(left)
@@ -355,9 +355,9 @@ function deg2_diff_eval(
     tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx}
     n = size(cX, 2)
-    (left, complete) = differentiableEvalTreeArray(tree.l, cX, options)
+    (left, complete) = differentiable_eval_tree_array(tree.l, cX, options)
     @return_on_false complete left
-    (right, complete2) = differentiableEvalTreeArray(tree.r, cX, options)
+    (right, complete2) = differentiable_eval_tree_array(tree.r, cX, options)
     @return_on_false complete2 left
     op = options.binops[op_idx]
     out = op.(left, right)

--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -342,7 +342,6 @@ end
 function deg1_diff_eval(
     tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx}
-    n = size(cX, 2)
     (left, complete) = differentiable_eval_tree_array(tree.l, cX, options)
     @return_on_false complete left
     op = options.unaops[op_idx]
@@ -354,7 +353,6 @@ end
 function deg2_diff_eval(
     tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx}
-    n = size(cX, 2)
     (left, complete) = differentiable_eval_tree_array(tree.l, cX, options)
     @return_on_false complete left
     (right, complete2) = differentiable_eval_tree_array(tree.r, cX, options)

--- a/src/EvaluateEquationDerivative.jl
+++ b/src/EvaluateEquationDerivative.jl
@@ -19,7 +19,9 @@ respect to `x1`.
 - `(evaluation, derivative, complete)::Tuple{AbstractVector{T}, AbstractVector{T}, Bool}`: the normal evaluation,
     the derivative, and whether the evaluation completed as normal (or encountered a nan or inf).
 """
-function evalDiffTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options, direction::Int)::Tuple{AbstractVector{T}, AbstractVector{T}, Bool} where {T<:Real}
+function evalDiffTreeArray(
+    tree::Node, cX::AbstractMatrix{T}, options::Options, direction::Int
+)::Tuple{AbstractVector{T},AbstractVector{T},Bool} where {T<:Real}
     # TODO: Implement quick check for whether the variable is actually used
     # in this tree. Otherwise, return zero.
     evaluation, derivative, complete = _evalDiffTreeArray(tree, cX, options, direction)
@@ -27,7 +29,9 @@ function evalDiffTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options, 
     return evaluation, derivative, !(is_bad_array(evaluation) || is_bad_array(derivative))
 end
 
-function _evalDiffTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options, direction::Int)::Tuple{AbstractVector{T}, AbstractVector{T}, Bool} where {T<:Real}
+function _evalDiffTreeArray(
+    tree::Node, cX::AbstractMatrix{T}, options::Options, direction::Int
+)::Tuple{AbstractVector{T},AbstractVector{T},Bool} where {T<:Real}
     if tree.degree == 0
         diff_deg0_eval(tree, cX, options, direction)
     elseif tree.degree == 1
@@ -37,14 +41,18 @@ function _evalDiffTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options,
     end
 end
 
-function diff_deg0_eval(tree::Node, cX::AbstractMatrix{T}, options::Options, direction::Int)::Tuple{AbstractVector{T}, AbstractVector{T}, Bool} where {T<:Real}
+function diff_deg0_eval(
+    tree::Node, cX::AbstractMatrix{T}, options::Options, direction::Int
+)::Tuple{AbstractVector{T},AbstractVector{T},Bool} where {T<:Real}
     n = size(cX, 2)
     const_part = deg0_eval(tree, cX, options)[1]
     derivative_part = (tree.feature == direction) ? ones(T, n) : zeros(T, n)
     return (const_part, derivative_part, true)
 end
 
-function diff_deg1_eval(tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options, direction::Int)::Tuple{AbstractVector{T}, AbstractVector{T}, Bool} where {T<:Real,op_idx}
+function diff_deg1_eval(
+    tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options, direction::Int
+)::Tuple{AbstractVector{T},AbstractVector{T},Bool} where {T<:Real,op_idx}
     n = size(cX, 2)
     (cumulator, dcumulator, complete) = evalDiffTreeArray(tree.l, cX, options, direction)
     @return_on_false2 complete cumulator dcumulator
@@ -52,7 +60,7 @@ function diff_deg1_eval(tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, option
     op = options.unaops[op_idx]
     diff_op = options.diff_unaops[op_idx]
 
-    @inbounds @simd for j=1:n
+    @inbounds @simd for j in 1:n
         x = op(cumulator[j])::T
         dx = diff_op(cumulator[j])::T * dcumulator[j]
 
@@ -62,7 +70,9 @@ function diff_deg1_eval(tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, option
     return (cumulator, dcumulator, true)
 end
 
-function diff_deg2_eval(tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options, direction::Int)::Tuple{AbstractVector{T}, AbstractVector{T}, Bool} where {T<:Real,op_idx}
+function diff_deg2_eval(
+    tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options, direction::Int
+)::Tuple{AbstractVector{T},AbstractVector{T},Bool} where {T<:Real,op_idx}
     n = size(cX, 2)
     (cumulator, dcumulator, complete) = evalDiffTreeArray(tree.l, cX, options, direction)
     @return_on_false2 complete cumulator dcumulator
@@ -72,23 +82,16 @@ function diff_deg2_eval(tree::Node, cX::AbstractMatrix{T}, ::Val{op_idx}, option
     op = options.binops[op_idx]
     diff_op = options.diff_binops[op_idx]
 
-    @inbounds @simd for j=1:n
+    @inbounds @simd for j in 1:n
         x = op(cumulator[j], array2[j])
 
-        dx = dot(
-                 diff_op(cumulator[j], array2[j]),
-                        [dcumulator[j], dcumulator2[j]]
-                )
+        dx = dot(diff_op(cumulator[j], array2[j]), [dcumulator[j], dcumulator2[j]])
 
         cumulator[j] = x
         dcumulator[j] = dx
     end
     return (cumulator, dcumulator, true)
 end
-
-
-
-
 
 """
     evalGradTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options; variable::Bool=false)
@@ -103,7 +106,9 @@ to every constant in the expression.
 - `(evaluation, gradient, complete)::Tuple{AbstractVector{T}, AbstractMatrix{T}, Bool}`: the normal evaluation,
     the gradient, and whether the evaluation completed as normal (or encountered a nan or inf).
 """
-function evalGradTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options; variable::Bool=false)::Tuple{AbstractVector{T},AbstractMatrix{T}, Bool} where {T<:Real}
+function evalGradTreeArray(
+    tree::Node, cX::AbstractMatrix{T}, options::Options; variable::Bool=false
+)::Tuple{AbstractVector{T},AbstractMatrix{T},Bool} where {T<:Real}
     n = size(cX, 2)
     if variable
         n_gradients = size(cX, 1)
@@ -114,24 +119,53 @@ function evalGradTreeArray(tree::Node, cX::AbstractMatrix{T}, options::Options; 
     return evalGradTreeArray(tree, n, n_gradients, index_tree, cX, options, Val(variable))
 end
 
-function evalGradTreeArray(tree::Node, n::Int, n_gradients::Int, index_tree::NodeIndex, cX::AbstractMatrix{T}, options::Options, ::Val{variable})::Tuple{AbstractVector{T},AbstractMatrix{T}, Bool} where {T<:Real,variable}
-    evaluation, gradient, complete = _evalGradTreeArray(tree, n, n_gradients, index_tree, cX, options, Val(variable))
+function evalGradTreeArray(
+    tree::Node,
+    n::Int,
+    n_gradients::Int,
+    index_tree::NodeIndex,
+    cX::AbstractMatrix{T},
+    options::Options,
+    ::Val{variable},
+)::Tuple{AbstractVector{T},AbstractMatrix{T},Bool} where {T<:Real,variable}
+    evaluation, gradient, complete = _evalGradTreeArray(
+        tree, n, n_gradients, index_tree, cX, options, Val(variable)
+    )
     @return_on_false2 complete evaluation gradient
     return evaluation, gradient, !(is_bad_array(evaluation) || is_bad_array(gradient))
 end
 
-
-function _evalGradTreeArray(tree::Node, n::Int, n_gradients::Int, index_tree::NodeIndex, cX::AbstractMatrix{T}, options::Options, ::Val{variable})::Tuple{AbstractVector{T},AbstractMatrix{T}, Bool} where {T<:Real,variable}
+function _evalGradTreeArray(
+    tree::Node,
+    n::Int,
+    n_gradients::Int,
+    index_tree::NodeIndex,
+    cX::AbstractMatrix{T},
+    options::Options,
+    ::Val{variable},
+)::Tuple{AbstractVector{T},AbstractMatrix{T},Bool} where {T<:Real,variable}
     if tree.degree == 0
         grad_deg0_eval(tree, n, n_gradients, index_tree, cX, options, Val(variable))
     elseif tree.degree == 1
-        grad_deg1_eval(tree, n, n_gradients, index_tree, cX, Val(tree.op), options, Val(variable))
+        grad_deg1_eval(
+            tree, n, n_gradients, index_tree, cX, Val(tree.op), options, Val(variable)
+        )
     else
-        grad_deg2_eval(tree, n, n_gradients, index_tree, cX, Val(tree.op), options, Val(variable))
+        grad_deg2_eval(
+            tree, n, n_gradients, index_tree, cX, Val(tree.op), options, Val(variable)
+        )
     end
 end
 
-function grad_deg0_eval(tree::Node, n::Int, n_gradients::Int, index_tree::NodeIndex, cX::AbstractMatrix{T}, options::Options, ::Val{variable})::Tuple{AbstractVector{T},AbstractMatrix{T}, Bool} where {T<:Real,variable}
+function grad_deg0_eval(
+    tree::Node,
+    n::Int,
+    n_gradients::Int,
+    index_tree::NodeIndex,
+    cX::AbstractMatrix{T},
+    options::Options,
+    ::Val{variable},
+)::Tuple{AbstractVector{T},AbstractMatrix{T},Bool} where {T<:Real,variable}
     const_part = deg0_eval(tree, cX, options)[1]
 
     if variable == tree.constant
@@ -144,47 +178,69 @@ function grad_deg0_eval(tree::Node, n::Int, n_gradients::Int, index_tree::NodeIn
     return (const_part, derivative_part, true)
 end
 
-function grad_deg1_eval(tree::Node, n::Int, n_gradients::Int, index_tree::NodeIndex, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options, ::Val{variable})::Tuple{AbstractVector{T},AbstractMatrix{T}, Bool} where {T<:Real,op_idx,variable}
-    (cumulator, dcumulator, complete) = evalGradTreeArray(tree.l, n, n_gradients, index_tree.l, cX, options, Val(variable))
+function grad_deg1_eval(
+    tree::Node,
+    n::Int,
+    n_gradients::Int,
+    index_tree::NodeIndex,
+    cX::AbstractMatrix{T},
+    ::Val{op_idx},
+    options::Options,
+    ::Val{variable},
+)::Tuple{AbstractVector{T},AbstractMatrix{T},Bool} where {T<:Real,op_idx,variable}
+    (cumulator, dcumulator, complete) = evalGradTreeArray(
+        tree.l, n, n_gradients, index_tree.l, cX, options, Val(variable)
+    )
     @return_on_false2 complete cumulator dcumulator
 
     op = options.unaops[op_idx]
     diff_op = options.diff_unaops[op_idx]
 
-    @inbounds @simd for j=1:n
+    @inbounds @simd for j in 1:n
         x = op(cumulator[j])::T
         dx = diff_op(cumulator[j])
 
-        cumulator[j] = x 
-        for k=1:n_gradients
+        cumulator[j] = x
+        for k in 1:n_gradients
             dcumulator[k, j] = dx * dcumulator[k, j]
         end
     end
     return (cumulator, dcumulator, true)
 end
 
-function grad_deg2_eval(tree::Node, n::Int, n_gradients::Int, index_tree::NodeIndex, cX::AbstractMatrix{T}, ::Val{op_idx}, options::Options, ::Val{variable})::Tuple{AbstractVector{T},AbstractMatrix{T}, Bool} where {T<:Real,op_idx,variable}
-    derivative_part = Array{T, 2}(undef, n_gradients, n)
-    (cumulator1, dcumulator1, complete) = evalGradTreeArray(tree.l, n, n_gradients, index_tree.l, cX, options, Val(variable))
+function grad_deg2_eval(
+    tree::Node,
+    n::Int,
+    n_gradients::Int,
+    index_tree::NodeIndex,
+    cX::AbstractMatrix{T},
+    ::Val{op_idx},
+    options::Options,
+    ::Val{variable},
+)::Tuple{AbstractVector{T},AbstractMatrix{T},Bool} where {T<:Real,op_idx,variable}
+    derivative_part = Array{T,2}(undef, n_gradients, n)
+    (cumulator1, dcumulator1, complete) = evalGradTreeArray(
+        tree.l, n, n_gradients, index_tree.l, cX, options, Val(variable)
+    )
     @return_on_false2 complete cumulator1 dcumulator1
-    (cumulator2, dcumulator2, complete2) = evalGradTreeArray(tree.r, n, n_gradients, index_tree.r, cX, options, Val(variable))
+    (cumulator2, dcumulator2, complete2) = evalGradTreeArray(
+        tree.r, n, n_gradients, index_tree.r, cX, options, Val(variable)
+    )
     @return_on_false2 complete2 cumulator1 dcumulator1
 
     op = options.binops[op_idx]
     diff_op = options.diff_binops[op_idx]
 
-    @inbounds @simd for j=1:n
+    @inbounds @simd for j in 1:n
         x = op(cumulator1[j], cumulator2[j])
         dx = diff_op(cumulator1[j], cumulator2[j])
         cumulator1[j] = x
-        for k=1:n_gradients
+        for k in 1:n_gradients
             derivative_part[k, j] = dx[1] * dcumulator1[k, j] + dx[2] * dcumulator2[k, j]
         end
     end
 
     return (cumulator1, derivative_part, true)
 end
-
-
 
 end

--- a/src/EvaluateEquationDerivative.jl
+++ b/src/EvaluateEquationDerivative.jl
@@ -116,7 +116,9 @@ function eval_grad_tree_array(
         n_gradients = count_constants(tree)
     end
     index_tree = index_constants(tree, 0)
-    return eval_grad_tree_array(tree, n, n_gradients, index_tree, cX, options, Val(variable))
+    return eval_grad_tree_array(
+        tree, n, n_gradients, index_tree, cX, options, Val(variable)
+    )
 end
 
 function eval_grad_tree_array(

--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -8,8 +8,8 @@ using Printf: @sprintf
 
 """ List of the best members seen all time in `.members` """
 mutable struct HallOfFame
-    members::Array{PopMember, 1}
-    exists::Array{Bool, 1} #Whether it has been set
+    members::Array{PopMember,1}
+    exists::Array{Bool,1} #Whether it has been set
 
     # Arranged by complexity - store one at each.
 end
@@ -25,21 +25,23 @@ has been instantiated or not.
 """
 function HallOfFame(options::Options)
     actualMaxsize = options.maxsize + MAX_DEGREE
-    HallOfFame([PopMember(Node(convert(CONST_TYPE, 1)), 1f9, 1f9) for i=1:actualMaxsize], [false for i=1:actualMaxsize])
+    return HallOfFame(
+        [PopMember(Node(convert(CONST_TYPE, 1)), 1.0f9, 1.0f9) for i in 1:actualMaxsize],
+        [false for i in 1:actualMaxsize],
+    )
 end
-
 
 """
     calculateParetoFrontier(dataset::Dataset{T}, hallOfFame::HallOfFame,
                             options::Options) where {T<:Real}
 """
-function calculateParetoFrontier(dataset::Dataset{T},
-                                 hallOfFame::HallOfFame,
-                                 options::Options)::Array{PopMember, 1} where {T<:Real}
+function calculateParetoFrontier(
+    dataset::Dataset{T}, hallOfFame::HallOfFame, options::Options
+)::Array{PopMember,1} where {T<:Real}
     # Dominating pareto curve - must be better than all simpler equations
     dominating = PopMember[]
     actualMaxsize = options.maxsize + MAX_DEGREE
-    for size=1:actualMaxsize
+    for size in 1:actualMaxsize
         if !hallOfFame.exists[size]
             continue
         end
@@ -47,7 +49,7 @@ function calculateParetoFrontier(dataset::Dataset{T},
         # We check if this member is better than all members which are smaller than it and
         # also exist.
         betterThanAllSmaller = true
-        for i=1:(size-1)
+        for i in 1:(size - 1)
             if !hallOfFame.exists[i]
                 continue
             end
@@ -73,41 +75,56 @@ Compute the dominating Pareto frontier for a given hallOfFame. This
 is the list of equations where each equation has a better loss than all
 simpler equations.
 """
-function calculateParetoFrontier(X::AbstractMatrix{T},
-                                 y::AbstractVector{T},
-                                 hallOfFame::HallOfFame,
-                                 options::Options;
-                                 weights=nothing,
-                                 varMap=nothing) where {T<:Real}
-    calculateParetoFrontier(Dataset(X, y, weights=weights, varMap=varMap), hallOfFame, options)
+function calculateParetoFrontier(
+    X::AbstractMatrix{T},
+    y::AbstractVector{T},
+    hallOfFame::HallOfFame,
+    options::Options;
+    weights=nothing,
+    varMap=nothing,
+) where {T<:Real}
+    return calculateParetoFrontier(
+        Dataset(X, y; weights=weights, varMap=varMap), hallOfFame, options
+    )
 end
 
-function string_dominating_pareto_curve(hallOfFame, baselineMSE,
-                                        dataset, options,
-                                        avgy)
+function string_dominating_pareto_curve(hallOfFame, baselineMSE, dataset, options, avgy)
     output = ""
     curMSE = Float64(baselineMSE)
     lastMSE = curMSE
     lastComplexity = 0
     output *= "Hall of Fame:\n"
     output *= "-----------------------------------------\n"
-    output *= @sprintf("%-10s  %-8s   %-8s  %-8s\n", "Complexity", "Loss", "Score", "Equation")
+    output *= @sprintf(
+        "%-10s  %-8s   %-8s  %-8s\n", "Complexity", "Loss", "Score", "Equation"
+    )
 
     dominating = calculateParetoFrontier(dataset, hallOfFame, options)
     for member in dominating
         complexity = countNodes(member.tree)
         if member.loss < 0.0
-            throw(DomainError(member.loss, "Your loss function must be non-negative. To do this, consider wrapping your loss inside an exponential, which will not affect the search (unless you are using annealing)."))
+            throw(
+                DomainError(
+                    member.loss,
+                    "Your loss function must be non-negative. To do this, consider wrapping your loss inside an exponential, which will not affect the search (unless you are using annealing).",
+                ),
+            )
         end
         # User higher precision when finding the original loss:
         relu(x) = x < 0 ? 0 : x
         curMSE = member.loss
-        
+
         delta_c = complexity - lastComplexity
         ZERO_POINT = 1e-10
-        delta_l_mse = log(abs(curMSE/lastMSE) + ZERO_POINT)
-        score = convert(Float32, -delta_l_mse/delta_c)
-        output *= @sprintf("%-10d  %-8.3e  %-8.3e  %-s\n" , complexity, curMSE, score, stringTree(member.tree, options, varMap=dataset.varMap))
+        delta_l_mse = log(abs(curMSE / lastMSE) + ZERO_POINT)
+        score = convert(Float32, -delta_l_mse / delta_c)
+        output *= @sprintf(
+            "%-10d  %-8.3e  %-8.3e  %-s\n",
+            complexity,
+            curMSE,
+            score,
+            stringTree(member.tree, options, varMap=dataset.varMap)
+        )
         lastMSE = curMSE
         lastComplexity = complexity
     end

--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -1,9 +1,9 @@
 module HallOfFameModule
 
-import ..CoreModule: CONST_TYPE, MAX_DEGREE, Node, Options, Dataset, stringTree
-import ..EquationUtilsModule: countNodes
-import ..PopMemberModule: PopMember, copyPopMember
-import ..LossFunctionsModule: EvalLoss
+import ..CoreModule: CONST_TYPE, MAX_DEGREE, Node, Options, Dataset, string_tree
+import ..EquationUtilsModule: count_nodes
+import ..PopMemberModule: PopMember, copy_pop_member
+import ..LossFunctionsModule: eval_loss
 using Printf: @sprintf
 
 """ List of the best members seen all time in `.members` """
@@ -32,10 +32,10 @@ function HallOfFame(options::Options)
 end
 
 """
-    calculateParetoFrontier(dataset::Dataset{T}, hallOfFame::HallOfFame,
+    calculate_pareto_frontier(dataset::Dataset{T}, hallOfFame::HallOfFame,
                             options::Options) where {T<:Real}
 """
-function calculateParetoFrontier(
+function calculate_pareto_frontier(
     dataset::Dataset{T}, hallOfFame::HallOfFame, options::Options
 )::Array{PopMember,1} where {T<:Real}
     # Dominating pareto curve - must be better than all simpler equations
@@ -60,14 +60,14 @@ function calculateParetoFrontier(
             end
         end
         if betterThanAllSmaller
-            push!(dominating, copyPopMember(member))
+            push!(dominating, copy_pop_member(member))
         end
     end
     return dominating
 end
 
 """
-    calculateParetoFrontier(X::AbstractMatrix{T}, y::AbstractVector{T},
+    calculate_pareto_frontier(X::AbstractMatrix{T}, y::AbstractVector{T},
                             hallOfFame::HallOfFame, options::Options;
                             weights=nothing, varMap=nothing) where {T<:Real}
 
@@ -75,7 +75,7 @@ Compute the dominating Pareto frontier for a given hallOfFame. This
 is the list of equations where each equation has a better loss than all
 simpler equations.
 """
-function calculateParetoFrontier(
+function calculate_pareto_frontier(
     X::AbstractMatrix{T},
     y::AbstractVector{T},
     hallOfFame::HallOfFame,
@@ -83,7 +83,7 @@ function calculateParetoFrontier(
     weights=nothing,
     varMap=nothing,
 ) where {T<:Real}
-    return calculateParetoFrontier(
+    return calculate_pareto_frontier(
         Dataset(X, y; weights=weights, varMap=varMap), hallOfFame, options
     )
 end
@@ -96,12 +96,12 @@ function string_dominating_pareto_curve(hallOfFame, baselineMSE, dataset, option
     output *= "Hall of Fame:\n"
     output *= "-----------------------------------------\n"
     output *= @sprintf(
-        "%-10s  %-8s   %-8s  %-8s\n", "Complexity", "Loss", "Score", "Equation"
+        "%-10s  %-8s   %-8s  %-8s\n", "Complexity", "loss", "Score", "Equation"
     )
 
-    dominating = calculateParetoFrontier(dataset, hallOfFame, options)
+    dominating = calculate_pareto_frontier(dataset, hallOfFame, options)
     for member in dominating
-        complexity = countNodes(member.tree)
+        complexity = count_nodes(member.tree)
         if member.loss < 0.0
             throw(
                 DomainError(
@@ -123,7 +123,7 @@ function string_dominating_pareto_curve(hallOfFame, baselineMSE, dataset, option
             complexity,
             curMSE,
             score,
-            stringTree(member.tree, options, varMap=dataset.varMap)
+            string_tree(member.tree, options, varMap=dataset.varMap)
         )
         lastMSE = curMSE
         lastComplexity = complexity

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -72,7 +72,6 @@ end
 function score_func_batch(
     dataset::Dataset{T}, baseline::T, tree::Node, options::Options
 )::Tuple{T,T} where {T<:Real}
-    batchSize = options.batchSize
     batch_idx = randperm(dataset.n)[1:(options.batchSize)]
     batch_X = dataset.X[:, batch_idx]
     batch_y = dataset.y[batch_idx]

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -49,7 +49,9 @@ function eval_loss(tree::Node, dataset::Dataset{T}, options::Options)::T where {
 end
 
 # Compute a score which includes a complexity penalty in the loss
-function loss_to_score(loss::T, baseline::T, tree::Node, options::Options)::T where {T<:Real}
+function loss_to_score(
+    loss::T, baseline::T, tree::Node, options::Options
+)::T where {T<:Real}
     normalized_loss_term = loss / baseline
     size = count_nodes(tree)
     parsimony_term = size * options.parsimony

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -3,21 +3,21 @@ module LossFunctionsModule
 import Random: randperm
 import LossFunctions: value, AggMode, SupervisedLoss
 import ..CoreModule: Options, Dataset, Node
-import ..EquationUtilsModule: countNodes
-import ..EvaluateEquationModule: evalTreeArray, differentiableEvalTreeArray
+import ..EquationUtilsModule: count_nodes
+import ..EvaluateEquationModule: eval_tree_array, differentiable_eval_tree_array
 
-function Loss(
+function loss(
     x::AbstractArray{T}, y::AbstractArray{T}, options::Options{A,B,dA,dB,C}
 )::T where {T<:Real,A,B,dA,dB,C<:SupervisedLoss}
     return value(options.loss, y, x, AggMode.Mean())
 end
-function Loss(
+function loss(
     x::AbstractArray{T}, y::AbstractArray{T}, options::Options{A,B,dA,dB,C}
 )::T where {T<:Real,A,B,dA,dB,C<:Function}
     return sum(options.loss.(x, y)) / length(y)
 end
 
-function Loss(
+function loss(
     x::AbstractArray{T},
     y::AbstractArray{T},
     w::AbstractArray{T},
@@ -25,7 +25,7 @@ function Loss(
 )::T where {T<:Real,A,B,dA,dB,C<:SupervisedLoss}
     return value(options.loss, y, x, AggMode.WeightedMean(w))
 end
-function Loss(
+function loss(
     x::AbstractArray{T},
     y::AbstractArray{T},
     w::AbstractArray{T},
@@ -35,57 +35,57 @@ function Loss(
 end
 
 # Evaluate the loss of a particular expression on the input dataset.
-function EvalLoss(tree::Node, dataset::Dataset{T}, options::Options)::T where {T<:Real}
-    (prediction, completion) = evalTreeArray(tree, dataset.X, options)
+function eval_loss(tree::Node, dataset::Dataset{T}, options::Options)::T where {T<:Real}
+    (prediction, completion) = eval_tree_array(tree, dataset.X, options)
     if !completion
         return T(1000000000)
     end
 
     if dataset.weighted
-        return Loss(prediction, dataset.y, dataset.weights, options)
+        return loss(prediction, dataset.y, dataset.weights, options)
     else
-        return Loss(prediction, dataset.y, options)
+        return loss(prediction, dataset.y, options)
     end
 end
 
 # Compute a score which includes a complexity penalty in the loss
-function lossToScore(loss::T, baseline::T, tree::Node, options::Options)::T where {T<:Real}
+function loss_to_score(loss::T, baseline::T, tree::Node, options::Options)::T where {T<:Real}
     normalized_loss_term = loss / baseline
-    size = countNodes(tree)
+    size = count_nodes(tree)
     parsimony_term = size * options.parsimony
 
     return normalized_loss_term + parsimony_term
 end
 
 # Score an equation
-function scoreFunc(
+function score_func(
     dataset::Dataset{T}, baseline::T, tree::Node, options::Options
 )::Tuple{T,T} where {T<:Real}
-    loss = EvalLoss(tree, dataset, options)
-    score = lossToScore(loss, baseline, tree, options)
+    loss = eval_loss(tree, dataset, options)
+    score = loss_to_score(loss, baseline, tree, options)
     return score, loss
 end
 
 # Score an equation with a small batch
-function scoreFuncBatch(
+function score_func_batch(
     dataset::Dataset{T}, baseline::T, tree::Node, options::Options
 )::Tuple{T,T} where {T<:Real}
     batchSize = options.batchSize
     batch_idx = randperm(dataset.n)[1:(options.batchSize)]
     batch_X = dataset.X[:, batch_idx]
     batch_y = dataset.y[batch_idx]
-    (prediction, completion) = evalTreeArray(tree, batch_X, options)
+    (prediction, completion) = eval_tree_array(tree, batch_X, options)
     if !completion
         return T(1000000000), T(1000000000)
     end
 
     if !dataset.weighted
-        loss = Loss(prediction, batch_y, options)
+        loss = loss(prediction, batch_y, options)
     else
         batch_w = dataset.weights[batch_idx]
-        loss = Loss(prediction, batch_y, batch_w, options)
+        loss = loss(prediction, batch_y, batch_w, options)
     end
-    score = lossToScore(loss, baseline, tree, options)
+    score = loss_to_score(loss, baseline, tree, options)
     return score, loss
 end
 

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -63,9 +63,9 @@ end
 function score_func(
     dataset::Dataset{T}, baseline::T, tree::Node, options::Options
 )::Tuple{T,T} where {T<:Real}
-    loss = eval_loss(tree, dataset, options)
-    score = loss_to_score(loss, baseline, tree, options)
-    return score, loss
+    result_loss = eval_loss(tree, dataset, options)
+    score = loss_to_score(result_loss, baseline, tree, options)
+    return score, result_loss
 end
 
 # Score an equation with a small batch
@@ -82,13 +82,13 @@ function score_func_batch(
     end
 
     if !dataset.weighted
-        loss = loss(prediction, batch_y, options)
+        result_loss = loss(prediction, batch_y, options)
     else
         batch_w = dataset.weights[batch_idx]
-        loss = loss(prediction, batch_y, batch_w, options)
+        result_loss = loss(prediction, batch_y, batch_w, options)
     end
-    score = loss_to_score(loss, baseline, tree, options)
-    return score, loss
+    score = loss_to_score(result_loss, baseline, tree, options)
+    return score, result_loss
 end
 
 end

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -6,19 +6,32 @@ import ..CoreModule: Options, Dataset, Node
 import ..EquationUtilsModule: countNodes
 import ..EvaluateEquationModule: evalTreeArray, differentiableEvalTreeArray
 
+function Loss(
+    x::AbstractArray{T}, y::AbstractArray{T}, options::Options{A,B,dA,dB,C}
+)::T where {T<:Real,A,B,dA,dB,C<:SupervisedLoss}
+    return value(options.loss, y, x, AggMode.Mean())
+end
+function Loss(
+    x::AbstractArray{T}, y::AbstractArray{T}, options::Options{A,B,dA,dB,C}
+)::T where {T<:Real,A,B,dA,dB,C<:Function}
+    return sum(options.loss.(x, y)) / length(y)
+end
 
-function Loss(x::AbstractArray{T}, y::AbstractArray{T}, options::Options{A,B,dA,dB,C})::T where {T<:Real,A,B,dA,dB,C<:SupervisedLoss}
-    value(options.loss, y, x, AggMode.Mean())
+function Loss(
+    x::AbstractArray{T},
+    y::AbstractArray{T},
+    w::AbstractArray{T},
+    options::Options{A,B,dA,dB,C},
+)::T where {T<:Real,A,B,dA,dB,C<:SupervisedLoss}
+    return value(options.loss, y, x, AggMode.WeightedMean(w))
 end
-function Loss(x::AbstractArray{T}, y::AbstractArray{T}, options::Options{A,B,dA,dB,C})::T where {T<:Real,A,B,dA,dB,C<:Function}
-    sum(options.loss.(x, y))/length(y)
-end
-
-function Loss(x::AbstractArray{T}, y::AbstractArray{T}, w::AbstractArray{T}, options::Options{A,B,dA,dB,C})::T where {T<:Real,A,B,dA,dB,C<:SupervisedLoss}
-    value(options.loss, y, x, AggMode.WeightedMean(w))
-end
-function Loss(x::AbstractArray{T}, y::AbstractArray{T}, w::AbstractArray{T}, options::Options{A,B,dA,dB,C})::T where {T<:Real,A,B,dA,dB,C<:Function}
-    sum(options.loss.(x, y, w))/sum(w)
+function Loss(
+    x::AbstractArray{T},
+    y::AbstractArray{T},
+    w::AbstractArray{T},
+    options::Options{A,B,dA,dB,C},
+)::T where {T<:Real,A,B,dA,dB,C<:Function}
+    return sum(options.loss.(x, y, w)) / sum(w)
 end
 
 # Evaluate the loss of a particular expression on the input dataset.
@@ -39,25 +52,26 @@ end
 function lossToScore(loss::T, baseline::T, tree::Node, options::Options)::T where {T<:Real}
     normalized_loss_term = loss / baseline
     size = countNodes(tree)
-    parsimony_term = size*options.parsimony
+    parsimony_term = size * options.parsimony
 
     return normalized_loss_term + parsimony_term
 end
 
 # Score an equation
-function scoreFunc(dataset::Dataset{T},
-                   baseline::T, tree::Node,
-                   options::Options)::Tuple{T,T} where {T<:Real}
+function scoreFunc(
+    dataset::Dataset{T}, baseline::T, tree::Node, options::Options
+)::Tuple{T,T} where {T<:Real}
     loss = EvalLoss(tree, dataset, options)
     score = lossToScore(loss, baseline, tree, options)
     return score, loss
 end
 
 # Score an equation with a small batch
-function scoreFuncBatch(dataset::Dataset{T}, baseline::T,
-                        tree::Node, options::Options)::Tuple{T,T} where {T<:Real}
+function scoreFuncBatch(
+    dataset::Dataset{T}, baseline::T, tree::Node, options::Options
+)::Tuple{T,T} where {T<:Real}
     batchSize = options.batchSize
-    batch_idx = randperm(dataset.n)[1:options.batchSize]
+    batch_idx = randperm(dataset.n)[1:(options.batchSize)]
     batch_X = dataset.X[:, batch_idx]
     batch_y = dataset.y[batch_idx]
     (prediction, completion) = evalTreeArray(tree, batch_X, options)

--- a/src/MutationFunctions.jl
+++ b/src/MutationFunctions.jl
@@ -18,7 +18,7 @@ function randomNode(tree::Node)::Node
         c = countNodes(tree.r)
     end
 
-    i = rand(1:1+b+c)
+    i = rand(1:(1 + b + c))
     if i <= b
         return randomNode(tree.l)
     elseif i == b + 1
@@ -39,17 +39,15 @@ function mutateOperator(tree::Node, options::Options)::Node
         node = randomNode(tree)
     end
     if node.degree == 1
-        node.op = rand(1:options.nuna)
+        node.op = rand(1:(options.nuna))
     else
-        node.op = rand(1:options.nbin)
+        node.op = rand(1:(options.nbin))
     end
     return tree
 end
 
 # Randomly perturb a constant
-function mutateConstant(
-        tree::Node, temperature::T,
-        options::Options)::Node where {T<:Real}
+function mutateConstant(tree::Node, temperature::T, options::Options)::Node where {T<:Real}
     # T is between 0 and 1.
 
     if countConstants(tree) == 0
@@ -79,29 +77,25 @@ function mutateConstant(
 end
 
 # Add a random unary/binary operation to the end of a tree
-function appendRandomOp(tree::Node, options::Options, nfeatures::Int; makeNewBinOp::Union{Bool,Nothing}=nothing)::Node
+function appendRandomOp(
+    tree::Node, options::Options, nfeatures::Int; makeNewBinOp::Union{Bool,Nothing}=nothing
+)::Node
     node = randomNode(tree)
     while node.degree != 0
         node = randomNode(tree)
     end
 
-
     if makeNewBinOp === nothing
         choice = rand()
-        makeNewBinOp = choice < options.nbin/(options.nuna + options.nbin)
+        makeNewBinOp = choice < options.nbin / (options.nuna + options.nbin)
     end
 
     if makeNewBinOp
         newnode = Node(
-            rand(1:options.nbin),
-            makeRandomLeaf(nfeatures),
-            makeRandomLeaf(nfeatures)
+            rand(1:(options.nbin)), makeRandomLeaf(nfeatures), makeRandomLeaf(nfeatures)
         )
     else
-        newnode = Node(
-            rand(1:options.nuna),
-            makeRandomLeaf(nfeatures)
-        )
+        newnode = Node(rand(1:(options.nuna)), makeRandomLeaf(nfeatures))
     end
 
     if newnode.degree == 2
@@ -121,21 +115,14 @@ end
 function insertRandomOp(tree::Node, options::Options, nfeatures::Int)::Node
     node = randomNode(tree)
     choice = rand()
-    makeNewBinOp = choice < options.nbin/(options.nuna + options.nbin)
+    makeNewBinOp = choice < options.nbin / (options.nuna + options.nbin)
     left = copyNode(node)
 
     if makeNewBinOp
         right = makeRandomLeaf(nfeatures)
-        newnode = Node(
-            rand(1:options.nbin),
-            left,
-            right
-        )
+        newnode = Node(rand(1:(options.nbin)), left, right)
     else
-        newnode = Node(
-            rand(1:options.nuna),
-            left
-        )
+        newnode = Node(rand(1:(options.nuna)), left)
     end
     if newnode.degree == 2
         node.r = newnode.r
@@ -153,21 +140,14 @@ end
 function prependRandomOp(tree::Node, options::Options, nfeatures::Int)::Node
     node = tree
     choice = rand()
-    makeNewBinOp = choice < options.nbin/(options.nuna + options.nbin)
+    makeNewBinOp = choice < options.nbin / (options.nuna + options.nbin)
     left = copyNode(tree)
 
     if makeNewBinOp
         right = makeRandomLeaf(nfeatures)
-        newnode = Node(
-            rand(1:options.nbin),
-            left,
-            right
-        )
+        newnode = Node(rand(1:(options.nbin)), left, right)
     else
-        newnode = Node(
-            rand(1:options.nuna),
-            left
-        )
+        newnode = Node(rand(1:(options.nuna)), left)
     end
     if newnode.degree == 2
         node.r = newnode.r
@@ -189,9 +169,10 @@ function makeRandomLeaf(nfeatures::Int)::Node
     end
 end
 
-
 # Return a random node from the tree with parent, and side ('n' for no parent)
-function randomNodeAndParent(tree::Node, parent::Union{Node, Nothing}; side::Char)::Tuple{Node, Union{Node, Nothing}, Char}
+function randomNodeAndParent(
+    tree::Node, parent::Union{Node,Nothing}; side::Char
+)::Tuple{Node,Union{Node,Nothing},Char}
     if tree.degree == 0
         return tree, parent, side
     end
@@ -205,7 +186,7 @@ function randomNodeAndParent(tree::Node, parent::Union{Node, Nothing}; side::Cha
         c = countNodes(tree.r)
     end
 
-    i = rand(1:1+b+c)
+    i = rand(1:(1 + b + c))
     if i <= b
         return randomNodeAndParent(tree.l, tree; side='l')
     elseif i == b + 1
@@ -215,7 +196,7 @@ function randomNodeAndParent(tree::Node, parent::Union{Node, Nothing}; side::Cha
     return randomNodeAndParent(tree.r, tree; side='r')
 end
 
-function randomNodeAndParent(tree::Node)::Tuple{Node, Union{Node, Nothing}, Char}
+function randomNodeAndParent(tree::Node)::Tuple{Node,Union{Node,Nothing},Char}
     return randomNodeAndParent(tree, nothing; side='n')
 end
 
@@ -270,7 +251,7 @@ end
 function genRandomTree(length::Int, options::Options, nfeatures::Int)::Node
     # Note that this base tree is just a placeholder; it will be replaced.
     tree = Node(convert(CONST_TYPE, 1))
-    for i=1:length
+    for i in 1:length
         # TODO: This can be larger number of nodes than length.
         tree = appendRandomOp(tree, options, nfeatures)
     end
@@ -293,7 +274,7 @@ function genRandomTreeFixedSize(node_count::Int, options::Options, nfeatures::In
 end
 
 """Crossover between two expressions"""
-function crossoverTrees(tree1::Node, tree2::Node)::Tuple{Node, Node}
+function crossoverTrees(tree1::Node, tree2::Node)::Tuple{Node,Node}
     tree1 = copyNode(tree1)
     tree2 = copyNode(tree2)
 

--- a/src/MutationFunctions.jl
+++ b/src/MutationFunctions.jl
@@ -8,7 +8,6 @@ function random_node(tree::Node)::Node
     if tree.degree == 0
         return tree
     end
-    a = count_nodes(tree)
     b = 0
     c = 0
     if tree.degree >= 1
@@ -176,7 +175,6 @@ function random_node_and_parent(
     if tree.degree == 0
         return tree, parent, side
     end
-    a = count_nodes(tree)
     b = 0
     c = 0
     if tree.degree >= 1

--- a/src/MutationFunctions.jl
+++ b/src/MutationFunctions.jl
@@ -1,42 +1,42 @@
 module MutationFunctionsModule
 
-import ..CoreModule: CONST_TYPE, Node, copyNode, Options
-import ..EquationUtilsModule: countNodes, countConstants, countOperators, countDepth
+import ..CoreModule: CONST_TYPE, Node, copy_node, Options
+import ..EquationUtilsModule: count_nodes, count_constants, count_operators, count_depth
 
 # Return a random node from the tree
-function randomNode(tree::Node)::Node
+function random_node(tree::Node)::Node
     if tree.degree == 0
         return tree
     end
-    a = countNodes(tree)
+    a = count_nodes(tree)
     b = 0
     c = 0
     if tree.degree >= 1
-        b = countNodes(tree.l)
+        b = count_nodes(tree.l)
     end
     if tree.degree == 2
-        c = countNodes(tree.r)
+        c = count_nodes(tree.r)
     end
 
     i = rand(1:(1 + b + c))
     if i <= b
-        return randomNode(tree.l)
+        return random_node(tree.l)
     elseif i == b + 1
         return tree
     end
 
-    return randomNode(tree.r)
+    return random_node(tree.r)
 end
 
 # Randomly convert an operator into another one (binary->binary;
 # unary->unary)
-function mutateOperator(tree::Node, options::Options)::Node
-    if countOperators(tree) == 0
+function mutate_operator(tree::Node, options::Options)::Node
+    if count_operators(tree) == 0
         return tree
     end
-    node = randomNode(tree)
+    node = random_node(tree)
     while node.degree == 0
-        node = randomNode(tree)
+        node = random_node(tree)
     end
     if node.degree == 1
         node.op = rand(1:(options.nuna))
@@ -47,15 +47,15 @@ function mutateOperator(tree::Node, options::Options)::Node
 end
 
 # Randomly perturb a constant
-function mutateConstant(tree::Node, temperature::T, options::Options)::Node where {T<:Real}
+function mutate_constant(tree::Node, temperature::T, options::Options)::Node where {T<:Real}
     # T is between 0 and 1.
 
-    if countConstants(tree) == 0
+    if count_constants(tree) == 0
         return tree
     end
-    node = randomNode(tree)
+    node = random_node(tree)
     while node.degree != 0 || node.constant == false
-        node = randomNode(tree)
+        node = random_node(tree)
     end
 
     bottom = convert(T, 1//10)
@@ -77,12 +77,12 @@ function mutateConstant(tree::Node, temperature::T, options::Options)::Node wher
 end
 
 # Add a random unary/binary operation to the end of a tree
-function appendRandomOp(
+function append_random_op(
     tree::Node, options::Options, nfeatures::Int; makeNewBinOp::Union{Bool,Nothing}=nothing
 )::Node
-    node = randomNode(tree)
+    node = random_node(tree)
     while node.degree != 0
-        node = randomNode(tree)
+        node = random_node(tree)
     end
 
     if makeNewBinOp === nothing
@@ -92,10 +92,10 @@ function appendRandomOp(
 
     if makeNewBinOp
         newnode = Node(
-            rand(1:(options.nbin)), makeRandomLeaf(nfeatures), makeRandomLeaf(nfeatures)
+            rand(1:(options.nbin)), make_random_leaf(nfeatures), make_random_leaf(nfeatures)
         )
     else
-        newnode = Node(rand(1:(options.nuna)), makeRandomLeaf(nfeatures))
+        newnode = Node(rand(1:(options.nuna)), make_random_leaf(nfeatures))
     end
 
     if newnode.degree == 2
@@ -112,14 +112,14 @@ function appendRandomOp(
 end
 
 # Insert random node
-function insertRandomOp(tree::Node, options::Options, nfeatures::Int)::Node
-    node = randomNode(tree)
+function insert_random_op(tree::Node, options::Options, nfeatures::Int)::Node
+    node = random_node(tree)
     choice = rand()
     makeNewBinOp = choice < options.nbin / (options.nuna + options.nbin)
-    left = copyNode(node)
+    left = copy_node(node)
 
     if makeNewBinOp
-        right = makeRandomLeaf(nfeatures)
+        right = make_random_leaf(nfeatures)
         newnode = Node(rand(1:(options.nbin)), left, right)
     else
         newnode = Node(rand(1:(options.nuna)), left)
@@ -137,14 +137,14 @@ function insertRandomOp(tree::Node, options::Options, nfeatures::Int)::Node
 end
 
 # Add random node to the top of a tree
-function prependRandomOp(tree::Node, options::Options, nfeatures::Int)::Node
+function prepend_random_op(tree::Node, options::Options, nfeatures::Int)::Node
     node = tree
     choice = rand()
     makeNewBinOp = choice < options.nbin / (options.nuna + options.nbin)
-    left = copyNode(tree)
+    left = copy_node(tree)
 
     if makeNewBinOp
-        right = makeRandomLeaf(nfeatures)
+        right = make_random_leaf(nfeatures)
         newnode = Node(rand(1:(options.nbin)), left, right)
     else
         newnode = Node(rand(1:(options.nuna)), left)
@@ -161,7 +161,7 @@ function prependRandomOp(tree::Node, options::Options, nfeatures::Int)::Node
     return node
 end
 
-function makeRandomLeaf(nfeatures::Int)::Node
+function make_random_leaf(nfeatures::Int)::Node
     if rand() > 0.5
         return Node(randn(CONST_TYPE))
     else
@@ -170,45 +170,45 @@ function makeRandomLeaf(nfeatures::Int)::Node
 end
 
 # Return a random node from the tree with parent, and side ('n' for no parent)
-function randomNodeAndParent(
+function random_node_and_parent(
     tree::Node, parent::Union{Node,Nothing}; side::Char
 )::Tuple{Node,Union{Node,Nothing},Char}
     if tree.degree == 0
         return tree, parent, side
     end
-    a = countNodes(tree)
+    a = count_nodes(tree)
     b = 0
     c = 0
     if tree.degree >= 1
-        b = countNodes(tree.l)
+        b = count_nodes(tree.l)
     end
     if tree.degree == 2
-        c = countNodes(tree.r)
+        c = count_nodes(tree.r)
     end
 
     i = rand(1:(1 + b + c))
     if i <= b
-        return randomNodeAndParent(tree.l, tree; side='l')
+        return random_node_and_parent(tree.l, tree; side='l')
     elseif i == b + 1
         return tree, parent, side
     end
 
-    return randomNodeAndParent(tree.r, tree; side='r')
+    return random_node_and_parent(tree.r, tree; side='r')
 end
 
-function randomNodeAndParent(tree::Node)::Tuple{Node,Union{Node,Nothing},Char}
-    return randomNodeAndParent(tree, nothing; side='n')
+function random_node_and_parent(tree::Node)::Tuple{Node,Union{Node,Nothing},Char}
+    return random_node_and_parent(tree, nothing; side='n')
 end
 
 # Select a random node, and replace it an the subtree
 # with a variable or constant
-function deleteRandomOp(tree::Node, options::Options, nfeatures::Int)::Node
-    node, parent, side = randomNodeAndParent(tree)
+function delete_random_op(tree::Node, options::Options, nfeatures::Int)::Node
+    node, parent, side = random_node_and_parent(tree)
     isroot = (parent === nothing)
 
     if node.degree == 0
         # Replace with new constant
-        newnode = makeRandomLeaf(nfeatures)
+        newnode = make_random_leaf(nfeatures)
         node.degree = newnode.degree
         node.val = newnode.val
         node.constant = newnode.constant
@@ -248,50 +248,50 @@ function deleteRandomOp(tree::Node, options::Options, nfeatures::Int)::Node
 end
 
 # Create a random equation by appending random operators
-function genRandomTree(length::Int, options::Options, nfeatures::Int)::Node
+function gen_random_tree(length::Int, options::Options, nfeatures::Int)::Node
     # Note that this base tree is just a placeholder; it will be replaced.
     tree = Node(convert(CONST_TYPE, 1))
     for i in 1:length
         # TODO: This can be larger number of nodes than length.
-        tree = appendRandomOp(tree, options, nfeatures)
+        tree = append_random_op(tree, options, nfeatures)
     end
     return tree
 end
 
-function genRandomTreeFixedSize(node_count::Int, options::Options, nfeatures::Int)::Node
-    tree = makeRandomLeaf(nfeatures)
-    cur_size = countNodes(tree)
+function gen_random_tree_fixed_size(node_count::Int, options::Options, nfeatures::Int)::Node
+    tree = make_random_leaf(nfeatures)
+    cur_size = count_nodes(tree)
     while cur_size < node_count
         if cur_size == node_count - 1  # only unary operator allowed.
             options.nuna == 0 && break # We will go over the requested amount, so we must break.
-            tree = appendRandomOp(tree, options, nfeatures; makeNewBinOp=false)
+            tree = append_random_op(tree, options, nfeatures; makeNewBinOp=false)
         else
-            tree = appendRandomOp(tree, options, nfeatures)
+            tree = append_random_op(tree, options, nfeatures)
         end
-        cur_size = countNodes(tree)
+        cur_size = count_nodes(tree)
     end
     return tree
 end
 
 """Crossover between two expressions"""
-function crossoverTrees(tree1::Node, tree2::Node)::Tuple{Node,Node}
-    tree1 = copyNode(tree1)
-    tree2 = copyNode(tree2)
+function crossover_trees(tree1::Node, tree2::Node)::Tuple{Node,Node}
+    tree1 = copy_node(tree1)
+    tree2 = copy_node(tree2)
 
-    node1, parent1, side1 = randomNodeAndParent(tree1)
-    node2, parent2, side2 = randomNodeAndParent(tree2)
+    node1, parent1, side1 = random_node_and_parent(tree1)
+    node2, parent2, side2 = random_node_and_parent(tree2)
 
-    node1 = copyNode(node1)
+    node1 = copy_node(node1)
 
     if side1 == 'l'
-        parent1.l = copyNode(node2)
+        parent1.l = copy_node(node2)
         # tree1 now contains this.
     elseif side1 == 'r'
-        parent1.r = copyNode(node2)
+        parent1.r = copy_node(node2)
         # tree1 now contains this.
     else # 'n'
         # This means that there is no parent2.
-        tree1 = copyNode(node2)
+        tree1 = copy_node(node2)
     end
 
     if side2 == 'l'

--- a/src/Operators.jl
+++ b/src/Operators.jl
@@ -1,6 +1,6 @@
 module OperatorsModule
 
-import SpecialFunctions
+using SpecialFunctions: SpecialFunctions
 import SpecialFunctions: erf, erfc
 #TODO - actually add these operators to the module!
 
@@ -13,7 +13,7 @@ function gamma(x::T)::T where {T<:Real}
 end
 gamma(x) = SpecialFunctions.gamma(x)
 
-atanh_clip(x) = atanh(mod(x+1, 2) - 1)
+atanh_clip(x) = atanh(mod(x + 1, 2) - 1)
 
 # Implicitly defined:
 #binary: mod
@@ -22,40 +22,40 @@ atanh_clip(x) = atanh(mod(x+1, 2) - 1)
 # Use some fast operators from https://github.com/JuliaLang/julia/blob/81597635c4ad1e8c2e1c5753fda4ec0e7397543f/base/fastmath.jl
 # Define allowed operators. Any julia operator can also be used.
 function plus(x::T, y::T)::T where {T<:Real}
-	x + y #Do not change the name of this operator.
+    return x + y #Do not change the name of this operator.
 end
 function sub(x::T, y::T)::T where {T<:Real}
-	x - y #Do not change the name of this operator.
+    return x - y #Do not change the name of this operator.
 end
 function mult(x::T, y::T)::T where {T<:Real}
-	x * y #Do not change the name of this operator.
+    return x * y #Do not change the name of this operator.
 end
 function square(x::T)::T where {T<:Real}
-	x * x
+    return x * x
 end
 function cube(x::T)::T where {T<:Real}
-	x ^ 3
+    return x^3
 end
 function pow(x::T, y::T)::T where {T<:Real}
-	abs(x)^y
+    return abs(x)^y
 end
 function div(x::T, y::T)::T where {T<:Real}
-	x / y
+    return x / y
 end
 function log_abs(x::T)::T where {T<:Real}
-    log(abs(x) + convert(T, 1//100000000))
+    return log(abs(x) + convert(T, 1//100000000))
 end
 function log2_abs(x::T)::T where {T<:Real}
-    log2(abs(x) + convert(T, 1//100000000))
+    return log2(abs(x) + convert(T, 1//100000000))
 end
 function log10_abs(x::T)::T where {T<:Real}
-    log10(abs(x) + convert(T, 1//100000000))
+    return log10(abs(x) + convert(T, 1//100000000))
 end
 function log1p_abs(x::T)::T where {T<:Real}
-    log(abs(x) + convert(T, 1))
+    return log(abs(x) + convert(T, 1))
 end
 function acosh_abs(x::T)::T where {T<:Real}
-    acosh(abs(x) + convert(T, 1))
+    return acosh(abs(x) + convert(T, 1))
 end
 
 # Generics:
@@ -73,10 +73,10 @@ log1p_abs(x) = log(abs(x) + 1)
 acosh_abs(x) = acosh(abs(x) + 1)
 
 function sqrt_abs(x::T)::T where {T}
-	sqrt(abs(x))
+    return sqrt(abs(x))
 end
 function neg(x::T)::T where {T}
-	- x
+    return -x
 end
 
 function greater(x::T, y::T)::T where {T}

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -459,11 +459,12 @@ function Options(;
             continue
         end
         @eval begin
-            Base.$_f(l::Node, r::Node)::Node = if (l.constant && r.constant)
-                Node($f(l.val, r.val)::AbstractFloat)
-            else
-                Node($op, l, r)
-            end
+            Base.$_f(l::Node, r::Node)::Node =
+                if (l.constant && r.constant)
+                    Node($f(l.val, r.val)::AbstractFloat)
+                else
+                    Node($op, l, r)
+                end
             Base.$_f(l::Node, r::AbstractFloat)::Node =
                 l.constant ? Node($f(l.val, r)::AbstractFloat) : Node($op, l, r)
             Base.$_f(l::AbstractFloat, r::Node)::Node =

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -6,7 +6,19 @@ import Zygote: gradient
 #TODO - eventually move some of these
 # into the SR call itself, rather than
 # passing huge options at once.
-import ..OperatorsModule: plus, pow, mult, sub, div, log_abs, log10_abs, log2_abs, log1p_abs, sqrt_abs, acosh_abs, atanh_clip
+import ..OperatorsModule:
+    plus,
+    pow,
+    mult,
+    sub,
+    div,
+    log_abs,
+    log10_abs,
+    log2_abs,
+    log1p_abs,
+    sqrt_abs,
+    acosh_abs,
+    atanh_clip
 import ..EquationModule: Node, stringTree
 import ..OptionsStructModule: Options
 
@@ -16,9 +28,9 @@ import ..OptionsStructModule: Options
 
 Build constraints on operator-level complexity from a user-passed dict.
 """
-function build_constraints(una_constraints, bin_constraints,
-                           unary_operators, binary_operators,
-                           nuna, nbin)::Tuple{Array{Int, 1}, Array{Tuple{Int,Int}, 1}}
+function build_constraints(
+    una_constraints, bin_constraints, unary_operators, binary_operators, nuna, nbin
+)::Tuple{Array{Int,1},Array{Tuple{Int,Int},1}}
     # Expect format ((*)=>(-1, 3)), etc.
     # TODO: Need to disable simplification if (*, -, +, /) are constrained?
     #  Or, just quit simplification is constraints violated.
@@ -34,7 +46,7 @@ function build_constraints(una_constraints, bin_constraints,
     end
 
     if una_constraints === nothing
-        una_constraints = [-1 for i=1:nuna]
+        una_constraints = [-1 for i in 1:nuna]
     elseif !is_una_constraints_already_done
         una_constraints::Dict
         _una_constraints = Int[]
@@ -50,7 +62,7 @@ function build_constraints(una_constraints, bin_constraints,
         una_constraints = _una_constraints
     end
     if bin_constraints === nothing
-        bin_constraints = [(-1, -1) for i=1:nbin]
+        bin_constraints = [(-1, -1) for i in 1:nbin]
     elseif !is_bin_constraints_already_done
         bin_constraints::Dict
         _bin_constraints = Tuple{Int,Int}[]
@@ -102,7 +114,6 @@ function unaopmap(op)
     end
     return op
 end
-
 
 """
     Options(;kws...)
@@ -235,8 +246,8 @@ https://github.com/MilesCranmer/PySR/discussions/115.
     For binary operators, both arguments are treated the same way, and the max of each argument is constrained.
 """
 function Options(;
-    binary_operators::NTuple{nbin, Any}=(+, -, /, *),
-    unary_operators::NTuple{nuna, Any}=(),
+    binary_operators::NTuple{nbin,Any}=(+, -, /, *),
+    unary_operators::NTuple{nuna,Any}=(),
     constraints=nothing,
     loss=L2DistLoss(),
     ns=12, #1 sampled from every ns per mutation
@@ -258,7 +269,7 @@ function Options(;
     batchSize=50,
     mutationWeights=[0.048, 0.47, 0.79, 5.1, 1.7, 0.0020, 0.00023, 0.21],
     crossoverProbability=0.066f0,
-    warmupMaxsizeBy=0f0,
+    warmupMaxsizeBy=0.0f0,
     useFrequency=true,
     useFrequencyInTournament=true,
     npop=33,
@@ -279,16 +290,17 @@ function Options(;
     recorder=nothing,
     recorder_file="pysr_recorder.json",
     probPickFirst=0.86f0,
-    earlyStopCondition::Union{Function, AbstractFloat, Nothing}=nothing,
+    earlyStopCondition::Union{Function,AbstractFloat,Nothing}=nothing,
     stateReturn::Bool=false,
     timeout_in_seconds=nothing,
     skip_mutation_failures::Bool=true,
     enable_autodiff::Bool=false,
     nested_constraints=nothing,
-   ) where {nuna,nbin}
-
+) where {nuna,nbin}
     if warmupMaxsize !== nothing
-        error("warmupMaxsize is deprecated. Please use warmupMaxsizeBy, and give the time at which the warmup will end as a fraction of the total search cycles.")
+        error(
+            "warmupMaxsize is deprecated. Please use warmupMaxsizeBy, and give the time at which the warmup will end as a fraction of the total search cycles.",
+        )
     end
 
     if hofFile === nothing
@@ -296,28 +308,31 @@ function Options(;
     end
 
     @assert maxsize > 3
-    @assert warmupMaxsizeBy >= 0f0
+    @assert warmupMaxsizeBy >= 0.0f0
 
     # Make sure nested_constraints contains functions within our operator set:
     if nested_constraints !== nothing
         # Check that intersection of binary operators and unary operators is empty:
-        for op ∈ binary_operators
+        for op in binary_operators
             if op ∈ unary_operators
-                error("Operator " + op + " is both a binary and unary operator. You can't use nested constraints.")
+                error(
+                    "Operator " +
+                    op +
+                    " is both a binary and unary operator. You can't use nested constraints.",
+                )
             end
         end
 
         # Convert to dict:
         if !(typeof(nested_constraints) <: Dict)
             # Convert to dict:
-            nested_constraints = Dict([
-                cons[1] => Dict(cons[2]...)
-                for cons in nested_constraints
-            ]...)
+            nested_constraints = Dict(
+                [cons[1] => Dict(cons[2]...) for cons in nested_constraints]...
+            )
         end
-        for (op, nested_constraint) ∈ nested_constraints
+        for (op, nested_constraint) in nested_constraints
             @assert op ∈ binary_operators || op ∈ unary_operators
-            for (nested_op, max_nesting) ∈ nested_constraint
+            for (nested_op, max_nesting) in nested_constraint
                 @assert nested_op ∈ binary_operators || nested_op ∈ unary_operators
                 @assert max_nesting >= -1 && typeof(max_nesting) <: Int
             end
@@ -326,7 +341,7 @@ function Options(;
         # Lastly, we clean it up into a dict of (degree,op_idx) => max_nesting.
         new_nested_constraints = []
         # Dict()
-        for (op, nested_constraint) ∈ nested_constraints
+        for (op, nested_constraint) in nested_constraints
             (degree, idx) = if op ∈ binary_operators
                 2, findfirst(isequal(op), binary_operators)
             else
@@ -334,7 +349,7 @@ function Options(;
             end
             new_max_nesting_dict = []
             # Dict()
-            for (nested_op, max_nesting) ∈ nested_constraint
+            for (nested_op, max_nesting) in nested_constraint
                 (nested_degree, nested_idx) = if nested_op ∈ binary_operators
                     2, findfirst(isequal(nested_op), binary_operators)
                 else
@@ -348,7 +363,6 @@ function Options(;
         end
         nested_constraints = new_nested_constraints
     end
-
 
     if typeof(constraints) <: Tuple
         constraints = collect(constraints)
@@ -367,9 +381,9 @@ function Options(;
         una_constraints = constraints
     end
 
-    una_constraints, bin_constraints = build_constraints(una_constraints, bin_constraints,
-                                                         unary_operators, binary_operators,
-                                                         nuna, nbin)
+    una_constraints, bin_constraints = build_constraints(
+        una_constraints, bin_constraints, unary_operators, binary_operators, nuna, nbin
+    )
 
     if maxdepth === nothing
         maxdepth = maxsize
@@ -386,16 +400,16 @@ function Options(;
         diff_binary_operators = Any[]
         diff_unary_operators = Any[]
 
-        test_inputs = map(x->convert(Float32, x), LinRange(-100, 100, 99))
+        test_inputs = map(x -> convert(Float32, x), LinRange(-100, 100, 99))
         # Create grid over [-100, 100]^2:
-        test_inputs_xy = reduce(hcat, reduce(hcat, (
-            [[[x, y] for x ∈ test_inputs] for y ∈ test_inputs]
-        )))
-        for op ∈ binary_operators
+        test_inputs_xy = reduce(
+            hcat, reduce(hcat, ([[[x, y] for x in test_inputs] for y in test_inputs]))
+        )
+        for op in binary_operators
             diff_op(x, y) = gradient(op, x, y)
-            
+
             test_output = diff_op.(test_inputs_xy[1, :], test_inputs_xy[2, :])
-            gradient_exists = all((x) -> x!==nothing, Iterators.flatten(test_output))
+            gradient_exists = all((x) -> x !== nothing, Iterators.flatten(test_output))
             if gradient_exists
                 push!(diff_binary_operators, diff_op)
             else
@@ -407,10 +421,10 @@ function Options(;
             end
         end
 
-        for op ∈ unary_operators
+        for op in unary_operators
             diff_op(x) = gradient(op, x)[1]
             test_output = diff_op.(test_inputs)
-            gradient_exists = all((x) -> x!==nothing, test_output)
+            gradient_exists = all((x) -> x !== nothing, test_output)
             if gradient_exists
                 push!(diff_unary_operators, diff_op)
             else
@@ -430,8 +444,7 @@ function Options(;
         diff_unary_operators = nothing
     end
 
-
-    mutationWeights = map((x,)->convert(Float64, x), mutationWeights)
+    mutationWeights = map((x,) -> convert(Float64, x), mutationWeights)
     if length(mutationWeights) != 8
         error("Not the right number of mutation probabilities given")
     end
@@ -446,9 +459,15 @@ function Options(;
             continue
         end
         @eval begin
-            Base.$_f(l::Node, r::Node)::Node = (l.constant && r.constant) ? Node($f(l.val, r.val)::AbstractFloat) : Node($op, l, r)
-            Base.$_f(l::Node, r::AbstractFloat)::Node =        l.constant ? Node($f(l.val, r)::AbstractFloat)     : Node($op, l, r)
-            Base.$_f(l::AbstractFloat, r::Node)::Node =        r.constant ? Node($f(l, r.val)::AbstractFloat)     : Node($op, l, r)
+            Base.$_f(l::Node, r::Node)::Node = if (l.constant && r.constant)
+                Node($f(l.val, r.val)::AbstractFloat)
+            else
+                Node($op, l, r)
+            end
+            Base.$_f(l::Node, r::AbstractFloat)::Node =
+                l.constant ? Node($f(l.val, r)::AbstractFloat) : Node($op, l, r)
+            Base.$_f(l::AbstractFloat, r::Node)::Node =
+                r.constant ? Node($f(l, r.val)::AbstractFloat) : Node($op, l, r)
         end
     end
 
@@ -458,7 +477,8 @@ function Options(;
             continue
         end
         @eval begin
-            Base.$f(l::Node)::Node = l.constant ? Node($f(l.val)::AbstractFloat) : Node($op, l)
+            Base.$f(l::Node)::Node =
+                l.constant ? Node($f(l.val)::AbstractFloat) : Node($op, l)
         end
     end
 
@@ -476,15 +496,73 @@ function Options(;
         earlyStopCondition = (loss, complexity) -> loss < stopping_point
     end
 
-    options = Options{typeof(binary_operators),typeof(unary_operators), typeof(diff_binary_operators), typeof(diff_unary_operators), typeof(loss)}(binary_operators, unary_operators, diff_binary_operators, diff_unary_operators, bin_constraints, una_constraints, ns, parsimony, alpha, maxsize, maxdepth, fast_cycle, migration, hofMigration, fractionReplacedHof, shouldOptimizeConstants, hofFile, npopulations, perturbationFactor, annealing, batching, batchSize, mutationWeights, crossoverProbability, warmupMaxsizeBy, useFrequency, useFrequencyInTournament, npop, ncyclesperiteration, fractionReplaced, topn, verbosity, probNegate, nuna, nbin, seed, loss, progress, terminal_width, optimizer_algorithm, optimize_probability, optimizer_nrestarts, optimizer_iterations, recorder, recorder_file, probPickFirst, earlyStopCondition, stateReturn, timeout_in_seconds, skip_mutation_failures, enable_autodiff, nested_constraints)
+    options = Options{
+        typeof(binary_operators),
+        typeof(unary_operators),
+        typeof(diff_binary_operators),
+        typeof(diff_unary_operators),
+        typeof(loss),
+    }(
+        binary_operators,
+        unary_operators,
+        diff_binary_operators,
+        diff_unary_operators,
+        bin_constraints,
+        una_constraints,
+        ns,
+        parsimony,
+        alpha,
+        maxsize,
+        maxdepth,
+        fast_cycle,
+        migration,
+        hofMigration,
+        fractionReplacedHof,
+        shouldOptimizeConstants,
+        hofFile,
+        npopulations,
+        perturbationFactor,
+        annealing,
+        batching,
+        batchSize,
+        mutationWeights,
+        crossoverProbability,
+        warmupMaxsizeBy,
+        useFrequency,
+        useFrequencyInTournament,
+        npop,
+        ncyclesperiteration,
+        fractionReplaced,
+        topn,
+        verbosity,
+        probNegate,
+        nuna,
+        nbin,
+        seed,
+        loss,
+        progress,
+        terminal_width,
+        optimizer_algorithm,
+        optimize_probability,
+        optimizer_nrestarts,
+        optimizer_iterations,
+        recorder,
+        recorder_file,
+        probPickFirst,
+        earlyStopCondition,
+        stateReturn,
+        timeout_in_seconds,
+        skip_mutation_failures,
+        enable_autodiff,
+        nested_constraints,
+    )
 
     @eval begin
         Base.print(io::IO, tree::Node) = print(io, stringTree(tree, $options))
         Base.show(io::IO, tree::Node) = print(io, stringTree(tree, $options))
     end
-    
+
     return options
 end
-
 
 end

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -19,7 +19,7 @@ import ..OperatorsModule:
     sqrt_abs,
     acosh_abs,
     atanh_clip
-import ..EquationModule: Node, stringTree
+import ..EquationModule: Node, string_tree
 import ..OptionsStructModule: Options
 
 """
@@ -558,8 +558,8 @@ function Options(;
     )
 
     @eval begin
-        Base.print(io::IO, tree::Node) = print(io, stringTree(tree, $options))
-        Base.show(io::IO, tree::Node) = print(io, stringTree(tree, $options))
+        Base.print(io::IO, tree::Node) = print(io, string_tree(tree, $options))
+        Base.show(io::IO, tree::Node) = print(io, string_tree(tree, $options))
     end
 
     return options

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -3,7 +3,6 @@ module OptionsStructModule
 import LossFunctions: SupervisedLoss
 
 struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
-
     binops::A
     unaops::B
     diff_binops::dA
@@ -26,7 +25,7 @@ struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
     annealing::Bool
     batching::Bool
     batchSize::Int
-    mutationWeights::Array{Float64, 1}
+    mutationWeights::Array{Float64,1}
     crossoverProbability::Float32
     warmupMaxsizeBy::Float32
     useFrequency::Bool
@@ -39,10 +38,10 @@ struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
     probNegate::Float32
     nuna::Int
     nbin::Int
-    seed::Union{Int, Nothing}
+    seed::Union{Int,Nothing}
     loss::C
     progress::Bool
-    terminal_width::Union{Int, Nothing}
+    terminal_width::Union{Int,Nothing}
     optimizer_algorithm::String
     optimize_probability::Float32
     optimizer_nrestarts::Int
@@ -50,16 +49,18 @@ struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
     recorder::Bool
     recorder_file::String
     probPickFirst::Float32
-    earlyStopCondition::Union{Function, Nothing}
+    earlyStopCondition::Union{Function,Nothing}
     stateReturn::Bool
-    timeout_in_seconds::Union{Float64, Nothing}
+    timeout_in_seconds::Union{Float64,Nothing}
     skip_mutation_failures::Bool
     enable_autodiff::Bool
     nested_constraints::Union{Vector{Tuple{Int,Int,Vector{Tuple{Int,Int,Int}}}},Nothing}
-
 end
 
-Base.print(io::IO, options::Options) = print(io, """Options(
+function Base.print(io::IO, options::Options)
+    return print(
+        io,
+        """Options(
 # Operators:
     binops=$(options.binops), unaops=$(options.unaops),
 # Loss:
@@ -84,7 +85,9 @@ Base.print(io::IO, options::Options) = print(io, """Options(
     hofFile=$(options.hofFile), verbosity=$(options.verbosity), seed=$(options.seed), progress=$(options.progress),
 # Early Exit:
     earlyStopCondition=$(options.earlyStopCondition), timeout_in_seconds=$(options.timeout_in_seconds),
-)""")
+)""",
+    )
+end
 Base.show(io::IO, options::Options) = Base.print(io, options)
 
 end

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -31,7 +31,7 @@ function PopMember(t::Node, score::T, loss::T; ref::Int=-1, parent::Int=-1) wher
     if ref == -1
         ref = abs(rand(Int))
     end
-    PopMember{T}(t, score, loss, getTime(), ref, parent)
+    return PopMember{T}(t, score, loss, getTime(), ref, parent)
 end
 
 """
@@ -48,11 +48,11 @@ Automatically compute the score for this tree.
 - `t::Node`: The tree for the population member.
 - `options::Options`: What options to use.
 """
-function PopMember(dataset::Dataset{T},
-                   baseline::T, t::Node,
-                   options::Options; ref::Int=-1, parent::Int=-1) where {T<:Real}
+function PopMember(
+    dataset::Dataset{T}, baseline::T, t::Node, options::Options; ref::Int=-1, parent::Int=-1
+) where {T<:Real}
     score, loss = scoreFunc(dataset, baseline, t, options)
-    PopMember(t, score, loss, ref=ref, parent=parent)
+    return PopMember(t, score, loss; ref=ref, parent=parent)
 end
 
 function copyPopMember(p::PopMember{T}) where {T<:Real}

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -1,8 +1,8 @@
 module PopMemberModule
 
-import ..CoreModule: Options, Dataset, Node, copyNode
-import ..UtilsModule: getTime
-import ..LossFunctionsModule: scoreFunc
+import ..CoreModule: Options, Dataset, Node, copy_node
+import ..UtilsModule: get_time
+import ..LossFunctionsModule: score_func
 
 # Define a member of population by equation, score, and age
 mutable struct PopMember{T<:Real}
@@ -31,7 +31,7 @@ function PopMember(t::Node, score::T, loss::T; ref::Int=-1, parent::Int=-1) wher
     if ref == -1
         ref = abs(rand(Int))
     end
-    return PopMember{T}(t, score, loss, getTime(), ref, parent)
+    return PopMember{T}(t, score, loss, get_time(), ref, parent)
 end
 
 """
@@ -51,12 +51,12 @@ Automatically compute the score for this tree.
 function PopMember(
     dataset::Dataset{T}, baseline::T, t::Node, options::Options; ref::Int=-1, parent::Int=-1
 ) where {T<:Real}
-    score, loss = scoreFunc(dataset, baseline, t, options)
+    score, loss = score_func(dataset, baseline, t, options)
     return PopMember(t, score, loss; ref=ref, parent=parent)
 end
 
-function copyPopMember(p::PopMember{T}) where {T<:Real}
-    tree = copyNode(p.tree)
+function copy_pop_member(p::PopMember{T}) where {T<:Real}
+    tree = copy_node(p.tree)
     score = copy(p.score)
     loss = copy(p.loss)
     birth = copy(p.birth)

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -1,10 +1,10 @@
 module PopulationModule
 
 import Random: randperm
-import ..CoreModule: Options, Dataset, RecordType, stringTree
-import ..EquationUtilsModule: countNodes
-import ..LossFunctionsModule: scoreFunc
-import ..MutationFunctionsModule: genRandomTree
+import ..CoreModule: Options, Dataset, RecordType, string_tree
+import ..EquationUtilsModule: count_nodes
+import ..LossFunctionsModule: score_func
+import ..MutationFunctionsModule: gen_random_tree
 import ..PopMemberModule: PopMember
 # A list of members of the population, with easy constructors,
 #  which allow for random generation of new populations
@@ -36,7 +36,7 @@ function Population(
     return Population(
         [
             PopMember(
-                dataset, baseline, genRandomTree(nlength, options, nfeatures), options
+                dataset, baseline, gen_random_tree(nlength, options, nfeatures), options
             ) for i in 1:npop
         ],
         npop,
@@ -64,16 +64,16 @@ function Population(
 end
 
 # Sample 10 random members of the population, and make a new one
-function samplePop(pop::Population, options::Options)::Population
+function sample_pop(pop::Population, options::Options)::Population
     idx = randperm(pop.n)[1:(options.ns)]
     return Population(pop.members[idx])
 end
 
 # Sample the population, and get the best member from that sample
-function bestOfSample(
+function best_of_sample(
     pop::Population, frequencyComplexity::AbstractVector{T}, options::Options
 )::PopMember where {T<:Real}
-    sample = samplePop(pop, options)
+    sample = sample_pop(pop, options)
 
     if options.useFrequencyInTournament
         # Score based on frequency of that size occuring.
@@ -84,7 +84,7 @@ function bestOfSample(
         scores = [
             sample.members[member].score * exp(
                 frequency_scaling *
-                frequencyComplexity[countNodes(sample.members[member].tree)],
+                frequencyComplexity[count_nodes(sample.members[member].tree)],
             ) for member in 1:(options.ns)
         ]
     else
@@ -116,13 +116,13 @@ function bestOfSample(
     return sample.members[chosen_idx]
 end
 
-function finalizeScores(
+function finalize_scores(
     dataset::Dataset{T}, baseline::T, pop::Population, options::Options
 )::Population where {T<:Real}
     need_recalculate = options.batching
     if need_recalculate
         @inbounds @simd for member in 1:(pop.n)
-            score, loss = scoreFunc(dataset, baseline, pop.members[member].tree, options)
+            score, loss = score_func(dataset, baseline, pop.members[member].tree, options)
             pop.members[member].score = score
             pop.members[member].loss = loss
         end
@@ -131,7 +131,7 @@ function finalizeScores(
 end
 
 # Return best 10 examples
-function bestSubPop(pop::Population; topn::Int=10)::Population
+function best_sub_pop(pop::Population; topn::Int=10)::Population
     best_idx = sortperm([pop.members[member].score for member in 1:(pop.n)])
     return Population(pop.members[best_idx[1:topn]])
 end
@@ -140,10 +140,10 @@ function record_population(pop::Population{T}, options::Options)::RecordType whe
     return RecordType(
         "population" => [
             RecordType(
-                "tree" => stringTree(member.tree, options),
+                "tree" => string_tree(member.tree, options),
                 "loss" => member.loss,
                 "score" => member.score,
-                "complexity" => countNodes(member.tree),
+                "complexity" => count_nodes(member.tree),
                 "birth" => member.birth,
                 "ref" => member.ref,
                 "parent" => member.parent,

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -9,7 +9,7 @@ import ..PopMemberModule: PopMember
 # A list of members of the population, with easy constructors,
 #  which allow for random generation of new populations
 mutable struct Population{T<:Real}
-    members::Array{PopMember{T}, 1}
+    members::Array{PopMember{T},1}
     n::Int
 end
 """
@@ -17,7 +17,7 @@ end
 
 Create population from list of PopMembers.
 """
-Population(pop::Array{PopMember{T}, 1}) where {T<:Real} = Population{T}(pop, size(pop, 1))
+Population(pop::Array{PopMember{T},1}) where {T<:Real} = Population{T}(pop, size(pop, 1))
 """
     Population(dataset::Dataset{T}, baseline::T;
                npop::Int, nlength::Int=3, options::Options,
@@ -25,10 +25,23 @@ Population(pop::Array{PopMember{T}, 1}) where {T<:Real} = Population{T}(pop, siz
 
 Create random population and score them on the dataset.
 """
-Population(dataset::Dataset{T}, baseline::T;
-           npop::Int, nlength::Int=3,
-           options::Options,
-           nfeatures::Int) where {T<:Real} = Population([PopMember(dataset, baseline, genRandomTree(nlength, options, nfeatures), options) for i=1:npop], npop)
+function Population(
+    dataset::Dataset{T},
+    baseline::T;
+    npop::Int,
+    nlength::Int=3,
+    options::Options,
+    nfeatures::Int,
+) where {T<:Real}
+    return Population(
+        [
+            PopMember(
+                dataset, baseline, genRandomTree(nlength, options, nfeatures), options
+            ) for i in 1:npop
+        ],
+        npop,
+    )
+end
 """
     Population(X::AbstractMatrix{T}, y::AbstractVector{T},
                baseline::T; npop::Int, nlength::Int=3,
@@ -36,33 +49,46 @@ Population(dataset::Dataset{T}, baseline::T;
 
 Create random population and score them on the dataset.
 """
-Population(X::AbstractMatrix{T}, y::AbstractVector{T}, baseline::T;
-           npop::Int, nlength::Int=3,
-           options::Options,
-           nfeatures::Int) where {T<:Real} = Population(Dataset(X, y), baseline, npop=npop, options=options, nfeatures=nfeatures)
+function Population(
+    X::AbstractMatrix{T},
+    y::AbstractVector{T},
+    baseline::T;
+    npop::Int,
+    nlength::Int=3,
+    options::Options,
+    nfeatures::Int,
+) where {T<:Real}
+    return Population(
+        Dataset(X, y), baseline; npop=npop, options=options, nfeatures=nfeatures
+    )
+end
 
 # Sample 10 random members of the population, and make a new one
 function samplePop(pop::Population, options::Options)::Population
-    idx = randperm(pop.n)[1:options.ns]
+    idx = randperm(pop.n)[1:(options.ns)]
     return Population(pop.members[idx])
 end
 
 # Sample the population, and get the best member from that sample
-function bestOfSample(pop::Population, frequencyComplexity::AbstractVector{T}, options::Options)::PopMember where {T<:Real}
+function bestOfSample(
+    pop::Population, frequencyComplexity::AbstractVector{T}, options::Options
+)::PopMember where {T<:Real}
     sample = samplePop(pop, options)
 
     if options.useFrequencyInTournament
         # Score based on frequency of that size occuring.
         # In the end, all sizes should be just as common in the population.
-        frequency_scaling = 20 
+        frequency_scaling = 20
         # e.g., for 100% occupied at one size, exp(-20*1) = 2.061153622438558e-9; which seems like a good punishment for dominating the population.
 
         scores = [
-            sample.members[member].score * exp(frequency_scaling * frequencyComplexity[countNodes(sample.members[member].tree)])
-            for member=1:options.ns
+            sample.members[member].score * exp(
+                frequency_scaling *
+                frequencyComplexity[countNodes(sample.members[member].tree)],
+            ) for member in 1:(options.ns)
         ]
     else
-        scores = [sample.members[member].score for member=1:options.ns]
+        scores = [sample.members[member].score for member in 1:(options.ns)]
     end
 
     p = options.probPickFirst
@@ -78,7 +104,7 @@ function bestOfSample(pop::Population, frequencyComplexity::AbstractVector{T}, o
         prob_each /= sum(prob_each)
         cumprob = cumsum(prob_each)
         raw_chosen_idx = findfirst(cumprob .> rand())
-        
+
         # Sometimes, due to precision issues, we might have cumprob[end] < 1,
         # so we must check for nothing returned:
         if raw_chosen_idx === nothing
@@ -90,15 +116,13 @@ function bestOfSample(pop::Population, frequencyComplexity::AbstractVector{T}, o
     return sample.members[chosen_idx]
 end
 
-function finalizeScores(dataset::Dataset{T},
-                        baseline::T, pop::Population,
-                        options::Options)::Population where {T<:Real}
+function finalizeScores(
+    dataset::Dataset{T}, baseline::T, pop::Population, options::Options
+)::Population where {T<:Real}
     need_recalculate = options.batching
     if need_recalculate
-        @inbounds @simd for member=1:pop.n
-            score, loss = scoreFunc(dataset, baseline,
-                                    pop.members[member].tree,
-                                    options)
+        @inbounds @simd for member in 1:(pop.n)
+            score, loss = scoreFunc(dataset, baseline, pop.members[member].tree, options)
             pop.members[member].score = score
             pop.members[member].loss = loss
         end
@@ -108,21 +132,24 @@ end
 
 # Return best 10 examples
 function bestSubPop(pop::Population; topn::Int=10)::Population
-    best_idx = sortperm([pop.members[member].score for member=1:pop.n])
+    best_idx = sortperm([pop.members[member].score for member in 1:(pop.n)])
     return Population(pop.members[best_idx[1:topn]])
 end
 
-
 function record_population(pop::Population{T}, options::Options)::RecordType where {T<:Real}
-    RecordType("population"=>[RecordType("tree"=>stringTree(member.tree, options),
-                                         "loss"=>member.loss,
-                                         "score"=>member.score,
-                                         "complexity"=>countNodes(member.tree),
-                                         "birth"=>member.birth,
-                                         "ref"=>member.ref,
-                                         "parent"=>member.parent)
-                             for member in pop.members],
-               "time"=>time()
+    return RecordType(
+        "population" => [
+            RecordType(
+                "tree" => stringTree(member.tree, options),
+                "loss" => member.loss,
+                "score" => member.score,
+                "complexity" => countNodes(member.tree),
+                "birth" => member.birth,
+                "ref" => member.ref,
+                "parent" => member.parent,
+            ) for member in pop.members
+        ],
+        "time" => time(),
     )
 end
 

--- a/src/ProgramConstants.jl
+++ b/src/ProgramConstants.jl
@@ -4,7 +4,7 @@ const MAX_DEGREE = 2
 const CONST_TYPE = Float32
 const BATCH_DIM = 2
 const FEATURE_DIM = 1
-const RecordType = Dict{String, Any}
+const RecordType = Dict{String,Any}
 
 """Enum for concurrency type (to get function specialization)"""
 abstract type SRConcurrency end

--- a/src/ProgressBars.jl
+++ b/src/ProgressBars.jl
@@ -12,15 +12,9 @@ Usage:
 
 import Printf: @sprintf
 
-EIGHTS = Dict(0 => ' ',
-              1 => '▏',
-              2 => '▎',
-              3 => '▍',
-              4 => '▌',
-              5 => '▋',
-              6 => '▊',
-              7 => '▉',
-              8 => '█')
+EIGHTS = Dict(
+    0 => ' ', 1 => '▏', 2 => '▎', 3 => '▍', 4 => '▌', 5 => '▋', 6 => '▊', 7 => '▉', 8 => '█'
+)
 
 # Split this because UTF-8 indexing is horrible otherwise
 # IDLE = collect("◢◤ ")
@@ -50,7 +44,7 @@ mutable struct ProgressBar
     multilinepostfix::AbstractString
     mutex::Threads.SpinLock
 
-    function ProgressBar(wrapped::Any; total::Int = -2, width = nothing, leave=true)
+    function ProgressBar(wrapped::Any; total::Int=-2, width=nothing, leave=true)
         this = new()
         this.wrapped = wrapped
         if width === nothing
@@ -71,11 +65,10 @@ mutable struct ProgressBar
         this.mutex = Threads.SpinLock()
         this.current = 0
 
-
         if total == -2  # No total given
             try
                 this.total = length(wrapped)
-            catch 
+            catch
                 this.total = -1
             end
         else
@@ -91,17 +84,17 @@ tqdm = ProgressBar
 
 function format_time(seconds)
     if isfinite(seconds)
-        mins,s  = divrem(round(Int, seconds), 60)
-        h, m    = divrem(mins, 60)
+        mins, s = divrem(round(Int, seconds), 60)
+        h, m = divrem(mins, 60)
     else
         h = 0
         m = Inf
         s = Inf
     end
-    if h!=0
-        return @sprintf("%02d:%02d:%02d",h,m,s)
+    if h != 0
+        return @sprintf("%02d:%02d:%02d", h, m, s)
     else
-        return @sprintf("%02d:%02d",m,s)
+        return @sprintf("%02d:%02d", m, s)
     end
 end
 
@@ -122,17 +115,15 @@ function display_progress(t::ProgressBar)
     postfix_string = postfix_repr(t.postfix)
 
     # Reset Cursor to beginning of the line
-    for line in 1:t.extra_lines
+    for line in 1:(t.extra_lines)
         move_up_1_line()
     end
     go_to_start_of_line()
-
 
     if t.description != ""
         barwidth -= length(t.description) + 1
         print(t.description * " ")
     end
-
 
     if (t.total <= 0)
         status_string = "$(t.current)it $elapsed [$iterations_per_second$postfix_string]"
@@ -146,11 +137,11 @@ function display_progress(t::ProgressBar)
         print("┫ ")
         print(status_string)
     else
-        ETA = (t.total-t.current) / speed
+        ETA = (t.total - t.current) / speed
 
-        percentage_string = string(@sprintf("%.1f%%",t.current/t.total*100))
+        percentage_string = string(@sprintf("%.1f%%", t.current / t.total * 100))
 
-        eta     = format_time(ETA)
+        eta = format_time(ETA)
         status_string = "$(t.current)/$(t.total) [$elapsed<$eta, $iterations_per_second$postfix_string]"
 
         barwidth -= length(status_string) + length(percentage_string) + 1
@@ -177,9 +168,8 @@ function display_progress(t::ProgressBar)
     t.last_extra_lines = t.extra_lines
     t.extra_lines = ceil(Int, length(multiline_postfix_string) / t.width) + 1
     print(multiline_postfix_string)
-    println() #Newline is required for Python to read in.
+    return println() #Newline is required for Python to read in.
 end
-
 
 erase_to_end_of_line() = print("\033[K")
 move_up_1_line() = print("\033[1A")
@@ -202,7 +192,7 @@ function clear_progress(t::ProgressBar)
         erase_line()
         move_up_1_line()
     end
-    erase_line()
+    return erase_line()
 end
 
 function set_multiline_postfix(t::ProgressBar, postfix::AbstractString)
@@ -210,7 +200,7 @@ function set_multiline_postfix(t::ProgressBar, postfix::AbstractString)
     if mistakenly_used_newline_at_start
         postfix = postfix[2:end]
     end
-    t.multilinepostfix = postfix
+    return t.multilinepostfix = postfix
 end
 
 function postfix_repr(postfix::NamedTuple)::AbstractString
@@ -228,17 +218,17 @@ function Base.iterate(iter::ProgressBar)
     return iterate(iter.wrapped)
 end
 
-function Base.iterate(iter::ProgressBar,s)
+function Base.iterate(iter::ProgressBar, s)
     if displaysize(stdout)[2] != iter.width && !iter.fixwidth
         iter.width = displaysize(stdout)[2]
         print("\n"^(iter.extra_lines + 2))
     end
     iter.current += 1
-    if(time_ns() - iter.last_print > PRINTING_DELAY)
+    if (time_ns() - iter.last_print > PRINTING_DELAY)
         display_progress(iter)
         iter.last_print = time_ns()
     end
-    state = iterate(iter.wrapped,s)
+    state = iterate(iter.wrapped, s)
     if state === nothing
         if iter.total > 0
             iter.current = iter.total

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -1,15 +1,15 @@
 module RegularizedEvolutionModule
 
 import Random: shuffle!
-import ..CoreModule: Options, Dataset, RecordType, stringTree
+import ..CoreModule: Options, Dataset, RecordType, string_tree
 import ..PopMemberModule: PopMember
-import ..PopulationModule: Population, bestOfSample
-import ..MutateModule: nextGeneration, crossoverGeneration
+import ..PopulationModule: Population, best_of_sample
+import ..MutateModule: next_generation, crossover_generation
 import ..RecorderModule: @recorder
 
 # Pass through the population several times, replacing the oldest
 # with the fittest of a small subsample
-function regEvolCycle(
+function reg_evol_cycle(
     dataset::Dataset{T},
     baseline::T,
     pop::Population,
@@ -53,7 +53,7 @@ function regEvolCycle(
             end
             allstar = pop.members[best_idx]
             mutation_recorder = RecordType()
-            babies[i], accepted[i] = nextGeneration(
+            babies[i], accepted[i] = next_generation(
                 dataset,
                 baseline,
                 allstar,
@@ -75,9 +75,9 @@ function regEvolCycle(
     else
         for i in 1:round(Int, pop.n / options.ns)
             if rand() > options.crossoverProbability
-                allstar = bestOfSample(pop, frequencyComplexity, options)
+                allstar = best_of_sample(pop, frequencyComplexity, options)
                 mutation_recorder = RecordType()
-                baby, mutation_accepted = nextGeneration(
+                baby, mutation_accepted = next_generation(
                     dataset,
                     baseline,
                     allstar,
@@ -103,7 +103,7 @@ function regEvolCycle(
                         if !haskey(record["mutations"], "$(member.ref)")
                             record["mutations"]["$(member.ref)"] = RecordType(
                                 "events" => Vector{RecordType}(),
-                                "tree" => stringTree(member.tree, options),
+                                "tree" => string_tree(member.tree, options),
                                 "score" => member.score,
                                 "loss" => member.loss,
                                 "parent" => member.parent,
@@ -129,10 +129,10 @@ function regEvolCycle(
                 pop.members[oldest] = baby
 
             else # Crossover
-                allstar1 = bestOfSample(pop, frequencyComplexity, options)
-                allstar2 = bestOfSample(pop, frequencyComplexity, options)
+                allstar1 = best_of_sample(pop, frequencyComplexity, options)
+                allstar2 = best_of_sample(pop, frequencyComplexity, options)
 
-                baby1, baby2, crossover_accepted = crossoverGeneration(
+                baby1, baby2, crossover_accepted = crossover_generation(
                     allstar1, allstar2, dataset, baseline, curmaxsize, options
                 )
 

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -9,11 +9,16 @@ import ..RecorderModule: @recorder
 
 # Pass through the population several times, replacing the oldest
 # with the fittest of a small subsample
-function regEvolCycle(dataset::Dataset{T},
-                      baseline::T, pop::Population, temperature::T, curmaxsize::Int,
-                      frequencyComplexity::AbstractVector{T},
-                      options::Options,
-                      record::RecordType)::Population where {T<:Real}
+function regEvolCycle(
+    dataset::Dataset{T},
+    baseline::T,
+    pop::Population,
+    temperature::T,
+    curmaxsize::Int,
+    frequencyComplexity::AbstractVector{T},
+    options::Options,
+    record::RecordType,
+)::Population where {T<:Real}
     # Batch over each subsample. Can give 15% improvement in speed; probably moreso for large pops.
     # but is ultimately a different algorithm than regularized evolution, and might not be
     # as good.
@@ -24,21 +29,23 @@ function regEvolCycle(dataset::Dataset{T},
     if options.fast_cycle
 
         # These options are not implemented for fast_cycle:
-        @recorder error("You cannot have the recorder and fast_cycle set to true at the same time!")
+        @recorder error(
+            "You cannot have the recorder and fast_cycle set to true at the same time!"
+        )
         @assert options.probPickFirst == 1.0
         @assert options.crossoverProbability == 0.0
 
         shuffle!(pop.members)
-        n_evol_cycles = round(Int, pop.n/options.ns)
+        n_evol_cycles = round(Int, pop.n / options.ns)
         babies = Array{PopMember}(undef, n_evol_cycles)
         accepted = Array{Bool}(undef, n_evol_cycles)
 
         # Iterate each ns-member sub-sample
-        @inbounds Threads.@threads for i=1:n_evol_cycles
+        @inbounds Threads.@threads for i in 1:n_evol_cycles
             best_score = Inf
-            best_idx = 1+(i-1)*options.ns
+            best_idx = 1 + (i - 1) * options.ns
             # Calculate best member of the subsample:
-            for sub_i=1+(i-1)*options.ns:i*options.ns
+            for sub_i in (1 + (i - 1) * options.ns):(i * options.ns)
                 if pop.members[sub_i].score < best_score
                     best_score = pop.members[sub_i].score
                     best_idx = sub_i
@@ -46,33 +53,47 @@ function regEvolCycle(dataset::Dataset{T},
             end
             allstar = pop.members[best_idx]
             mutation_recorder = RecordType()
-            babies[i], accepted[i] = nextGeneration(dataset, baseline, allstar, temperature,
-                                                    curmaxsize, frequencyComplexity, options,
-                                                    tmp_recorder=mutation_recorder)
+            babies[i], accepted[i] = nextGeneration(
+                dataset,
+                baseline,
+                allstar,
+                temperature,
+                curmaxsize,
+                frequencyComplexity,
+                options;
+                tmp_recorder=mutation_recorder,
+            )
         end
 
         # Replace the n_evol_cycles-oldest members of each population
-        @inbounds for i=1:n_evol_cycles
-            oldest = argmin([pop.members[member].birth for member=1:pop.n])
+        @inbounds for i in 1:n_evol_cycles
+            oldest = argmin([pop.members[member].birth for member in 1:(pop.n)])
             if accepted[i] || !options.skip_mutation_failures
                 pop.members[oldest] = babies[i]
             end
         end
     else
-        for i=1:round(Int, pop.n/options.ns)
+        for i in 1:round(Int, pop.n / options.ns)
             if rand() > options.crossoverProbability
                 allstar = bestOfSample(pop, frequencyComplexity, options)
                 mutation_recorder = RecordType()
-                baby, mutation_accepted = nextGeneration(dataset, baseline, allstar, temperature,
-                                                         curmaxsize, frequencyComplexity, options,
-                                                         tmp_recorder=mutation_recorder)
+                baby, mutation_accepted = nextGeneration(
+                    dataset,
+                    baseline,
+                    allstar,
+                    temperature,
+                    curmaxsize,
+                    frequencyComplexity,
+                    options;
+                    tmp_recorder=mutation_recorder,
+                )
 
                 if !mutation_accepted && options.skip_mutation_failures
                     # Skip this mutation rather than replacing oldest member with unchanged member
                     continue
                 end
 
-                oldest = argmin([pop.members[member].birth for member=1:pop.n])
+                oldest = argmin([pop.members[member].birth for member in 1:(pop.n)])
 
                 @recorder begin
                     if !haskey(record, "mutations")
@@ -80,19 +101,29 @@ function regEvolCycle(dataset::Dataset{T},
                     end
                     for member in [allstar, baby, pop.members[oldest]]
                         if !haskey(record["mutations"], "$(member.ref)")
-                            record["mutations"]["$(member.ref)"] = RecordType("events"=>Vector{RecordType}(),
-                                                                            "tree"=>stringTree(member.tree, options),
-                                                                            "score"=>member.score,
-                                                                            "loss"=>member.loss,
-                                                                            "parent"=>member.parent)
+                            record["mutations"]["$(member.ref)"] = RecordType(
+                                "events" => Vector{RecordType}(),
+                                "tree" => stringTree(member.tree, options),
+                                "score" => member.score,
+                                "loss" => member.loss,
+                                "parent" => member.parent,
+                            )
                         end
                     end
-                    mutate_event = RecordType("type"=>"mutate", "time"=>time(), "child"=>baby.ref, "mutation"=>mutation_recorder)
-                    death_event  = RecordType("type"=>"death",  "time"=>time())
+                    mutate_event = RecordType(
+                        "type" => "mutate",
+                        "time" => time(),
+                        "child" => baby.ref,
+                        "mutation" => mutation_recorder,
+                    )
+                    death_event = RecordType("type" => "death", "time" => time())
 
                     # Put in random key rather than vector; otherwise there are collisions!
                     push!(record["mutations"]["$(allstar.ref)"]["events"], mutate_event)
-                    push!(record["mutations"]["$(pop.members[oldest].ref)"]["events"], death_event)
+                    push!(
+                        record["mutations"]["$(pop.members[oldest].ref)"]["events"],
+                        death_event,
+                    )
                 end
 
                 pop.members[oldest] = baby
@@ -101,17 +132,18 @@ function regEvolCycle(dataset::Dataset{T},
                 allstar1 = bestOfSample(pop, frequencyComplexity, options)
                 allstar2 = bestOfSample(pop, frequencyComplexity, options)
 
-                baby1, baby2, crossover_accepted = crossoverGeneration(allstar1, allstar2, dataset, baseline,
-                                                   curmaxsize, options)
-                
+                baby1, baby2, crossover_accepted = crossoverGeneration(
+                    allstar1, allstar2, dataset, baseline, curmaxsize, options
+                )
+
                 if !crossover_accepted && options.skip_mutation_failures
                     continue
                 end
 
                 # Replace old members with new ones:
-                oldest = argmin([pop.members[member].birth for member=1:pop.n])
+                oldest = argmin([pop.members[member].birth for member in 1:(pop.n)])
                 pop.members[oldest] = baby1
-                oldest = argmin([pop.members[member].birth for member=1:pop.n])
+                oldest = argmin([pop.members[member].birth for member in 1:(pop.n)])
                 pop.members[oldest] = baby2
             end
         end

--- a/src/SimplifyEquation.jl
+++ b/src/SimplifyEquation.jl
@@ -23,7 +23,9 @@ function combineOperators(tree::Node, options::Options)::Node
     end
 
     top_level_constant = tree.degree == 2 && (tree.l.constant || tree.r.constant)
-    if tree.degree == 2 && (options.binops[tree.op] == (*) || options.binops[tree.op] == (+)) && top_level_constant
+    if tree.degree == 2 &&
+        (options.binops[tree.op] == (*) || options.binops[tree.op] == (+)) &&
+        top_level_constant
         op = tree.op
         # Put the constant in r. Need to assume var in left for simplification assumption.
         if tree.l.constant
@@ -107,8 +109,7 @@ function simplifyTree(tree::Node, options::Options)::Node
         tree.l = simplifyTree(tree.l, options)
         tree.r = simplifyTree(tree.r, options)
         constantsBelow = (
-             tree.l.degree == 0 && tree.l.constant &&
-             tree.r.degree == 0 && tree.r.constant
+            tree.l.degree == 0 && tree.l.constant && tree.r.degree == 0 && tree.r.constant
         )
         if constantsBelow
             # NaN checks:

--- a/src/SimplifyEquation.jl
+++ b/src/SimplifyEquation.jl
@@ -1,13 +1,13 @@
 module SimplifyEquationModule
 
-import ..CoreModule: CONST_TYPE, Node, copyNode, Options
-import ..EquationUtilsModule: countNodes
+import ..CoreModule: CONST_TYPE, Node, copy_node, Options
+import ..EquationUtilsModule: count_nodes
 import ..CheckConstraintsModule: check_constraints
 import ..UtilsModule: isbad, isgood
 
 # Simplify tree
-function combineOperators(tree::Node, options::Options)::Node
-    # NOTE: (const (+*-) const) already accounted for. Call simplifyTree before.
+function combine_operators(tree::Node, options::Options)::Node
+    # NOTE: (const (+*-) const) already accounted for. Call simplify_tree before.
     # ((const + var) + const) => (const + var)
     # ((const * var) * const) => (const * var)
     # ((const - var) - const) => (const - var)
@@ -16,10 +16,10 @@ function combineOperators(tree::Node, options::Options)::Node
     if tree.degree == 0
         return tree
     elseif tree.degree == 1
-        tree.l = combineOperators(tree.l, options)
+        tree.l = combine_operators(tree.l, options)
     elseif tree.degree == 2
-        tree.l = combineOperators(tree.l, options)
-        tree.r = combineOperators(tree.r, options)
+        tree.l = combine_operators(tree.l, options)
+        tree.r = combine_operators(tree.r, options)
     end
 
     top_level_constant = tree.degree == 2 && (tree.l.constant || tree.r.constant)
@@ -94,9 +94,9 @@ function combineOperators(tree::Node, options::Options)::Node
 end
 
 # Simplify tree
-function simplifyTree(tree::Node, options::Options)::Node
+function simplify_tree(tree::Node, options::Options)::Node
     if tree.degree == 1
-        tree.l = simplifyTree(tree.l, options)
+        tree.l = simplify_tree(tree.l, options)
         l = tree.l.val
         if tree.l.degree == 0 && tree.l.constant && isgood(l)
             out = options.unaops[tree.op](l)
@@ -106,8 +106,8 @@ function simplifyTree(tree::Node, options::Options)::Node
             return Node(convert(CONST_TYPE, out))
         end
     elseif tree.degree == 2
-        tree.l = simplifyTree(tree.l, options)
-        tree.r = simplifyTree(tree.r, options)
+        tree.l = simplify_tree(tree.l, options)
+        tree.r = simplify_tree(tree.r, options)
         constantsBelow = (
             tree.l.degree == 0 && tree.l.constant && tree.r.degree == 0 && tree.r.constant
         )

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -1,18 +1,18 @@
 module SingleIterationModule
 
-import ..CoreModule: Options, Dataset, RecordType, stringTree
-import ..EquationUtilsModule: countNodes
+import ..CoreModule: Options, Dataset, RecordType, string_tree
+import ..EquationUtilsModule: count_nodes
 import ..UtilsModule: debug
-import ..SimplifyEquationModule: simplifyTree, combineOperators
-import ..PopMemberModule: copyPopMember
-import ..PopulationModule: Population, finalizeScores, bestSubPop
+import ..SimplifyEquationModule: simplify_tree, combine_operators
+import ..PopMemberModule: copy_pop_member
+import ..PopulationModule: Population, finalize_scores, best_sub_pop
 import ..HallOfFameModule: HallOfFame
-import ..RegularizedEvolutionModule: regEvolCycle
-import ..ConstantOptimizationModule: optimizeConstants
+import ..RegularizedEvolutionModule: reg_evol_cycle
+import ..ConstantOptimizationModule: optimize_constants
 
 # Cycle through regularized evolution many times,
 # printing the fittest equation every 10% through
-function SRCycle(
+function s_r_cycle(
     dataset::Dataset{T},
     baseline::T,
     pop::Population,
@@ -29,7 +29,7 @@ function SRCycle(
 
     for temperature in 1:size(allT, 1)
         if options.annealing
-            pop = regEvolCycle(
+            pop = reg_evol_cycle(
                 dataset,
                 baseline,
                 pop,
@@ -40,7 +40,7 @@ function SRCycle(
                 record,
             )
         else
-            pop = regEvolCycle(
+            pop = reg_evol_cycle(
                 dataset,
                 baseline,
                 pop,
@@ -52,12 +52,12 @@ function SRCycle(
             )
         end
         for member in pop.members
-            size = countNodes(member.tree)
+            size = count_nodes(member.tree)
             score = member.score
             if !best_examples_seen.exists[size] ||
                 score < best_examples_seen.members[size].score
                 best_examples_seen.exists[size] = true
-                best_examples_seen.members[size] = copyPopMember(member)
+                best_examples_seen.members[size] = copy_pop_member(member)
             end
         end
     end
@@ -65,7 +65,7 @@ function SRCycle(
     return (pop, best_examples_seen)
 end
 
-function OptimizeAndSimplifyPopulation(
+function optimize_and_simplify_population(
     dataset::Dataset{T},
     baseline::T,
     pop::Population,
@@ -74,13 +74,13 @@ function OptimizeAndSimplifyPopulation(
     record::RecordType,
 )::Population where {T<:Real}
     @inbounds @simd for j in 1:(pop.n)
-        pop.members[j].tree = simplifyTree(pop.members[j].tree, options)
-        pop.members[j].tree = combineOperators(pop.members[j].tree, options)
+        pop.members[j].tree = simplify_tree(pop.members[j].tree, options)
+        pop.members[j].tree = combine_operators(pop.members[j].tree, options)
         if rand() < options.optimize_probability && options.shouldOptimizeConstants
-            pop.members[j] = optimizeConstants(dataset, baseline, pop.members[j], options)
+            pop.members[j] = optimize_constants(dataset, baseline, pop.members[j], options)
         end
     end
-    pop = finalizeScores(dataset, baseline, pop, options)
+    pop = finalize_scores(dataset, baseline, pop, options)
     return pop
 end
 

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -10,33 +10,52 @@ import ..HallOfFameModule: HallOfFame
 import ..RegularizedEvolutionModule: regEvolCycle
 import ..ConstantOptimizationModule: optimizeConstants
 
-
 # Cycle through regularized evolution many times,
 # printing the fittest equation every 10% through
-function SRCycle(dataset::Dataset{T}, baseline::T, 
-        pop::Population,
-        ncycles::Int,
-        curmaxsize::Int,
-        frequencyComplexity::AbstractVector{T};
-        verbosity::Int=0,
-        options::Options,
-        record::RecordType
-        )::Tuple{Population, HallOfFame} where {T<:Real}
-
+function SRCycle(
+    dataset::Dataset{T},
+    baseline::T,
+    pop::Population,
+    ncycles::Int,
+    curmaxsize::Int,
+    frequencyComplexity::AbstractVector{T};
+    verbosity::Int=0,
+    options::Options,
+    record::RecordType,
+)::Tuple{Population,HallOfFame} where {T<:Real}
     top = convert(T, 1)
     allT = LinRange(top, convert(T, 0), ncycles)
     best_examples_seen = HallOfFame(options)
 
     for temperature in 1:size(allT, 1)
         if options.annealing
-            pop = regEvolCycle(dataset, baseline, pop, allT[temperature], curmaxsize, frequencyComplexity, options, record)
+            pop = regEvolCycle(
+                dataset,
+                baseline,
+                pop,
+                allT[temperature],
+                curmaxsize,
+                frequencyComplexity,
+                options,
+                record,
+            )
         else
-            pop = regEvolCycle(dataset, baseline, pop, top, curmaxsize, frequencyComplexity, options, record)
+            pop = regEvolCycle(
+                dataset,
+                baseline,
+                pop,
+                top,
+                curmaxsize,
+                frequencyComplexity,
+                options,
+                record,
+            )
         end
         for member in pop.members
             size = countNodes(member.tree)
             score = member.score
-            if !best_examples_seen.exists[size] || score < best_examples_seen.members[size].score
+            if !best_examples_seen.exists[size] ||
+                score < best_examples_seen.members[size].score
                 best_examples_seen.exists[size] = true
                 best_examples_seen.members[size] = copyPopMember(member)
             end
@@ -47,12 +66,14 @@ function SRCycle(dataset::Dataset{T}, baseline::T,
 end
 
 function OptimizeAndSimplifyPopulation(
-            dataset::Dataset{T}, baseline::T,
-            pop::Population, options::Options,
-            curmaxsize::Int,
-            record::RecordType
-        )::Population where {T<:Real}
-    @inbounds @simd for j=1:pop.n
+    dataset::Dataset{T},
+    baseline::T,
+    pop::Population,
+    options::Options,
+    curmaxsize::Int,
+    record::RecordType,
+)::Population where {T<:Real}
+    @inbounds @simd for j in 1:(pop.n)
         pop.members[j].tree = simplifyTree(pop.members[j].tree, options)
         pop.members[j].tree = combineOperators(pop.members[j].tree, options)
         if rand() < options.optimize_probability && options.shouldOptimizeConstants

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -152,7 +152,11 @@ import .EvaluateEquationModule: eval_tree_array, differentiable_eval_tree_array
 import .EvaluateEquationDerivativeModule: eval_diff_tree_array, eval_grad_tree_array
 import .CheckConstraintsModule: check_constraints
 import .MutationFunctionsModule:
-    gen_random_tree, gen_random_tree_fixed_size, random_node, random_node_and_parent, crossover_trees
+    gen_random_tree,
+    gen_random_tree_fixed_size,
+    random_node,
+    random_node_and_parent,
+    crossover_trees
 import .LossFunctionsModule: eval_loss, loss, score_func
 import .PopMemberModule: PopMember, copy_pop_member
 import .PopulationModule: Population, best_sub_pop, record_population, best_of_sample
@@ -405,7 +409,9 @@ function _EquationSearch(
     # Set up a channel to send finished populations back to head node
     if ConcurrencyType in [SRDistributed, SRThreaded]
         if ConcurrencyType == SRDistributed
-            channels = [[RemoteChannel(1) for i in 1:(options.npopulations)] for j in 1:nout]
+            channels = [
+                [RemoteChannel(1) for i in 1:(options.npopulations)] for j in 1:nout
+            ]
         else
             channels = [[Channel(1) for i in 1:(options.npopulations)] for j in 1:nout]
         end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -597,14 +597,14 @@ function _EquationSearch(
                 )
                 if options.batching
                     for i_member in 1:(options.maxsize + MAX_DEGREE)
-                        score, loss = score_func(
+                        score, result_loss = score_func(
                             dataset,
                             baselineMSE,
                             tmp_best_seen.members[i_member].tree,
                             options,
                         )
                         tmp_best_seen.members[i_member].score = score
-                        tmp_best_seen.members[i_member].loss = loss
+                        tmp_best_seen.members[i_member].loss = result_loss
                     end
                 end
                 (tmp_pop, tmp_best_seen, cur_record)
@@ -726,10 +726,9 @@ function _EquationSearch(
             open(hofFile, "w") do io
                 println(io, "Complexity|MSE|Equation")
                 for member in dominating
-                    loss = member.loss
                     println(
                         io,
-                        "$(count_nodes(member.tree))|$(loss)|$(string_tree(member.tree, options, varMap=dataset.varMap))",
+                        "$(count_nodes(member.tree))|$(member.loss)|$(string_tree(member.tree, options, varMap=dataset.varMap))",
                     )
                 end
             end
@@ -807,14 +806,14 @@ function _EquationSearch(
                 if options.batching
                     for i_member in 1:(options.maxsize + MAX_DEGREE)
                         if tmp_best_seen.exists[i_member]
-                            score, loss = score_func(
+                            score, result_loss = score_func(
                                 dataset,
                                 baselineMSE,
                                 tmp_best_seen.members[i_member].tree,
                                 options,
                             )
                             tmp_best_seen.members[i_member].score = score
-                            tmp_best_seen.members[i_member].loss = loss
+                            tmp_best_seen.members[i_member].loss = result_loss
                         end
                     end
                 end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -52,13 +52,38 @@ export Population,
     atanh_clip
 
 using Distributed
-import JSON3
+using JSON3: JSON3
 import Printf: @printf, @sprintf
-import Pkg
+using Pkg: Pkg
 import Random: seed!, shuffle!
 using Reexport
-@reexport import LossFunctions: MarginLoss, DistanceLoss, SupervisedLoss, ZeroOneLoss, LogitMarginLoss, PerceptronLoss, HingeLoss, L1HingeLoss, L2HingeLoss, SmoothedL1HingeLoss, ModifiedHuberLoss, L2MarginLoss, ExpLoss, SigmoidLoss, DWDMarginLoss, LPDistLoss, L1DistLoss, L2DistLoss, PeriodicLoss, HuberLoss, EpsilonInsLoss, L1EpsilonInsLoss, L2EpsilonInsLoss, LogitDistLoss, QuantileLoss, LogCoshLoss
-
+@reexport import LossFunctions:
+    MarginLoss,
+    DistanceLoss,
+    SupervisedLoss,
+    ZeroOneLoss,
+    LogitMarginLoss,
+    PerceptronLoss,
+    HingeLoss,
+    L1HingeLoss,
+    L2HingeLoss,
+    SmoothedL1HingeLoss,
+    ModifiedHuberLoss,
+    L2MarginLoss,
+    ExpLoss,
+    SigmoidLoss,
+    DWDMarginLoss,
+    LPDistLoss,
+    L1DistLoss,
+    L2DistLoss,
+    PeriodicLoss,
+    HuberLoss,
+    EpsilonInsLoss,
+    L1EpsilonInsLoss,
+    L2EpsilonInsLoss,
+    LogitDistLoss,
+    QuantileLoss,
+    LogCoshLoss
 
 include("Core.jl")
 include("Recorder.jl")
@@ -80,17 +105,59 @@ include("RegularizedEvolution.jl")
 include("SingleIteration.jl")
 include("ProgressBars.jl")
 
-import .CoreModule: CONST_TYPE, MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType, Dataset, Node, copyNode, Options, plus, sub, mult, square, cube, pow, div, log_abs, log2_abs, log10_abs, log1p_abs, sqrt_abs, acosh_abs, neg, greater, greater, relu, logical_or, logical_and, gamma, erf, erfc, atanh_clip, SRConcurrency, SRSerial, SRThreaded, SRDistributed, stringTree, printTree
-import .UtilsModule: debug, debug_inline, is_anonymous_function, recursive_merge, next_worker, @sr_spawner
-import .EquationUtilsModule: countNodes, getConstants, setConstants, indexConstants, NodeIndex
+import .CoreModule:
+    CONST_TYPE,
+    MAX_DEGREE,
+    BATCH_DIM,
+    FEATURE_DIM,
+    RecordType,
+    Dataset,
+    Node,
+    copyNode,
+    Options,
+    plus,
+    sub,
+    mult,
+    square,
+    cube,
+    pow,
+    div,
+    log_abs,
+    log2_abs,
+    log10_abs,
+    log1p_abs,
+    sqrt_abs,
+    acosh_abs,
+    neg,
+    greater,
+    greater,
+    relu,
+    logical_or,
+    logical_and,
+    gamma,
+    erf,
+    erfc,
+    atanh_clip,
+    SRConcurrency,
+    SRSerial,
+    SRThreaded,
+    SRDistributed,
+    stringTree,
+    printTree
+import .UtilsModule:
+    debug, debug_inline, is_anonymous_function, recursive_merge, next_worker, @sr_spawner
+import .EquationUtilsModule:
+    countNodes, getConstants, setConstants, indexConstants, NodeIndex
 import .EvaluateEquationModule: evalTreeArray, differentiableEvalTreeArray
 import .EvaluateEquationDerivativeModule: evalDiffTreeArray, evalGradTreeArray
 import .CheckConstraintsModule: check_constraints
-import .MutationFunctionsModule: genRandomTree, genRandomTreeFixedSize, randomNode, randomNodeAndParent, crossoverTrees
+import .MutationFunctionsModule:
+    genRandomTree, genRandomTreeFixedSize, randomNode, randomNodeAndParent, crossoverTrees
 import .LossFunctionsModule: EvalLoss, Loss, scoreFunc
 import .PopMemberModule: PopMember, copyPopMember
 import .PopulationModule: Population, bestSubPop, record_population, bestOfSample
-import .HallOfFameModule: HallOfFame, calculateParetoFrontier, string_dominating_pareto_curve
+import .HallOfFameModule:
+    HallOfFame, calculateParetoFrontier, string_dominating_pareto_curve
 import .SingleIterationModule: SRCycle, OptimizeAndSimplifyPopulation
 import .InterfaceSymbolicUtilsModule: node_to_symbolic, symbolic_to_node
 import .SimplifyEquationModule: combineOperators, simplifyTree
@@ -101,16 +168,9 @@ include("Configure.jl")
 include("Deprecates.jl")
 
 StateType{T} = Tuple{
-    Union{
-        Vector{Vector{Population{T}}},
-        Matrix{Population{T}}
-    },
-    Union{
-        HallOfFame,
-        Vector{HallOfFame}
-    }
+    Union{Vector{Vector{Population{T}}},Matrix{Population{T}}},
+    Union{HallOfFame,Vector{HallOfFame}},
 }
-
 
 """
     EquationSearch(X, y[; kws...])
@@ -169,58 +229,76 @@ which is useful for debugging and profiling.
     is given in `.score`. The array of `PopMember` objects
     is enumerated by size from `1` to `options.maxsize`.
 """
-function EquationSearch(X::AbstractMatrix{T}, y::AbstractMatrix{T};
-        niterations::Int=10,
-        weights::Union{AbstractMatrix{T}, AbstractVector{T}, Nothing}=nothing,
-        varMap::Union{Array{String, 1}, Nothing}=nothing,
-        options::Options=Options(),
-        numprocs::Union{Int, Nothing}=nothing,
-        procs::Union{Array{Int, 1}, Nothing}=nothing,
-        multithreading::Bool=false,
-        runtests::Bool=true,
-        saved_state::Union{StateType{T}, Nothing}=nothing,
-        addprocs_function::Union{Function, Nothing}=nothing,
-       ) where {T<:Real}
-
+function EquationSearch(
+    X::AbstractMatrix{T},
+    y::AbstractMatrix{T};
+    niterations::Int=10,
+    weights::Union{AbstractMatrix{T},AbstractVector{T},Nothing}=nothing,
+    varMap::Union{Array{String,1},Nothing}=nothing,
+    options::Options=Options(),
+    numprocs::Union{Int,Nothing}=nothing,
+    procs::Union{Array{Int,1},Nothing}=nothing,
+    multithreading::Bool=false,
+    runtests::Bool=true,
+    saved_state::Union{StateType{T},Nothing}=nothing,
+    addprocs_function::Union{Function,Nothing}=nothing,
+) where {T<:Real}
     nout = size(y, FEATURE_DIM)
     if weights !== nothing
         weights = reshape(weights, size(y))
     end
-    datasets = [Dataset(X, y[j, :],
-                    weights=(weights === nothing ? weights : weights[j, :]),
-                    varMap=varMap)
-                for j=1:nout]
+    datasets = [
+        Dataset(
+            X,
+            y[j, :];
+            weights=(weights === nothing ? weights : weights[j, :]),
+            varMap=varMap,
+        ) for j in 1:nout
+    ]
 
-    return EquationSearch(datasets;
-        niterations=niterations, options=options,
-        numprocs=numprocs, procs=procs, multithreading=multithreading,
-        runtests=runtests, saved_state=saved_state,
-        addprocs_function=addprocs_function)
+    return EquationSearch(
+        datasets;
+        niterations=niterations,
+        options=options,
+        numprocs=numprocs,
+        procs=procs,
+        multithreading=multithreading,
+        runtests=runtests,
+        saved_state=saved_state,
+        addprocs_function=addprocs_function,
+    )
 end
 
-function EquationSearch(X::AbstractMatrix{T1}, y::AbstractMatrix{T2}; kw...) where {T1<:Real,T2<:Real}
+function EquationSearch(
+    X::AbstractMatrix{T1}, y::AbstractMatrix{T2}; kw...
+) where {T1<:Real,T2<:Real}
     U = promote_type(T1, T2)
-    EquationSearch(convert(AbstractMatrix{U}, X), convert(AbstractMatrix{U}, y); kw...)
+    return EquationSearch(
+        convert(AbstractMatrix{U}, X), convert(AbstractMatrix{U}, y); kw...
+    )
 end
 
-function EquationSearch(X::AbstractMatrix{T1}, y::AbstractVector{T2}; kw...) where {T1<:Real,T2<:Real}
-    EquationSearch(X, reshape(y, (1, size(y, 1))); kw...)
+function EquationSearch(
+    X::AbstractMatrix{T1}, y::AbstractVector{T2}; kw...
+) where {T1<:Real,T2<:Real}
+    return EquationSearch(X, reshape(y, (1, size(y, 1))); kw...)
 end
 
-function EquationSearch(datasets::Array{Dataset{T}, 1};
-        niterations::Int=10,
-        options::Options=Options(),
-        numprocs::Union{Int, Nothing}=nothing,
-        procs::Union{Array{Int, 1}, Nothing}=nothing,
-        multithreading::Bool=false,
-        runtests::Bool=true,
-        saved_state::Union{StateType{T}, Nothing}=nothing,
-        addprocs_function::Union{Function, Nothing}=nothing,
-       ) where {T<:Real}
+function EquationSearch(
+    datasets::Array{Dataset{T},1};
+    niterations::Int=10,
+    options::Options=Options(),
+    numprocs::Union{Int,Nothing}=nothing,
+    procs::Union{Array{Int,1},Nothing}=nothing,
+    multithreading::Bool=false,
+    runtests::Bool=true,
+    saved_state::Union{StateType{T},Nothing}=nothing,
+    addprocs_function::Union{Function,Nothing}=nothing,
+) where {T<:Real}
 
-                # Population(datasets[j], baselineMSEs[j], npop=options.npop,
-                #            nlength=3, options=options, nfeatures=datasets[j].nfeatures),
-                # HallOfFame(options),
+    # Population(datasets[j], baselineMSEs[j], npop=options.npop,
+    #            nlength=3, options=options, nfeatures=datasets[j].nfeatures),
+    # HallOfFame(options),
 
     noprocs = (procs === nothing && numprocs == 0)
     someprocs = !noprocs
@@ -234,23 +312,30 @@ function EquationSearch(datasets::Array{Dataset{T}, 1};
         SRSerial()
     end
 
-    return _EquationSearch(concurrency, datasets;
-        niterations=niterations, options=options,
-        numprocs=numprocs, procs=procs,
-        runtests=runtests, saved_state=saved_state,
-        addprocs_function=addprocs_function)
+    return _EquationSearch(
+        concurrency,
+        datasets;
+        niterations=niterations,
+        options=options,
+        numprocs=numprocs,
+        procs=procs,
+        runtests=runtests,
+        saved_state=saved_state,
+        addprocs_function=addprocs_function,
+    )
 end
 
-function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
-        niterations::Int=10,
-        options::Options=Options(),
-        numprocs::Union{Int, Nothing}=nothing,
-        procs::Union{Array{Int, 1}, Nothing}=nothing,
-        runtests::Bool=true,
-        saved_state::Union{StateType{T}, Nothing}=nothing,
-        addprocs_function::Union{Function, Nothing}=nothing,
-       ) where {T<:Real,ConcurrencyType<:SRConcurrency}
-
+function _EquationSearch(
+    ::ConcurrencyType,
+    datasets::Array{Dataset{T},1};
+    niterations::Int=10,
+    options::Options=Options(),
+    numprocs::Union{Int,Nothing}=nothing,
+    procs::Union{Array{Int,1},Nothing}=nothing,
+    runtests::Bool=true,
+    saved_state::Union{StateType{T},Nothing}=nothing,
+    addprocs_function::Union{Function,Nothing}=nothing,
+) where {T<:Real,ConcurrencyType<:SRConcurrency}
     can_read_input = true
     try
         Base.start_reading(stdin)
@@ -267,11 +352,14 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
         end
     end
 
-
     # Redefine print, show:
     @eval begin
-        Base.print(io::IO, tree::Node) = print(io, stringTree(tree, $options; varMap=$(datasets[1].varMap)))
-        Base.show(io::IO, tree::Node) = print(io, stringTree(tree, $options; varMap=$(datasets[1].varMap)))
+        function Base.print(io::IO, tree::Node)
+            return print(io, stringTree(tree, $options; varMap=$(datasets[1].varMap)))
+        end
+        function Base.show(io::IO, tree::Node)
+            return print(io, stringTree(tree, $options; varMap=$(datasets[1].varMap)))
+        end
     end
 
     example_dataset = datasets[1]
@@ -284,14 +372,19 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
     end
 
     if example_dataset.weighted
-        avgys = [sum(dataset.y .* dataset.weights) / sum(dataset.weights)
-                for dataset in datasets]
-        baselineMSEs = [Loss(dataset.y, ones(T, dataset.n) .* avgy, dataset.weights, options)
-                       for dataset in datasets, avgy in avgys]
+        avgys = [
+            sum(dataset.y .* dataset.weights) / sum(dataset.weights) for dataset in datasets
+        ]
+        baselineMSEs = [
+            Loss(dataset.y, ones(T, dataset.n) .* avgy, dataset.weights, options) for
+            dataset in datasets, avgy in avgys
+        ]
     else
-        avgys = [sum(dataset.y)/dataset.n for dataset in datasets]
-        baselineMSEs = [Loss(dataset.y, ones(T, dataset.n) .* avgy, options)
-                       for (dataset, avgy) in zip(datasets, avgys)]
+        avgys = [sum(dataset.y) / dataset.n for dataset in datasets]
+        baselineMSEs = [
+            Loss(dataset.y, ones(T, dataset.n) .* avgy, options) for
+            (dataset, avgy) in zip(datasets, avgys)
+        ]
     end
 
     if options.seed !== nothing
@@ -307,32 +400,47 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
         Task
     end
 
-    allPops = [allPopsType[] for j=1:nout]
-    init_pops = [allPopsType[] for j=1:nout]
+    allPops = [allPopsType[] for j in 1:nout]
+    init_pops = [allPopsType[] for j in 1:nout]
     # Set up a channel to send finished populations back to head node
     if ConcurrencyType in [SRDistributed, SRThreaded]
         if ConcurrencyType == SRDistributed
-            channels = [[RemoteChannel(1) for i=1:options.npopulations] for j=1:nout]
+            channels = [[RemoteChannel(1) for i in 1:(options.npopulations)] for j in 1:nout]
         else
-            channels = [[Channel(1) for i=1:options.npopulations] for j=1:nout]
+            channels = [[Channel(1) for i in 1:(options.npopulations)] for j in 1:nout]
         end
-        tasks = [Task[] for j=1:nout]
+        tasks = [Task[] for j in 1:nout]
     end
 
     # This is a recorder for populations, but is not actually used for processing, just
     # for the final return.
-    returnPops = [[Population(datasets[j], baselineMSEs[j], npop=1,
-                              options=options, nfeatures=datasets[j].nfeatures)
-                    for i=1:options.npopulations]
-                    for j=1:nout]
+    returnPops = [
+        [
+            Population(
+                datasets[j],
+                baselineMSEs[j];
+                npop=1,
+                options=options,
+                nfeatures=datasets[j].nfeatures,
+            ) for i in 1:(options.npopulations)
+        ] for j in 1:nout
+    ]
     # These initial populations are discarded:
-    bestSubPops = [[Population(datasets[j], baselineMSEs[j], npop=1, options=options, nfeatures=datasets[j].nfeatures)
-                    for i=1:options.npopulations]
-                    for j=1:nout]
+    bestSubPops = [
+        [
+            Population(
+                datasets[j],
+                baselineMSEs[j];
+                npop=1,
+                options=options,
+                nfeatures=datasets[j].nfeatures,
+            ) for i in 1:(options.npopulations)
+        ] for j in 1:nout
+    ]
     if saved_state === nothing
-        hallOfFame = [HallOfFame(options) for j=1:nout]
+        hallOfFame = [HallOfFame(options) for j in 1:nout]
     else
-        hallOfFame = saved_state[2]::Union{HallOfFame, Vector{HallOfFame}}
+        hallOfFame = saved_state[2]::Union{HallOfFame,Vector{HallOfFame}}
         if !isa(hallOfFame, Vector{HallOfFame})
             hallOfFame = [hallOfFame]
         end
@@ -345,13 +453,15 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
     smallest_frequency_allowed = 1
     # 3 here means this will last 3 cycles before being "refreshed"
     # We start out with even numbers at all frequencies.
-    frequencyComplexities = [ones(T, actualMaxsize) * window_size / actualMaxsize for i=1:nout]
+    frequencyComplexities = [
+        ones(T, actualMaxsize) * window_size / actualMaxsize for i in 1:nout
+    ]
 
-    curmaxsizes = [3 for j=1:nout]
-    record = RecordType("options"=>"$(options)")
+    curmaxsizes = [3 for j in 1:nout]
+    record = RecordType("options" => "$(options)")
 
-    if options.warmupMaxsizeBy == 0f0
-        curmaxsizes = [options.maxsize for j=1:nout]
+    if options.warmupMaxsizeBy == 0.0f0
+        curmaxsizes = [options.maxsize for j in 1:nout]
     end
 
     we_created_procs = false
@@ -364,12 +474,12 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
         end
         if numprocs === nothing && procs === nothing
             numprocs = 4
-            procs = addprocs_function(4, lazy=false)
+            procs = addprocs_function(4; lazy=false)
             we_created_procs = true
         elseif numprocs === nothing
             numprocs = length(procs)
         elseif procs === nothing
-            procs = addprocs_function(numprocs, lazy=false)
+            procs = addprocs_function(numprocs; lazy=false)
             we_created_procs = true
         end
 
@@ -388,20 +498,26 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
         end
     end
     # Get the next worker process to give a job:
-    worker_assignment = Dict{Tuple{Int,Int}, Int}()
+    worker_assignment = Dict{Tuple{Int,Int},Int}()
 
-    for j=1:nout
-        for i=1:options.npopulations
+    for j in 1:nout
+        for i in 1:(options.npopulations)
             worker_idx = next_worker(worker_assignment, procs)
             if ConcurrencyType == SRDistributed
                 worker_assignment[(j, i)] = worker_idx
             end
             if saved_state === nothing
                 new_pop = @sr_spawner ConcurrencyType worker_idx (
-                    Population(datasets[j], baselineMSEs[j], npop=options.npop,
-                            nlength=3, options=options, nfeatures=datasets[j].nfeatures),
+                    Population(
+                        datasets[j],
+                        baselineMSEs[j];
+                        npop=options.npop,
+                        nlength=3,
+                        options=options,
+                        nfeatures=datasets[j].nfeatures,
+                    ),
                     HallOfFame(options),
-                    RecordType()
+                    RecordType(),
                 )
             else
                 is_vector = typeof(saved_state[1]) <: Vector{Vector{Population{T}}}
@@ -409,18 +525,24 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
 
                 if length(cur_saved_state.members) >= options.npop
                     new_pop = @sr_spawner ConcurrencyType worker_idx (
-                        cur_saved_state,
-                        HallOfFame(options),
-                        RecordType()
+                        cur_saved_state, HallOfFame(options), RecordType()
                     )
                 else
                     # If population has not yet been created (e.g., exited too early)
-                    println("Warning: recreating population (output=$(j), population=$(i)), as the saved one only has $(length(cur_saved_state.members)) members.")
+                    println(
+                        "Warning: recreating population (output=$(j), population=$(i)), as the saved one only has $(length(cur_saved_state.members)) members.",
+                    )
                     new_pop = @sr_spawner ConcurrencyType worker_idx (
-                        Population(datasets[j], baselineMSEs[j], npop=options.npop,
-                                nlength=3, options=options, nfeatures=datasets[j].nfeatures),
+                        Population(
+                            datasets[j],
+                            baselineMSEs[j];
+                            npop=options.npop,
+                            nlength=3,
+                            options=options,
+                            nfeatures=datasets[j].nfeatures,
+                        ),
                         HallOfFame(options),
-                        RecordType()
+                        RecordType(),
                     )
                 end
             end
@@ -428,12 +550,12 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
         end
     end
     # 2. Start the cycle on every process:
-    for j=1:nout
+    for j in 1:nout
         dataset = datasets[j]
         baselineMSE = baselineMSEs[j]
         frequencyComplexity = frequencyComplexities[j]
         curmaxsize = curmaxsizes[j]
-        for i=1:options.npopulations
+        for i in 1:(options.npopulations)
             @recorder record["out$(j)_pop$(i)"] = RecordType()
             worker_idx = next_worker(worker_assignment, procs)
             if ConcurrencyType == SRDistributed
@@ -450,16 +572,31 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                 end
 
                 cur_record = RecordType()
-                @recorder cur_record["out$(j)_pop$(i)"] = RecordType("iteration0"=>record_population(in_pop, options))
-                tmp_pop, tmp_best_seen = SRCycle(dataset, baselineMSE, in_pop,
-                                                 options.ncyclesperiteration, curmaxsize,
-                                                 copy(frequencyComplexity)/sum(frequencyComplexity),
-                                                 verbosity=options.verbosity, options=options,
-                                                 record=cur_record)
-                tmp_pop = OptimizeAndSimplifyPopulation(dataset, baselineMSE, tmp_pop, options, curmaxsize, cur_record)
+                @recorder cur_record["out$(j)_pop$(i)"] = RecordType(
+                    "iteration0" => record_population(in_pop, options)
+                )
+                tmp_pop, tmp_best_seen = SRCycle(
+                    dataset,
+                    baselineMSE,
+                    in_pop,
+                    options.ncyclesperiteration,
+                    curmaxsize,
+                    copy(frequencyComplexity) / sum(frequencyComplexity);
+                    verbosity=options.verbosity,
+                    options=options,
+                    record=cur_record,
+                )
+                tmp_pop = OptimizeAndSimplifyPopulation(
+                    dataset, baselineMSE, tmp_pop, options, curmaxsize, cur_record
+                )
                 if options.batching
-                    for i_member=1:(options.maxsize + MAX_DEGREE)
-                        score, loss = scoreFunc(dataset, baselineMSE, tmp_best_seen.members[i_member].tree, options)
+                    for i_member in 1:(options.maxsize + MAX_DEGREE)
+                        score, loss = scoreFunc(
+                            dataset,
+                            baselineMSE,
+                            tmp_best_seen.members[i_member].tree,
+                            options,
+                        )
                         tmp_best_seen.members[i_member].score = score
                         tmp_best_seen.members[i_member].loss = loss
                     end
@@ -473,12 +610,11 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
     debug(options.verbosity > 0 || options.progress, "Started!")
     start_time = time()
     total_cycles = options.npopulations * niterations
-    cycles_remaining = [total_cycles for j=1:nout]
+    cycles_remaining = [total_cycles for j in 1:nout]
     sum_cycle_remaining = sum(cycles_remaining)
     if options.progress && nout == 1
         #TODO: need to iterate this on the max cycles remaining!
-        progress_bar = ProgressBar(1:sum_cycle_remaining;
-                                   width=options.terminal_width)
+        progress_bar = ProgressBar(1:sum_cycle_remaining; width=options.terminal_width)
         cur_cycle = nothing
         cur_state = nothing
     end
@@ -489,8 +625,8 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
     equation_speed = Float32[]
 
     if ConcurrencyType in [SRDistributed, SRThreaded]
-        for j=1:nout
-            for i=1:options.npopulations
+        for j in 1:nout
+            for i in 1:(options.npopulations)
                 # Start listening for each population to finish:
                 t = @async put!(channels[j][i], fetch(allPops[j][i]))
                 push!(tasks[j], t)
@@ -500,10 +636,10 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
 
     # Randomly order which order to check populations:
     # This is done so that we do work on all nout equally.
-    all_idx = [(j, i) for j=1:nout for i=1:options.npopulations]
+    all_idx = [(j, i) for j in 1:nout for i in 1:(options.npopulations)]
     shuffle!(all_idx)
     kappa = 0
-    head_node_time = Dict("occupied"=>0, "start"=>time())
+    head_node_time = Dict("occupied" => 0, "start" => time())
     while sum(cycles_remaining) > 0
         kappa += 1
         if kappa > options.npopulations * nout
@@ -520,19 +656,25 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
             end
         end
         # Non-blocking check if a population is ready:
-        population_ready = ConcurrencyType in [SRDistributed, SRThreaded] ? isready(channels[j][i]) : true
+        population_ready =
+            ConcurrencyType in [SRDistributed, SRThreaded] ? isready(channels[j][i]) : true
         # Don't start more if this output has finished its cycles:
         # TODO - this might skip extra cycles?
         population_ready &= (cycles_remaining[j] > 0)
         if population_ready
             head_node_start_work = time()
             # Take the fetch operation from the channel since its ready
-            (cur_pop, best_seen, cur_record) = ConcurrencyType in [SRDistributed, SRThreaded] ? take!(channels[j][i]) : allPops[j][i]
+            (cur_pop, best_seen, cur_record) =
+                if ConcurrencyType in [SRDistributed, SRThreaded]
+                    take!(channels[j][i])
+                else
+                    allPops[j][i]
+                end
             returnPops[j][i] = cur_pop
             cur_pop::Population
             best_seen::HallOfFame
             cur_record::RecordType
-            bestSubPops[j][i] = bestSubPop(cur_pop, topn=options.topn)
+            bestSubPops[j][i] = bestSubPop(cur_pop; topn=options.topn)
             @recorder record = recursive_merge(record, cur_record)
 
             dataset = datasets[j]
@@ -540,11 +682,15 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
             curmaxsize = curmaxsizes[j]
 
             #Try normal copy...
-            bestPops = Population([member for pop in bestSubPops[j] for member in pop.members])
+            bestPops = Population([
+                member for pop in bestSubPops[j] for member in pop.members
+            ])
 
             ###################################################################
             # Hall Of Fame updating ###########################################
-            for (i_member, member) in enumerate(Iterators.flatten((cur_pop.members, best_seen.members[best_seen.exists])))
+            for (i_member, member) in enumerate(
+                Iterators.flatten((cur_pop.members, best_seen.members[best_seen.exists]))
+            )
                 part_of_cur_pop = i_member <= length(cur_pop.members)
                 size = countNodes(member.tree)
 
@@ -552,7 +698,6 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                     frequencyComplexities[j][size] += 1
                 end
                 actualMaxsize = options.maxsize + MAX_DEGREE
-
 
                 valid_size = size < actualMaxsize
                 if valid_size
@@ -576,36 +721,43 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                 println(io, "Complexity|MSE|Equation")
                 for member in dominating
                     loss = member.loss
-                    println(io, "$(countNodes(member.tree))|$(loss)|$(stringTree(member.tree, options, varMap=dataset.varMap))")
+                    println(
+                        io,
+                        "$(countNodes(member.tree))|$(loss)|$(stringTree(member.tree, options, varMap=dataset.varMap))",
+                    )
                 end
             end
-            cp(hofFile, hofFile*".bkup", force=true)
+            cp(hofFile, hofFile * ".bkup"; force=true)
 
             ###################################################################
             # Migration #######################################################
             # Try normal copy otherwise.
             if options.migration
-                for k in rand(1:options.npop, round(Int, options.npop*options.fractionReplaced))
+                for k in rand(
+                    1:(options.npop), round(Int, options.npop * options.fractionReplaced)
+                )
                     to_copy = rand(1:size(bestPops.members, 1))
 
                     # Explicit copy here resets the birth. 
                     cur_pop.members[k] = PopMember(
                         copyNode(bestPops.members[to_copy].tree),
                         copy(bestPops.members[to_copy].score),
-                        copy(bestPops.members[to_copy].loss)
+                        copy(bestPops.members[to_copy].loss),
                     )
                     # TODO: Clean this up using copyPopMember.
                 end
             end
 
             if options.hofMigration && size(dominating, 1) > 0
-                for k in rand(1:options.npop, round(Int, options.npop*options.fractionReplacedHof))
+                for k in rand(
+                    1:(options.npop), round(Int, options.npop * options.fractionReplacedHof)
+                )
                     # Copy in case one gets used twice
                     to_copy = rand(1:size(dominating, 1))
                     cur_pop.members[k] = PopMember(
-                       copyNode(dominating[to_copy].tree),
-                       copy(dominating[to_copy].score),
-                       copy(dominating[to_copy].loss)
+                        copyNode(dominating[to_copy].tree),
+                        copy(dominating[to_copy].score),
+                        copy(dominating[to_copy].loss),
                     )
                     # TODO: Clean this up with copyPopMember.
                 end
@@ -627,18 +779,34 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
 
             allPops[j][i] = @sr_spawner ConcurrencyType worker_idx let
                 cur_record = RecordType()
-                @recorder cur_record[key] = RecordType("iteration$(iteration)"=>record_population(cur_pop, options))
+                @recorder cur_record[key] = RecordType(
+                    "iteration$(iteration)" => record_population(cur_pop, options)
+                )
                 tmp_pop, tmp_best_seen = SRCycle(
-                    dataset, baselineMSE, cur_pop, options.ncyclesperiteration,
-                    curmaxsize, copy(frequencyComplexities[j])/sum(frequencyComplexities[j]),
-                    verbosity=options.verbosity, options=options, record=cur_record)
-                tmp_pop = OptimizeAndSimplifyPopulation(dataset, baselineMSE, tmp_pop, options, curmaxsize, cur_record)
+                    dataset,
+                    baselineMSE,
+                    cur_pop,
+                    options.ncyclesperiteration,
+                    curmaxsize,
+                    copy(frequencyComplexities[j]) / sum(frequencyComplexities[j]);
+                    verbosity=options.verbosity,
+                    options=options,
+                    record=cur_record,
+                )
+                tmp_pop = OptimizeAndSimplifyPopulation(
+                    dataset, baselineMSE, tmp_pop, options, curmaxsize, cur_record
+                )
 
                 # Update scores if using batching:
                 if options.batching
-                    for i_member=1:(options.maxsize + MAX_DEGREE)
+                    for i_member in 1:(options.maxsize + MAX_DEGREE)
                         if tmp_best_seen.exists[i_member]
-                            score, loss = scoreFunc(dataset, baselineMSE, tmp_best_seen.members[i_member].tree, options)
+                            score, loss = scoreFunc(
+                                dataset,
+                                baselineMSE,
+                                tmp_best_seen.members[i_member].tree,
+                                options,
+                            )
                             tmp_best_seen.members[i_member].score = score
                             tmp_best_seen.members[i_member].loss = loss
                         end
@@ -653,23 +821,35 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
 
             cycles_elapsed = total_cycles - cycles_remaining[j]
             if options.warmupMaxsizeBy > 0
-                fraction_elapsed = 1f0 * cycles_elapsed / total_cycles
+                fraction_elapsed = 1.0f0 * cycles_elapsed / total_cycles
                 if fraction_elapsed > options.warmupMaxsizeBy
                     curmaxsizes[j] = options.maxsize
                 else
-                    curmaxsizes[j] = 3 + floor(Int, (options.maxsize - 3) * fraction_elapsed / options.warmupMaxsizeBy)
+                    curmaxsizes[j] =
+                        3 + floor(
+                            Int,
+                            (options.maxsize - 3) * fraction_elapsed /
+                            options.warmupMaxsizeBy,
+                        )
                 end
             end
             num_equations += options.ncyclesperiteration * options.npop / 10.0
 
             if options.progress && nout == 1
                 # set_postfix(iter, Equations=)
-                equation_strings = string_dominating_pareto_curve(hallOfFame[j], baselineMSE,
-                                                                  datasets[j], options,
-                                                                  avgys[j])
-                load_string = @sprintf("Head worker occupation: %.1f", 100*head_node_time["occupied"]/(time() - head_node_time["start"])) * "%\n"
+                equation_strings = string_dominating_pareto_curve(
+                    hallOfFame[j], baselineMSE, datasets[j], options, avgys[j]
+                )
+                load_string =
+                    @sprintf(
+                        "Head worker occupation: %.1f",
+                        100 * head_node_time["occupied"] /
+                            (time() - head_node_time["start"])
+                    ) * "%\n"
                 # TODO - include command about "q" here.
-                load_string *= @sprintf("Press 'q' and then <enter> to stop execution early.\n")
+                load_string *= @sprintf(
+                    "Press 'q' and then <enter> to stop execution early.\n"
+                )
                 equation_strings = load_string * equation_strings
                 set_multiline_postfix(progress_bar, equation_strings)
                 if cur_cycle === nothing
@@ -681,7 +861,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
             end
             head_node_end_work = time()
             head_node_time["occupied"] += (head_node_end_work - head_node_start_work)
-        
+
             # Move moving window along frequencyComplexities:
             cur_size_frequency_complexities = sum(frequencyComplexities[j])
             if cur_size_frequency_complexities > window_size
@@ -689,20 +869,21 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
                 # We need frequencyComplexities to be positive, but also sum to a number.
                 # min(frequencyComplexities[j])
                 while difference_in_size > 0
-                    indices_to_subtract = findall(frequencyComplexities[j] .> smallest_frequency_allowed)
+                    indices_to_subtract = findall(
+                        frequencyComplexities[j] .> smallest_frequency_allowed
+                    )
                     num_remaining = size(indices_to_subtract, 1)
                     amount_to_subtract = min(
                         difference_in_size / num_remaining,
-                        min(frequencyComplexities[j][indices_to_subtract]...) - smallest_frequency_allowed
+                        min(frequencyComplexities[j][indices_to_subtract]...) -
+                        smallest_frequency_allowed,
                     )
                     frequencyComplexities[j][indices_to_subtract] .-= amount_to_subtract
                     difference_in_size -= amount_to_subtract * num_remaining
                 end
             end
-
         end
         sleep(1e-6)
-
 
         ################################################################
         ## Printing code
@@ -710,7 +891,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
         #Update if time has passed, and some new equations generated.
         if elapsed > print_every_n_seconds && num_equations > 0.0
             # Dominating pareto curve - must be better than all simpler equations
-            current_speed = num_equations/elapsed
+            current_speed = num_equations / elapsed
             average_over_m_measurements = 10 #for print_every...=5, this gives 50 second running average
             push!(equation_speed, current_speed)
             if length(equation_speed) > average_over_m_measurements
@@ -718,25 +899,31 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
             end
             if (options.verbosity > 0) || (options.progress && nout > 1)
                 @printf("\n")
-                average_speed = sum(equation_speed)/length(equation_speed)
+                average_speed = sum(equation_speed) / length(equation_speed)
                 @printf("Cycles per second: %.3e\n", round(average_speed, sigdigits=3))
-                @printf("Head worker occupation: %.1f%%\n", 100 * head_node_time["occupied"]/(time() - head_node_time["start"]))
+                @printf(
+                    "Head worker occupation: %.1f%%\n",
+                    100 * head_node_time["occupied"] / (time() - head_node_time["start"])
+                )
                 cycles_elapsed = total_cycles * nout - sum(cycles_remaining)
-                @printf("Progress: %d / %d total iterations (%.3f%%)\n",
-                        cycles_elapsed, total_cycles * nout,
-                        100.0*cycles_elapsed/total_cycles/nout)
+                @printf(
+                    "Progress: %d / %d total iterations (%.3f%%)\n",
+                    cycles_elapsed,
+                    total_cycles * nout,
+                    100.0 * cycles_elapsed / total_cycles / nout
+                )
 
                 @printf("==============================\n")
-                for j=1:nout
+                for j in 1:nout
                     if nout > 1
                         @printf("Best equations for output %d\n", j)
                     end
-                    equation_strings = string_dominating_pareto_curve(hallOfFame[j], baselineMSEs[j],
-                                                                      datasets[j], options,
-                                                                      avgys[j])
+                    equation_strings = string_dominating_pareto_curve(
+                        hallOfFame[j], baselineMSEs[j], datasets[j], options, avgys[j]
+                    )
                     print(equation_strings)
                     @printf("==============================\n")
-                    
+
                     # Debugging code for frequencyComplexities:
                     # for size_i=1:actualMaxsize
                     #     @printf("frequencyComplexities size %d = %.2f\n", size_i, frequencyComplexities[j][size_i])
@@ -754,12 +941,15 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
         if options.earlyStopCondition !== nothing
             # Check if all nout are below stopping condition.
             all_below = true
-            for j=1:nout
+            for j in 1:nout
                 dominating = calculateParetoFrontier(datasets[j], hallOfFame[j], options)
                 # Check if zero size:
                 if length(dominating) == 0
                     all_below = false
-                elseif !any([options.earlyStopCondition(member.loss, countNodes(member.tree)) for member in dominating])
+                elseif !any([
+                    options.earlyStopCondition(member.loss, countNodes(member.tree)) for
+                    member in dominating
+                ])
                     # None of the equations meet the stop condition.
                     all_below = false
                 end
@@ -813,7 +1003,7 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
 
     @recorder begin
         open(options.recorder_file, "w") do io
-            JSON3.write(io, record, allow_inf = true)
+            JSON3.write(io, record; allow_inf=true)
         end
     end
 
@@ -829,6 +1019,5 @@ function _EquationSearch(::ConcurrencyType, datasets::Array{Dataset{T}, 1};
         end
     end
 end
-
 
 end #module SR

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -17,9 +17,8 @@ function debug_inline(verbosity, string...)
 end
 
 function getTime()::Int
-    return round(Int, 1e3*(time()-1.6e9))
+    return round(Int, 1e3 * (time() - 1.6e9))
 end
-
 
 function check_numeric(n)
     return tryparse(Float64, n) !== nothing
@@ -31,15 +30,15 @@ function is_anonymous_function(op)
 end
 
 function recursive_merge(x::AbstractVector...)
-    cat(x...; dims=1)
+    return cat(x...; dims=1)
 end
 
 function recursive_merge(x::AbstractDict...)
-    merge(recursive_merge, x...)
+    return merge(recursive_merge, x...)
 end
 
 function recursive_merge(x...)
-    x[end]
+    return x[end]
 end
 
 isgood(x::T) where {T<:Number} = !(isnan(x) || !isfinite(x))
@@ -47,34 +46,35 @@ isgood(x) = true
 isbad(x) = !isgood(x)
 
 macro return_on_false(flag, retval)
-    :(if !$(esc(flag))
-          return ($(esc(retval)), false)
-    end)
+    :(
+        if !$(esc(flag))
+            return ($(esc(retval)), false)
+        end
+    )
 end
 
 # Returns two arrays
 macro return_on_false2(flag, retval, retval2)
-    :(if !$(esc(flag))
-          return ($(esc(retval)), $(esc(retval2)), false)
-    end)
+    :(
+        if !$(esc(flag))
+            return ($(esc(retval)), $(esc(retval2)), false)
+        end
+    )
 end
 
-function next_worker(worker_assignment::Dict{Tuple{Int,Int}, Int}, procs::Vector{Int})::Int
-    job_counts = Dict(proc=>0 for proc in procs)
+function next_worker(worker_assignment::Dict{Tuple{Int,Int},Int}, procs::Vector{Int})::Int
+    job_counts = Dict(proc => 0 for proc in procs)
     for (key, value) in worker_assignment
         @assert haskey(job_counts, value)
         job_counts[value] += 1
     end
     least_busy_worker = reduce(
-        (proc1, proc2) -> (
-            job_counts[proc1] <= job_counts[proc2] ? proc1 : proc2
-        ),
-        procs
+        (proc1, proc2) -> (job_counts[proc1] <= job_counts[proc2] ? proc1 : proc2), procs
     )
     return least_busy_worker
 end
 
-function next_worker(worker_assignment::Dict{Tuple{Int,Int}, Int}, procs::Nothing)::Int
+function next_worker(worker_assignment::Dict{Tuple{Int,Int},Int}, procs::Nothing)::Int
     return 0
 end
 

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -16,7 +16,7 @@ function debug_inline(verbosity, string...)
     end
 end
 
-function getTime()::Int
+function get_time()::Int
     return round(Int, 1e3 * (time() - 1.6e9))
 end
 

--- a/src/scripts/apply_deprecates.py
+++ b/src/scripts/apply_deprecates.py
@@ -1,0 +1,32 @@
+from glob import glob
+import re
+
+# Use src/Deprecates.jl to replace all deprecated functions
+# in entire codebase, excluding src/Deprecates.jl
+
+# First, we build the library:
+with open("src/Deprecates.jl", "r") as f:
+    library = {}
+    for line in f.read().split("\n"):
+        # If doesn't start with `@deprecate`, skip:
+        if not line.startswith("@deprecate"):
+            continue
+
+        # Each line is in the format:
+        # @deprecate <function> <replacement>
+        function_name = line.split(" ")[1]
+        replacement = line.split(" ")[2]
+        library[function_name] = replacement
+
+# Now, we replace all deprecated functions in src/*.jl:
+for fname in glob("**/*.jl"):
+    if fname == "src/Deprecates.jl":
+        continue
+    with open(fname, "r") as f:
+        contents = f.read()
+        for function_name in library:
+            contents = re.sub(
+                r"\b" + function_name + r"\b", library[function_name], contents
+            )
+    with open(fname, "w") as f:
+        f.write(contents)

--- a/test/full.jl
+++ b/test/full.jl
@@ -1,7 +1,7 @@
 include("test_params.jl")
 using SymbolicRegression, SymbolicUtils
 using Test
-using SymbolicRegression: stringTree
+using SymbolicRegression: string_tree
 using Random
 
 x1 = 0.1f0;
@@ -93,7 +93,7 @@ for i in 0:5
             numprocs=numprocs,
             multithreading=multithreading,
         )
-        dominating = [calculateParetoFrontier(X, y, hallOfFame, options; weights=weights)]
+        dominating = [calculate_pareto_frontier(X, y, hallOfFame, options; weights=weights)]
     else
         y = 2 * cos.(X[4, :])
         if multi
@@ -106,10 +106,10 @@ for i in 0:5
         )
         if multi
             dominating = [
-                calculateParetoFrontier(X, y[j, :], hallOfFame[j], options) for j in 1:2
+                calculate_pareto_frontier(X, y[j, :], hallOfFame[j], options) for j in 1:2
             ]
         else
-            dominating = [calculateParetoFrontier(X, y, hallOfFame, options)]
+            dominating = [calculate_pareto_frontier(X, y, hallOfFame, options)]
         end
     end
 
@@ -148,7 +148,7 @@ X = randn(MersenneTwister(0), Float32, 5, 100)
 y = 2 * cos.(X[4, :])
 varMap = ["t1", "t2", "t3", "t4", "t5"]
 state, hallOfFame = EquationSearch(X, y; varMap=varMap, niterations=2, options=options)
-dominating = calculateParetoFrontier(X, y, hallOfFame, options)
+dominating = calculate_pareto_frontier(X, y, hallOfFame, options)
 
 best = dominating[end]
 
@@ -177,9 +177,9 @@ state, hallOfFame = EquationSearch(
     X, y; varMap=varMap, niterations=0, options=options, saved_state=(state, hallOfFame)
 )
 
-dominating = calculateParetoFrontier(X, y, hallOfFame, options)
+dominating = calculate_pareto_frontier(X, y, hallOfFame, options)
 best = dominating[end]
-printTree(best.tree, options)
+print_tree(best.tree, options)
 eqn = node_to_symbolic(best.tree, options; varMap=varMap)
 residual = simplify(eqn - true_eqn) + t4 * 1e-10
 @test best.loss < maximum_residual / 10

--- a/test/manual_distributed.jl
+++ b/test/manual_distributed.jl
@@ -23,7 +23,7 @@ options = SymbolicRegression.Options(;
 hallOfFame = EquationSearch(X, y; niterations=8, options=options, procs=procs)
 rmprocs(procs)
 
-dominating = calculateParetoFrontier(X, y, hallOfFame, options)
+dominating = calculate_pareto_frontier(X, y, hallOfFame, options)
 best = dominating[end]
 # Test the score
 @test best.loss < maximum_residual / 10

--- a/test/manual_distributed.jl
+++ b/test/manual_distributed.jl
@@ -5,23 +5,22 @@ procs = addprocs(4)
 using Test, Pkg
 project_path = splitdir(Pkg.project().path)[1]
 @everywhere procs begin
-    Base.MainInclude.eval(quote
-        using Pkg
-        Pkg.activate($$project_path)
-    end)
+    Base.MainInclude.eval(
+        quote
+            using Pkg
+            Pkg.activate($$project_path)
+        end,
+    )
 end
 @everywhere using SymbolicRegression
-@everywhere _inv(x::Float32)::Float32 = 1f0/x
+@everywhere _inv(x::Float32)::Float32 = 1.0f0 / x
 X = rand(Float32, 5, 100) .+ 1
 y = 1.2f0 .+ 2 ./ X[3, :]
 
 options = SymbolicRegression.Options(;
-    default_params...,
-    binary_operators=(+, *),
-    unary_operators=(_inv,),
-    npopulations=8
+    default_params..., binary_operators=(+, *), unary_operators=(_inv,), npopulations=8
 )
-hallOfFame = EquationSearch(X, y, niterations=8, options=options, procs=procs)
+hallOfFame = EquationSearch(X, y; niterations=8, options=options, procs=procs)
 rmprocs(procs)
 
 dominating = calculateParetoFrontier(X, y, hallOfFame, options)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,8 @@
 using SafeTestsets
 
-@safetestset "Unit tests" begin include("unittest.jl") end
-@safetestset "End to end test" begin include("full.jl") end
+@safetestset "Unit tests" begin
+    include("unittest.jl")
+end
+@safetestset "End to end test" begin
+    include("full.jl")
+end

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -5,20 +5,34 @@ using Random
 using Zygote
 using LinearAlgebra
 
-
 seed = 0
-pow_abs(x::T, y::T) where {T<:Real} = abs(x) ^ y
+pow_abs(x::T, y::T) where {T<:Real} = abs(x)^y
 custom_cos(x::T) where {T<:Real} = cos(x)^2
 
 # Define these custom functions for Node data types:
-pow_abs(l::Node, r::Node)::Node = (l.constant && r.constant) ? Node(pow_abs(l.val, r.val)::AbstractFloat) : Node(5, l, r)
-pow_abs(l::Node, r::AbstractFloat)::Node = l.constant ? Node(pow_abs(l.val, r)::AbstractFloat) : Node(5, l, r)
-pow_abs(l::AbstractFloat, r::Node)::Node = r.constant ? Node(pow_abs(l, r.val)::AbstractFloat) : Node(5, l, r)
+pow_abs(l::Node, r::Node)::Node =
+    (l.constant && r.constant) ? Node(pow_abs(l.val, r.val)::AbstractFloat) : Node(5, l, r)
+pow_abs(l::Node, r::AbstractFloat)::Node =
+    l.constant ? Node(pow_abs(l.val, r)::AbstractFloat) : Node(5, l, r)
+pow_abs(l::AbstractFloat, r::Node)::Node =
+    r.constant ? Node(pow_abs(l, r.val)::AbstractFloat) : Node(5, l, r)
 custom_cos(x::Node)::Node = x.constant ? Node(custom_cos(x.val)::AbstractFloat) : Node(1, x)
 
 equation1(x1, x2, x3) = x1 + x2 + x3 + 3.2f0
-equation2(x1, x2, x3) = pow_abs(x1, x2) + x3 + custom_cos(1f0 + x3) + 3f0 / x1
-equation3(x1, x2, x3) = (((x2 + x2) * ((-0.5982493 / pow_abs(x1, x2)) / -0.54734415)) + (sin(custom_cos(sin(1.2926733 - 1.6606787) / sin(((0.14577048 * x1) + ((0.111149654 + x1) - -0.8298334)) - -1.2071426)) * (custom_cos(x3 - 2.3201916) + ((x1 - (x1 * x2)) / x2))) / (0.14854191 - ((custom_cos(x2) * -1.6047639) - 0.023943262))))
+equation2(x1, x2, x3) = pow_abs(x1, x2) + x3 + custom_cos(1.0f0 + x3) + 3.0f0 / x1
+function equation3(x1, x2, x3)
+    return (
+        ((x2 + x2) * ((-0.5982493 / pow_abs(x1, x2)) / -0.54734415)) + (
+            sin(
+                custom_cos(
+                    sin(1.2926733 - 1.6606787) / sin(
+                        ((0.14577048 * x1) + ((0.111149654 + x1) - -0.8298334)) - -1.2071426
+                    ),
+                ) * (custom_cos(x3 - 2.3201916) + ((x1 - (x1 * x2)) / x2)),
+            ) / (0.14854191 - ((custom_cos(x2) * -1.6047639) - 0.023943262))
+        )
+    )
+end
 
 nx1 = Node("x1")
 nx2 = Node("x2")
@@ -27,10 +41,10 @@ nx3 = Node("x3")
 # Equations to test gradients on:
 
 function array_test(ar1, ar2; rtol=0.1)
-    isapprox(ar1, ar2, rtol=rtol)
+    return isapprox(ar1, ar2; rtol=rtol)
 end
 
-for type ∈ [Float32, Float64]
+for type in [Float32, Float64]
     println("Testing derivatives with respect to variables, with type=$(type).")
     rng = MersenneTwister(seed)
     nfeatures = 3
@@ -44,21 +58,24 @@ for type ∈ [Float32, Float64]
         enable_autodiff=true,
     )
 
-    for j=1:3
+    for j in 1:3
         equation = [equation1, equation2, equation3][j]
 
         tree = equation(nx1, nx2, nx3)
         predicted_output = evalTreeArray(tree, X, options)[1]
-        true_output = equation.([X[i, :] for i=1:nfeatures]...)
+        true_output = equation.([X[i, :] for i in 1:nfeatures]...)
 
         # First, check if the predictions are approximately equal:
         @test array_test(predicted_output, true_output)
 
-        true_grad = gradient((x1, x2, x3) -> sum(equation.(x1, x2, x3)), [X[i, :] for i=1:nfeatures]...)
+        true_grad = gradient(
+            (x1, x2, x3) -> sum(equation.(x1, x2, x3)), [X[i, :] for i in 1:nfeatures]...
+        )
         # Convert tuple of vectors to matrix:
         true_grad = reduce(hcat, true_grad)'
         predicted_grad = evalGradTreeArray(tree, X, options; variable=true)[2]
-        predicted_grad2 = reduce(hcat, [evalDiffTreeArray(tree, X, options, i)[2] for i=1:nfeatures])'
+        predicted_grad2 =
+            reduce(hcat, [evalDiffTreeArray(tree, X, options, i)[2] for i in 1:nfeatures])'
 
         # Print largest difference between predicted_grad, true_grad:
         @test array_test(predicted_grad, true_grad)
@@ -67,7 +84,6 @@ for type ∈ [Float32, Float64]
         # Make sure that the array_test actually works:
         @test !array_test(predicted_grad .* 0, true_grad)
         @test !array_test(predicted_grad2 .* 0, true_grad)
-
     end
     println("Done.")
     println("Testing derivatives with respect to constants, with type=$(type).")
@@ -79,20 +95,25 @@ for type ∈ [Float32, Float64]
     predicted_grad = evalGradTreeArray(tree, X, options; variable=false)[2]
     @test array_test(predicted_grad[1, :], X[1, :])
 
-
     # More complex expression:
     const_value = 2.1f0
     const_value2 = -3.2f0
 
-    equation5(x1, x2, x3) = pow_abs(x1, x2) + x3 + custom_cos(const_value + x3) + const_value2 / x1
-    equation5_with_const(c1, c2, x1, x2, x3) = pow_abs(x1, x2) + x3 + custom_cos(c1 + x3) + c2 / x1
+    function equation5(x1, x2, x3)
+        return pow_abs(x1, x2) + x3 + custom_cos(const_value + x3) + const_value2 / x1
+    end
+    function equation5_with_const(c1, c2, x1, x2, x3)
+        return pow_abs(x1, x2) + x3 + custom_cos(c1 + x3) + c2 / x1
+    end
 
     tree = equation5(nx1, nx2, nx3)
 
     # Use zygote to explicitly find the gradient:
     true_grad = gradient(
         (c1, c2, x1, x2, x3) -> sum(equation5_with_const.(c1, c2, x1, x2, x3)),
-        fill(const_value, N), fill(const_value2, N), [X[i, :] for i=1:nfeatures]...
+        fill(const_value, N),
+        fill(const_value2, N),
+        [X[i, :] for i in 1:nfeatures]...,
     )[1:2]
     true_grad = reduce(hcat, true_grad)'
     predicted_grad = evalGradTreeArray(tree, X, options; variable=false)[2]
@@ -100,7 +121,6 @@ for type ∈ [Float32, Float64]
     @test array_test(predicted_grad, true_grad)
     println("Done.")
 end
-
 
 println("Testing NodeIndex.")
 
@@ -120,7 +140,8 @@ function check_tree(tree::Node, node_index::NodeIndex, constant_list::AbstractVe
     elseif tree.degree == 1
         check_tree(tree.l, node_index.l, constant_list)
     else
-        check_tree(tree.l, node_index.l, constant_list) && check_tree(tree.r, node_index.r, constant_list)
+        check_tree(tree.l, node_index.l, constant_list) &&
+            check_tree(tree.r, node_index.r, constant_list)
     end
 end
 

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -75,7 +75,9 @@ for type in [Float32, Float64]
         true_grad = reduce(hcat, true_grad)'
         predicted_grad = eval_grad_tree_array(tree, X, options; variable=true)[2]
         predicted_grad2 =
-            reduce(hcat, [eval_diff_tree_array(tree, X, options, i)[2] for i in 1:nfeatures])'
+            reduce(
+                hcat, [eval_diff_tree_array(tree, X, options, i)[2] for i in 1:nfeatures]
+            )'
 
         # Print largest difference between predicted_grad, true_grad:
         @test array_test(predicted_grad, true_grad)

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -1,6 +1,6 @@
 using Test
 using SymbolicRegression
-using SymbolicRegression: evalDiffTreeArray, evalGradTreeArray
+using SymbolicRegression: eval_diff_tree_array, eval_grad_tree_array
 using Random
 using Zygote
 using LinearAlgebra
@@ -62,7 +62,7 @@ for type in [Float32, Float64]
         equation = [equation1, equation2, equation3][j]
 
         tree = equation(nx1, nx2, nx3)
-        predicted_output = evalTreeArray(tree, X, options)[1]
+        predicted_output = eval_tree_array(tree, X, options)[1]
         true_output = equation.([X[i, :] for i in 1:nfeatures]...)
 
         # First, check if the predictions are approximately equal:
@@ -73,9 +73,9 @@ for type in [Float32, Float64]
         )
         # Convert tuple of vectors to matrix:
         true_grad = reduce(hcat, true_grad)'
-        predicted_grad = evalGradTreeArray(tree, X, options; variable=true)[2]
+        predicted_grad = eval_grad_tree_array(tree, X, options; variable=true)[2]
         predicted_grad2 =
-            reduce(hcat, [evalDiffTreeArray(tree, X, options, i)[2] for i in 1:nfeatures])'
+            reduce(hcat, [eval_diff_tree_array(tree, X, options, i)[2] for i in 1:nfeatures])'
 
         # Print largest difference between predicted_grad, true_grad:
         @test array_test(predicted_grad, true_grad)
@@ -92,7 +92,7 @@ for type in [Float32, Float64]
     equation4(x1, x2, x3) = 3.2f0 * x1
     # The gradient should be: (C * x1) => x1 is gradient with respect to C.
     tree = equation4(nx1, nx2, nx3)
-    predicted_grad = evalGradTreeArray(tree, X, options; variable=false)[2]
+    predicted_grad = eval_grad_tree_array(tree, X, options; variable=false)[2]
     @test array_test(predicted_grad[1, :], X[1, :])
 
     # More complex expression:
@@ -116,7 +116,7 @@ for type in [Float32, Float64]
         [X[i, :] for i in 1:nfeatures]...,
     )[1:2]
     true_grad = reduce(hcat, true_grad)'
-    predicted_grad = evalGradTreeArray(tree, X, options; variable=false)[2]
+    predicted_grad = eval_grad_tree_array(tree, X, options; variable=false)[2]
 
     @test array_test(predicted_grad, true_grad)
     println("Done.")
@@ -124,7 +124,7 @@ end
 
 println("Testing NodeIndex.")
 
-import SymbolicRegression: getConstants, NodeIndex, indexConstants
+import SymbolicRegression: get_constants, NodeIndex, index_constants
 
 options = Options(;
     binary_operators=(+, *, -, /, pow_abs),
@@ -145,6 +145,6 @@ function check_tree(tree::Node, node_index::NodeIndex, constant_list::AbstractVe
     end
 end
 
-@test check_tree(tree, indexConstants(tree), getConstants(tree))
+@test check_tree(tree, index_constants(tree), get_constants(tree))
 
 println("Done.")

--- a/test/test_params.jl
+++ b/test/test_params.jl
@@ -24,9 +24,11 @@ default_params = (
     annealing=true,
     batching=false,
     batchSize=50,
-    mutationWeights=[10.000000, 1.000000, 1.000000, 3.000000, 3.000000, 0.010000, 1.000000, 1.000000],
+    mutationWeights=[
+        10.000000, 1.000000, 1.000000, 3.000000, 3.000000, 0.010000, 1.000000, 1.000000
+    ],
     crossoverProbability=0.0f0,
-    warmupMaxsizeBy=0f0,
+    warmupMaxsizeBy=0.0f0,
     useFrequency=false,
     npop=1000,
     ncyclesperiteration=300,

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -5,9 +5,7 @@ include("test_params.jl")
 
 ## Test Base.print
 options = Options(;
-    default_params...,
-    binary_operators=(+, *, /, -),
-    unary_operators=(cos, sin),
+    default_params..., binary_operators=(+, *, /, -), unary_operators=(cos, sin)
 )
 
 f = (x1, x2, x3) -> (sin(cos(sin(cos(x1) * x3) * 3.0) * -0.5) + 2.0) * 5.0
@@ -21,9 +19,14 @@ true_s = "((sin(cos(sin(cos(x1) * x3) * 3.0) * -0.5) + 2.0) * 5.0)"
 
 # TODO: Next, we test that custom varMaps work:
 
-EquationSearch(randn(Float32, 3, 10), randn(Float32, 10),
-               options=options, varMap=["v1", "v2", "v3"],
-               niterations=0, multithreading=true)
+EquationSearch(
+    randn(Float32, 3, 10),
+    randn(Float32, 10);
+    options=options,
+    varMap=["v1", "v2", "v3"],
+    niterations=0,
+    multithreading=true,
+)
 
 s = repr(tree)
 true_s = "((sin(cos(sin(cos(v1) * v3) * 3.0) * -0.5) + 2.0) * 5.0)"

--- a/test/test_prob_pick_first.jl
+++ b/test/test_prob_pick_first.jl
@@ -15,25 +15,24 @@ for reverse in [false, true]
     members = PopMember{Float32}[]
 
     # Generate members with scores from 0 to 1:
-    for i=1:n
+    for i in 1:n
         tree = Node("x1") * 3.2f0
-        score = Float32(i-1)/(n-1)
+        score = Float32(i - 1) / (n - 1)
         if reverse
             score = 1 - score
         end
-        loss = 1f0  # (arbitrary for this test)
+        loss = 1.0f0  # (arbitrary for this test)
         push!(members, PopMember(tree, score, loss))
     end
 
     pop = Population(members, n)
 
-    dummy_frequencies = [0f-10 for i=1:100]
+    dummy_frequencies = [0.0f-10 for i in 1:100]
     best_pop_member = [
-        SymbolicRegression.bestOfSample(pop, dummy_frequencies, options).score
-        for j=1:100
+        SymbolicRegression.bestOfSample(pop, dummy_frequencies, options).score for j in 1:100
     ]
 
-    mean_value = sum(best_pop_member)/length(best_pop_member)
+    mean_value = sum(best_pop_member) / length(best_pop_member)
 
     # Make sure average score is small
     @test mean_value < 0.1

--- a/test/test_prob_pick_first.jl
+++ b/test/test_prob_pick_first.jl
@@ -21,8 +21,8 @@ for reverse in [false, true]
         if reverse
             score = 1 - score
         end
-        loss = 1.0f0  # (arbitrary for this test)
-        push!(members, PopMember(tree, score, loss))
+        test_loss = 1.0f0  # (arbitrary for this test)
+        push!(members, PopMember(tree, score, test_loss))
     end
 
     pop = Population(members, n)

--- a/test/test_prob_pick_first.jl
+++ b/test/test_prob_pick_first.jl
@@ -30,7 +30,7 @@ for reverse in [false, true]
     dummy_frequencies = [0.0f-10 for i in 1:100]
     best_pop_member = [
         SymbolicRegression.best_of_sample(pop, dummy_frequencies, options).score for
-        j = 1:100
+        j in 1:100
     ]
 
     mean_value = sum(best_pop_member) / length(best_pop_member)

--- a/test/test_prob_pick_first.jl
+++ b/test/test_prob_pick_first.jl
@@ -29,7 +29,8 @@ for reverse in [false, true]
 
     dummy_frequencies = [0.0f-10 for i in 1:100]
     best_pop_member = [
-        SymbolicRegression.best_of_sample(pop, dummy_frequencies, options).score for j in 1:100
+        SymbolicRegression.best_of_sample(pop, dummy_frequencies, options).score for
+        j = 1:100
     ]
 
     mean_value = sum(best_pop_member) / length(best_pop_member)

--- a/test/test_prob_pick_first.jl
+++ b/test/test_prob_pick_first.jl
@@ -29,7 +29,7 @@ for reverse in [false, true]
 
     dummy_frequencies = [0.0f-10 for i in 1:100]
     best_pop_member = [
-        SymbolicRegression.bestOfSample(pop, dummy_frequencies, options).score for j in 1:100
+        SymbolicRegression.best_of_sample(pop, dummy_frequencies, options).score for j in 1:100
     ]
 
     mean_value = sum(best_pop_member) / length(best_pop_member)

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -7,7 +7,7 @@ binary_operators = (+, -, /, *)
 
 index_of_mult = [i for (i, op) in enumerate(binary_operators) if op == *][1]
 
-options = Options(binary_operators=binary_operators)
+options = Options(; binary_operators=binary_operators)
 
 tree = Node("x1") + Node("x1")
 
@@ -38,22 +38,33 @@ tree_copy = convert(Node, eqn, options)
 # Let's test a much more complex function,
 # with custom operators, and unary operators:
 x1, x2, x3 = Node("x1"), Node("x2"), Node("x3")
-pow_abs(x, y) = abs(x) ^ y
+pow_abs(x, y) = abs(x)^y
 custom_cos(x) = cos(x)^2
 
 # Define for Node (usually these are done internally to Options)
-pow_abs(l::Node, r::Node)::Node = (l.constant && r.constant) ? Node(pow_abs(l.val, r.val)::AbstractFloat) : Node(5, l, r)
-pow_abs(l::Node, r::AbstractFloat)::Node = l.constant ? Node(pow_abs(l.val, r)::AbstractFloat) : Node(5, l, r)
-pow_abs(l::AbstractFloat, r::Node)::Node = r.constant ? Node(pow_abs(l, r.val)::AbstractFloat) : Node(5, l, r)
+pow_abs(l::Node, r::Node)::Node =
+    (l.constant && r.constant) ? Node(pow_abs(l.val, r.val)::AbstractFloat) : Node(5, l, r)
+pow_abs(l::Node, r::AbstractFloat)::Node =
+    l.constant ? Node(pow_abs(l.val, r)::AbstractFloat) : Node(5, l, r)
+pow_abs(l::AbstractFloat, r::Node)::Node =
+    r.constant ? Node(pow_abs(l, r.val)::AbstractFloat) : Node(5, l, r)
 custom_cos(x::Node)::Node = x.constant ? Node(custom_cos(x.val)::AbstractFloat) : Node(1, x)
 
 options = Options(;
-    binary_operators=(+, *, -, /, pow_abs),
-    unary_operators=(custom_cos, exp, sin),
+    binary_operators=(+, *, -, /, pow_abs), unary_operators=(custom_cos, exp, sin)
 )
-tree = (((x2 + x2) * ((-0.5982493 / pow_abs(x1, x2)) / -0.54734415)) + (sin(custom_cos(sin(1.2926733 - 1.6606787) / sin(((0.14577048 * x1) + ((0.111149654 + x1) - -0.8298334)) - -1.2071426)) * (custom_cos(x3 - 2.3201916) + ((x1 - (x1 * x2)) / x2))) / (0.14854191 - ((custom_cos(x2) * -1.6047639) - 0.023943262))))
+tree = (
+    ((x2 + x2) * ((-0.5982493 / pow_abs(x1, x2)) / -0.54734415)) + (
+        sin(
+            custom_cos(
+                sin(1.2926733 - 1.6606787) /
+                sin(((0.14577048 * x1) + ((0.111149654 + x1) - -0.8298334)) - -1.2071426),
+            ) * (custom_cos(x3 - 2.3201916) + ((x1 - (x1 * x2)) / x2)),
+        ) / (0.14854191 - ((custom_cos(x2) * -1.6047639) - 0.023943262))
+    )
+)
 # We use `index_functions` to avoid converting the custom operators into the primitives.
-eqn = convert(Symbolic, tree, options, index_functions=true)
+eqn = convert(Symbolic, tree, options; index_functions=true)
 
 tree_copy = convert(Node, eqn, options)
 tree_copy2 = convert(Node, simplify(eqn), options)

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -71,9 +71,9 @@ tree_copy2 = convert(Node, simplify(eqn), options)
 # Too difficult to check the representation, so we check by evaluation:
 N = 100
 X = rand(MersenneTwister(0), 3, N) .+ 0.1
-output1, flag1 = evalTreeArray(tree, X, options)
-output2, flag2 = evalTreeArray(tree_copy, X, options)
-output3, flag3 = evalTreeArray(tree_copy2, X, options)
+output1, flag1 = eval_tree_array(tree, X, options)
+output2, flag2 = eval_tree_array(tree_copy, X, options)
+output3, flag3 = eval_tree_array(tree_copy2, X, options)
 
 @test isapprox(output1, output2, atol=1e-4 * sqrt(N))
 # Simplified equation may give a different answer due to rounding errors,

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -166,13 +166,13 @@ customloss(x, y, w) = w * (abs(x - y)^2.5)
 testl1(x, y) = abs(x - y)
 testl1(x, y, w) = abs(x - y) * w
 
-for (loss, evaluator) in [(L1DistLoss(), testl1), (customloss, customloss)]
+for (loss_fnc, evaluator) in [(L1DistLoss(), testl1), (customloss, customloss)]
     local options = Options(;
         default_params...,
         binary_operators=(+, *, -, /),
         unary_operators=(cos, exp),
         npopulations=4,
-        loss=loss,
+        loss=loss_fnc,
     )
     x = randn(MersenneTwister(0), Float32, 100)
     y = randn(MersenneTwister(1), Float32, 100)

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -102,16 +102,10 @@ for unaop in [cos, exp, log_abs, log2_abs, log10_abs, relu, gamma, acosh_abs]
             # Test gradients:
             df_true = x -> ForwardDiff.derivative(f_true, x)
             dy = T.(df_true.(X[1, :]))
-            test_dy = (
-                x -> ForwardDiff.gradient(
-                    _x -> sum(differentiable_eval_tree_array(tree, _x, make_options())[1]),
-                    x,
-                )
-            )(
-                X
-            )[
-                1, :
-            ]
+            test_dy = ForwardDiff.gradient(
+                _x -> sum(differentiable_eval_tree_array(tree, _x, make_options())[1]), X
+            )
+            test_dy = test_dy[1, 1:end]
             @test all(abs.(test_dy .- dy) / N .< zero_tolerance)
         end
     end

--- a/test/user_defined_operator.jl
+++ b/test/user_defined_operator.jl
@@ -10,7 +10,7 @@ options = SymbolicRegression.Options(;
 )
 hallOfFame = EquationSearch(X, y; niterations=8, options=options, numprocs=4)
 
-dominating = calculateParetoFrontier(X, y, hallOfFame, options)
+dominating = calculate_pareto_frontier(X, y, hallOfFame, options)
 
 best = dominating[end]
 # Test the score

--- a/test/user_defined_operator.jl
+++ b/test/user_defined_operator.jl
@@ -1,17 +1,14 @@
 using SymbolicRegression, Test
 include("test_params.jl")
 
-_inv(x::Float32)::Float32 = 1f0/x
+_inv(x::Float32)::Float32 = 1.0f0 / x
 X = rand(Float32, 5, 100) .+ 1
 y = 1.2f0 .+ 2 ./ X[3, :]
 
 options = SymbolicRegression.Options(;
-    default_params...,
-    binary_operators=(+, *),
-    unary_operators=(_inv,),
-    npopulations=8
+    default_params..., binary_operators=(+, *), unary_operators=(_inv,), npopulations=8
 )
-hallOfFame = EquationSearch(X, y, niterations=8, options=options, numprocs=4)
+hallOfFame = EquationSearch(X, y; niterations=8, options=options, numprocs=4)
 
 dominating = calculateParetoFrontier(X, y, hallOfFame, options)
 


### PR DESCRIPTION
This applies the "blue style" Julia formatting to every single file in the repository. This will cause changes for branched code, so to fix this, it is probably easiest if you apply the same formatting to the branch, then manually git patch things.

The formatting can be done with:
```julia
using JuliaFormatter
format(".")
```
in the root directory.

The other changes were a bulk regex replace of the deprecations listed in `src/Deprecations.jl` using the Python regex script in `src/scripts/apply_deprecates.py`, with manual corrections where necessary (e.g., `loss` is often used as a variable, but it is now a function in the library).