### PR TITLE
Optimizer options

### DIFF
--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -41,7 +41,7 @@ function optimize_constants(
         end
     end
     result = Optim.optimize(
-        f, x0, algorithm, Optim.Options(; iterations=options.optimizer_iterations)
+        f, x0, algorithm, options.optimizer_options
     )
     num_evals += result.f_calls
     # Try other initial conditions:
@@ -55,7 +55,7 @@ function optimize_constants(
             f,
             new_start,
             algorithm,
-            Optim.Options(; iterations=options.optimizer_iterations),
+            options.optimizer_options,
         )
         num_evals += tmpresult.f_calls
 

--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -40,9 +40,7 @@ function optimize_constants(
             error("Optimization function not implemented.")
         end
     end
-    result = Optim.optimize(
-        f, x0, algorithm, options.optimizer_options
-    )
+    result = Optim.optimize(f, x0, algorithm, options.optimizer_options)
     num_evals += result.f_calls
     # Try other initial conditions:
     for i in 1:(options.optimizer_nrestarts)
@@ -51,12 +49,7 @@ function optimize_constants(
                 convert(CONST_TYPE, 1) .+
                 convert(CONST_TYPE, 1//2) * randn(CONST_TYPE, size(x0, 1))
             )
-        tmpresult = Optim.optimize(
-            f,
-            new_start,
-            algorithm,
-            options.optimizer_options,
-        )
+        tmpresult = Optim.optimize(f, new_start, algorithm, options.optimizer_options)
         num_evals += tmpresult.f_calls
 
         if tmpresult.minimum < result.minimum

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -223,6 +223,10 @@ https://github.com/MilesCranmer/PySR/discussions/115.
     for optimization of constants.
 - `optimizer_algorithm`: Select algorithm to use for optimizing constants. Default
     is "BFGS", but "NelderMead" is also supported.
+- `optimizer_options`: General options for the constant optimization. For details
+    we refer to the documentation on `Optim.Options` from the `Optim.jl` package.
+    Options can be provided here as `NamedTuple`, e.g. `(iterations=16,)`, as a
+    `Dict`, e.g. Dict(:x_tol => 1.0e-32,), or as an `Optim.Options` instance.
 - `hofFile`: What file to store equations to, as a backup.
 - `perturbationFactor`: When mutating a constant, either
     multiply or divide by (1+perturbationFactor)^(rand()+1).

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -221,6 +221,8 @@ https://github.com/MilesCranmer/PySR/discussions/115.
     to periodically optimize constants in equations.
 - `optimizer_nrestarts`: How many different random starting positions to consider
     for optimization of constants.
+- `optimizer_algorithm`: Select algorithm to use for optimizing constants. Default
+    is "BFGS", but "NelderMead" is also supported.
 - `hofFile`: What file to store equations to, as a backup.
 - `perturbationFactor`: When mutating a constant, either
     multiply or divide by (1+perturbationFactor)^(rand()+1).

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -591,7 +591,9 @@ function Options(;
             if haskey(optimizer_options, :iterations)
                 optimizer_iterations = optimizer_options[:iterations]
             end
-            optimizer_options = Optim.Options(; optimizer_options..., iterations=optimizer_iterations)
+            optimizer_options = Optim.Options(;
+                optimizer_options..., iterations=optimizer_iterations
+            )
         end
     end
 

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -217,10 +217,10 @@ https://github.com/MilesCranmer/PySR/discussions/115.
     migrated equations at the end of each cycle.
 - `fractionReplacedHof`: What fraction to replace with hall of fame
     equations at the end of each cycle.
-- `shouldOptimizeConstants`: Whether to use NelderMead optimization
+- `shouldOptimizeConstants`: Whether to use an optimization algorithm
     to periodically optimize constants in equations.
 - `optimizer_nrestarts`: How many different random starting positions to consider
-    when using NelderMead optimization.
+    for optimization of constants.
 - `hofFile`: What file to store equations to, as a backup.
 - `perturbationFactor`: When mutating a constant, either
     multiply or divide by (1+perturbationFactor)^(rand()+1).

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -1,5 +1,6 @@
 module OptionsStructModule
 
+using Optim: Optim
 import LossFunctions: SupervisedLoss
 
 """This struct defines how complexity is calculated."""
@@ -78,7 +79,7 @@ struct Options{A,B,dA,dB,C<:Union{SupervisedLoss,Function},D}
     optimizer_algorithm::String
     optimize_probability::Float32
     optimizer_nrestarts::Int
-    optimizer_iterations::Int
+    optimizer_options::Optim.Options
     recorder::Bool
     recorder_file::String
     probPickFirst::Float32
@@ -109,7 +110,7 @@ function Base.print(io::IO, options::Options)
 # Tournaments:
     probPickFirst=$(options.probPickFirst), ns=$(options.ns), topn=$(options.topn), 
 # Constant tuning:
-    perturbationFactor=$(options.perturbationFactor), probNegate=$(options.probNegate), shouldOptimizeConstants=$(options.shouldOptimizeConstants), optimizer_algorithm=$(options.optimizer_algorithm), optimize_probability=$(options.optimize_probability), optimizer_nrestarts=$(options.optimizer_nrestarts), optimizer_iterations=$(options.optimizer_iterations),
+    perturbationFactor=$(options.perturbationFactor), probNegate=$(options.probNegate), shouldOptimizeConstants=$(options.shouldOptimizeConstants), optimizer_algorithm=$(options.optimizer_algorithm), optimize_probability=$(options.optimize_probability), optimizer_nrestarts=$(options.optimizer_nrestarts), optimizer_iterations=$(options.optimizer_options.iterations),
 # Mutations:
     mutationWeights=$(options.mutationWeights), crossoverProbability=$(options.crossoverProbability), skip_mutation_failures=$(options.skip_mutation_failures)
 # Annealing:

--- a/test/test_options.jl
+++ b/test/test_options.jl
@@ -1,0 +1,16 @@
+using Test
+using SymbolicRegression
+using Optim: Optim
+
+# testing types
+op = Options(; optimizer_options=(iterations=16, f_calls_limit=100, x_tol=1e-16));
+@test isa(op.optimizer_options, Optim.Options)
+
+op = Options(;
+    optimizer_options=Dict(:iterations => 32, :g_calls_limit => 50, :f_tol => 1e-16)
+);
+@test isa(op.optimizer_options, Optim.Options)
+
+optim_op = Optim.Options(; iterations=16)
+op = Options(; optimizer_options=optim_op);
+@test isa(op.optimizer_options, Optim.Options)

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -202,6 +202,8 @@ include("test_constraints.jl")
 
 include("test_complexity.jl")
 
+include("test_options.jl")
+
 # Smoke test for hash of tree:
 options = Options(; binary_operators=(+, *, ^, /, greater), unary_operators=(cos,))
 tree = Node(3, (Node(3.0) * Node(1, Node("x1")))^2.0, -1.2)


### PR DESCRIPTION
This PR introduces a new field `optimizer_options` for `Options`.

This new field allows the user to change any of the options available for the optimization of constants. That is the user is able to set any of the options of `Optim.Options` [1] via a `NamedTuple`, `Dict`, or as an instance of `Optim.Options` directly:

```julia
julia> using SymbolicRegression
julia> using Optim: Optim
julia> op1 = Options(optimizer_options=(iterations=16,));
julia> op1.optimizer_options.iterations
16
julia> op2 = Options(optimizer_options=Dict(:x_tol => 1.0e-32));
julia> op2.optimizer_options.x_abstol
1.0e-32
julia> op3 = Options(optimizer_options=Optim.Options(; iterations=12));
julia> op3.optimizer_options.iterations
12
```

The `optimizer_iterations` keyword argument to the constructor is kept for backwards compatibility and convenient shorthand, and can be used in combination with `optimizer_options` (`optimizer_options` takes precedence), e.g.

```julia
julia> op4 = Options(optimizer_iterations=2);
julia> op4.optimizer_options.iterations
2
julia> op5 = Options(optimizer_options=(iterations=16,time_limit=1.0), optimizer_iterations=4);
julia> op5.optimizer_options.iterations
16
julia> op5.optimizer_options.time_limit
1.0
```

All tests in `test/runtests.jl` passes for me on this branch.

This PR also contains amendments to the documentation, including clearer statements on what the default algorithm is, how to change it, and also how to use the new `optimizer_options` field.

The `optimizer_iterations` remains undocumented as the same and more functionality exists using `optimizer_options`, which is demonstrated in the documentation.

[1]
https://julianlsolvers.github.io/Optim.jl/v0.9.3/user/config/#general-options