### PR TITLE
Set `timeout-minutes` for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
   test:
     name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Most jobs complete in about 20 minutes, so anything above 60 minutes can probably be considered a failure. This avoids having to wait 6 hours for a failure to be reported.