### PR TITLE
Limiting max evaluations

### DIFF
--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -25,7 +25,7 @@ function optimize_constants(
     nconst = count_constants(member.tree)
     num_evals = 0.0
     if nconst == 0
-        return member
+        return (member, 0.0)
     end
     x0 = get_constants(member.tree)
     f(x::Vector{CONST_TYPE})::T = opt_func(x, dataset, baseline, member.tree, options)

--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -21,8 +21,9 @@ end
 # Use Nelder-Mead to optimize the constants in an equation
 function optimize_constants(
     dataset::Dataset{T}, baseline::T, member::PopMember, options::Options
-)::PopMember where {T<:Real}
+)::Tuple{PopMember,Float64} where {T<:Real}
     nconst = count_constants(member.tree)
+    num_evals = 0.0
     if nconst == 0
         return member
     end
@@ -42,6 +43,7 @@ function optimize_constants(
     result = Optim.optimize(
         f, x0, algorithm, Optim.Options(; iterations=options.optimizer_iterations)
     )
+    num_evals += result.f_calls
     # Try other initial conditions:
     for i in 1:(options.optimizer_nrestarts)
         new_start =
@@ -55,6 +57,7 @@ function optimize_constants(
             algorithm,
             Optim.Options(; iterations=options.optimizer_iterations),
         )
+        num_evals += tmpresult.f_calls
 
         if tmpresult.minimum < result.minimum
             result = tmpresult
@@ -64,11 +67,12 @@ function optimize_constants(
     if Optim.converged(result)
         set_constants(member.tree, result.minimizer)
         member.score, member.loss = score_func(dataset, baseline, member.tree, options)
+        num_evals += 1
         member.birth = get_time()
     else
         set_constants(member.tree, x0)
     end
-    return member
+    return member, num_evals
 end
 
 end

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -232,6 +232,7 @@ https://github.com/MilesCranmer/PySR/discussions/115.
 - `earlyStopCondition`: Float - whether to stop early if the mean loss gets below this value.
     Function - a function taking (loss, complexity) as arguments and returning true or false.
 - `timeout_in_seconds`: Float64 - the time in seconds after which to exit (as an alternative to the number of iterations).
+- `max_evals`: Int (or Nothing) - the maximum number of evaluations of expressions to perform.
 - `skip_mutation_failures`: Whether to simply skip over mutations that fail or are rejected, rather than to replace the mutated
     expression with the original expression and proceed normally.
 - `enable_autodiff`: Whether to enable automatic differentiation functionality. This is turned off by default.
@@ -293,6 +294,7 @@ function Options(;
     earlyStopCondition::Union{Function,AbstractFloat,Nothing}=nothing,
     stateReturn::Bool=false,
     timeout_in_seconds=nothing,
+    max_evals=nothing,
     skip_mutation_failures::Bool=true,
     enable_autodiff::Bool=false,
     nested_constraints=nothing,
@@ -553,6 +555,7 @@ function Options(;
         earlyStopCondition,
         stateReturn,
         timeout_in_seconds,
+        max_evals,
         skip_mutation_failures,
         enable_autodiff,
         nested_constraints,

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -51,8 +51,8 @@ struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
     probPickFirst::Float32
     earlyStopCondition::Union{Function,Nothing}
     stateReturn::Bool
-    timeout_in_seconds::Union{Float64, Nothing}
-    max_evals::Union{Int, Nothing}
+    timeout_in_seconds::Union{Float64,Nothing}
+    max_evals::Union{Int,Nothing}
     skip_mutation_failures::Bool
     enable_autodiff::Bool
     nested_constraints::Union{Vector{Tuple{Int,Int,Vector{Tuple{Int,Int,Int}}}},Nothing}

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -51,7 +51,6 @@ struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
     probPickFirst::Float32
     earlyStopCondition::Union{Function,Nothing}
     stateReturn::Bool
-    use_symbolic_utils::Bool
     timeout_in_seconds::Union{Float64, Nothing}
     max_evals::Union{Int, Nothing}
     skip_mutation_failures::Bool

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -51,7 +51,9 @@ struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function}}
     probPickFirst::Float32
     earlyStopCondition::Union{Function,Nothing}
     stateReturn::Bool
-    timeout_in_seconds::Union{Float64,Nothing}
+    use_symbolic_utils::Bool
+    timeout_in_seconds::Union{Float64, Nothing}
+    max_evals::Union{Int, Nothing}
     skip_mutation_failures::Bool
     enable_autodiff::Bool
     nested_constraints::Union{Vector{Tuple{Int,Int,Vector{Tuple{Int,Int,Int}}}},Nothing}

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -118,16 +118,18 @@ end
 
 function finalize_scores(
     dataset::Dataset{T}, baseline::T, pop::Population, options::Options
-)::Population where {T<:Real}
+)::Tuple{Population,Float64} where {T<:Real}
     need_recalculate = options.batching
+    num_evals = 0.0
     if need_recalculate
         @inbounds @simd for member in 1:(pop.n)
             score, loss = score_func(dataset, baseline, pop.members[member].tree, options)
             pop.members[member].score = score
             pop.members[member].loss = loss
         end
+        num_evals += pop.n * (options.batchSize / dataset.n)
     end
-    return pop
+    return (pop, num_evals)
 end
 
 # Return best 10 examples

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -22,7 +22,7 @@ function s_r_cycle(
     verbosity::Int=0,
     options::Options,
     record::RecordType,
-)::Tuple{Population,HallOfFame} where {T<:Real}
+)::Tuple{Population,HallOfFame,Float64} where {T<:Real}
     max_temp = T(1.0)
     min_temp = T(0.0)
     if !options.annealing
@@ -30,9 +30,10 @@ function s_r_cycle(
     end
     all_temperatures = LinRange(max_temp, min_temp, ncycles)
     best_examples_seen = HallOfFame(options)
+    num_evals = 0.0
 
     for temperature in all_temperatures
-        pop = reg_evol_cycle(
+        pop, tmp_num_evals = reg_evol_cycle(
             dataset,
             baseline,
             pop,
@@ -42,6 +43,7 @@ function s_r_cycle(
             options,
             record,
         )
+        num_evals += tmp_num_evals
         for member in pop.members
             size = count_nodes(member.tree)
             score = member.score
@@ -53,7 +55,7 @@ function s_r_cycle(
         end
     end
 
-    return (pop, best_examples_seen)
+    return (pop, best_examples_seen, num_evals)
 end
 
 function optimize_and_simplify_population(
@@ -63,16 +65,21 @@ function optimize_and_simplify_population(
     options::Options,
     curmaxsize::Int,
     record::RecordType,
-)::Population where {T<:Real}
+)::Tuple{Population,Float64} where {T<:Real}
+    array_num_evals = zeros(Float64, pop.n)
     @inbounds @simd for j in 1:(pop.n)
         pop.members[j].tree = simplify_tree(pop.members[j].tree, options)
         pop.members[j].tree = combine_operators(pop.members[j].tree, options)
         if rand() < options.optimize_probability && options.shouldOptimizeConstants
-            pop.members[j] = optimize_constants(dataset, baseline, pop.members[j], options)
+            pop.members[j], array_num_evals[j] = optimize_constants(
+                dataset, baseline, pop.members[j], options
+            )
         end
     end
-    pop = finalize_scores(dataset, baseline, pop, options)
-    return pop
+    num_evals = sum(array_num_evals)
+    pop, tmp_num_evals = finalize_scores(dataset, baseline, pop, options)
+    num_evals += tmp_num_evals
+    return (pop, num_evals)
 end
 
 end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -1014,7 +1014,7 @@ function _EquationSearch(
         ################################################################
         ## num_evals stopping code
         if options.max_evals !== nothing
-            if options.max_evals <= sum(num_evals)
+            if options.max_evals <= sum(sum, num_evals)
                 break
             end
         end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -397,7 +397,7 @@ function _EquationSearch(
     # Start a population on every process
     #    Store the population, hall of fame
     allPopsType = if ConcurrencyType == SRSerial
-        Tuple{Population,HallOfFame,RecordType}
+        Tuple{Population,HallOfFame,RecordType,Float64}
     elseif ConcurrencyType == SRDistributed
         Future
     else
@@ -470,6 +470,10 @@ function _EquationSearch(
         curmaxsizes = [options.maxsize for j in 1:nout]
     end
 
+    # Records the number of evaluations:
+    # Real numbers indicate use of batching.
+    num_evals = [[0.0 for i in 1:(options.npopulations)] for j in 1:nout]
+
     we_created_procs = false
     ##########################################################################
     ### Distributed code:
@@ -525,6 +529,8 @@ function _EquationSearch(
                     HallOfFame(options),
                     RecordType(),
                 )
+                # This involves npop evaluations, on the full dataset:
+                num_evals[j][i] += options.npop
             else
                 is_vector = typeof(saved_state[1]) <: Vector{Vector{Population{T}}}
                 cur_saved_state = is_vector ? saved_state[1][j][i] : saved_state[1][j, i]
@@ -550,6 +556,7 @@ function _EquationSearch(
                         HallOfFame(options),
                         RecordType(),
                     )
+                    num_evals[j][i] += options.npop
                 end
             end
             push!(init_pops[j], new_pop)
@@ -581,7 +588,8 @@ function _EquationSearch(
                 @recorder cur_record["out$(j)_pop$(i)"] = RecordType(
                     "iteration0" => record_population(in_pop, options)
                 )
-                tmp_pop, tmp_best_seen = s_r_cycle(
+                tmp_num_evals = 0.0
+                tmp_pop, tmp_best_seen, evals_from_cycle = s_r_cycle(
                     dataset,
                     baselineMSE,
                     in_pop,
@@ -592,9 +600,11 @@ function _EquationSearch(
                     options=options,
                     record=cur_record,
                 )
-                tmp_pop = optimize_and_simplify_population(
+                tmp_num_evals += evals_from_cycle
+                tmp_pop, evals_from_optimize = optimize_and_simplify_population(
                     dataset, baselineMSE, tmp_pop, options, curmaxsize, cur_record
                 )
+                tmp_num_evals += evals_from_optimize
                 if options.batching
                     for i_member in 1:(options.maxsize + MAX_DEGREE)
                         score, result_loss = score_func(
@@ -605,9 +615,10 @@ function _EquationSearch(
                         )
                         tmp_best_seen.members[i_member].score = score
                         tmp_best_seen.members[i_member].loss = result_loss
+                        tmp_num_evals += 1
                     end
                 end
-                (tmp_pop, tmp_best_seen, cur_record)
+                (tmp_pop, tmp_best_seen, cur_record, tmp_num_evals)
             end
             push!(allPops[j], updated_pop)
         end
@@ -670,7 +681,7 @@ function _EquationSearch(
         if population_ready
             head_node_start_work = time()
             # Take the fetch operation from the channel since its ready
-            (cur_pop, best_seen, cur_record) =
+            (cur_pop, best_seen, cur_record, cur_num_evals) =
                 if ConcurrencyType in [SRDistributed, SRThreaded]
                     take!(channels[j][i])
                 else
@@ -680,8 +691,10 @@ function _EquationSearch(
             cur_pop::Population
             best_seen::HallOfFame
             cur_record::RecordType
+            cur_num_evals::Float64
             bestSubPops[j][i] = best_sub_pop(cur_pop; topn=options.topn)
             @recorder record = recursive_merge(record, cur_record)
+            num_evals[j][i] += cur_num_evals
 
             dataset = datasets[j]
             baselineMSE = baselineMSEs[j]
@@ -787,7 +800,8 @@ function _EquationSearch(
                 @recorder cur_record[key] = RecordType(
                     "iteration$(iteration)" => record_population(cur_pop, options)
                 )
-                tmp_pop, tmp_best_seen = s_r_cycle(
+                tmp_num_evals = 0.0
+                tmp_pop, tmp_best_seen, evals_from_cycle = s_r_cycle(
                     dataset,
                     baselineMSE,
                     cur_pop,
@@ -798,9 +812,11 @@ function _EquationSearch(
                     options=options,
                     record=cur_record,
                 )
-                tmp_pop = optimize_and_simplify_population(
+                tmp_num_evals += evals_from_cycle
+                tmp_pop, evals_from_optimize = optimize_and_simplify_population(
                     dataset, baselineMSE, tmp_pop, options, curmaxsize, cur_record
                 )
+                tmp_num_evals += evals_from_optimize
 
                 # Update scores if using batching:
                 if options.batching
@@ -814,11 +830,12 @@ function _EquationSearch(
                             )
                             tmp_best_seen.members[i_member].score = score
                             tmp_best_seen.members[i_member].loss = result_loss
+                            tmp_num_evals += 1
                         end
                     end
                 end
 
-                (tmp_pop, tmp_best_seen, cur_record)
+                (tmp_pop, tmp_best_seen, cur_record, tmp_num_evals)
             end
             if ConcurrencyType in [SRDistributed, SRThreaded]
                 tasks[j][i] = @async put!(channels[j][i], fetch(allPops[j][i]))
@@ -989,6 +1006,15 @@ function _EquationSearch(
         ## Timeout stopping code
         if options.timeout_in_seconds !== nothing
             if time() - start_time > options.timeout_in_seconds
+                break
+            end
+        end
+        ################################################################
+
+        ################################################################
+        ## num_evals stopping code
+        if options.max_evals !== nothing
+            if options.max_evals <= sum(num_evals)
                 break
             end
         end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -528,16 +528,16 @@ function _EquationSearch(
                     ),
                     HallOfFame(options),
                     RecordType(),
+                    Float64(options.npop),
                 )
                 # This involves npop evaluations, on the full dataset:
-                num_evals[j][i] += options.npop
             else
                 is_vector = typeof(saved_state[1]) <: Vector{Vector{Population{T}}}
                 cur_saved_state = is_vector ? saved_state[1][j][i] : saved_state[1][j, i]
 
                 if length(cur_saved_state.members) >= options.npop
                     new_pop = @sr_spawner ConcurrencyType worker_idx (
-                        cur_saved_state, HallOfFame(options), RecordType()
+                        cur_saved_state, HallOfFame(options), RecordType(), 0.0
                     )
                 else
                     # If population has not yet been created (e.g., exited too early)
@@ -555,8 +555,8 @@ function _EquationSearch(
                         ),
                         HallOfFame(options),
                         RecordType(),
+                        Float64(options.npop),
                     )
-                    num_evals[j][i] += options.npop
                 end
             end
             push!(init_pops[j], new_pop)


### PR DESCRIPTION
This PR adds support for limiting the number of evaluations. It records evaluations everywhere throughout the code, including the number of evaluations of optimizers.

When batching is turned on, it will add (batch_size/N) to the number of evaluations, rather than 1.

This fixes #74.