### PR TITLE
Even faster evaluation

### DIFF
--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -79,6 +79,8 @@ end
 function _eval_tree_array(
     tree::Node{T}, cX::AbstractMatrix{T}, options::Options
 )::Tuple{AbstractVector{T},Bool} where {T<:Real}
+    max_possible_op = max(length(options.binops), length(options.unaops))
+    vals = ntuple(i -> Val(i), max_possible_op)
     # First, we see if there are only constants in the tree - meaning
     # we can just return the constant result.
     if tree.degree == 0
@@ -91,28 +93,28 @@ function _eval_tree_array(
     elseif tree.degree == 1
         if tree.l.degree == 2 && tree.l.l.degree == 0 && tree.l.r.degree == 0
             # op(op2(x, y)), where x, y, z are constants or variables.
-            return deg1_l2_ll0_lr0_eval(tree, cX, Val(tree.op), Val(tree.l.op), options)
+            return deg1_l2_ll0_lr0_eval(tree, cX, vals[tree.op], vals[tree.l.op], options)
         elseif tree.l.degree == 1 && tree.l.l.degree == 0
             # op(op2(x)), where x is a constant or variable.
-            return deg1_l1_ll0_eval(tree, cX, Val(tree.op), Val(tree.l.op), options)
+            return deg1_l1_ll0_eval(tree, cX, vals[tree.op], vals[tree.l.op], options)
         else
             # op(x), for any x.
-            return deg1_eval(tree, cX, Val(tree.op), options)
+            return deg1_eval(tree, cX, vals[tree.op], options)
         end
     elseif tree.degree == 2
         # TODO - add op(op2(x, y), z) and op(x, op2(y, z))
         if tree.l.degree == 0 && tree.r.degree == 0
             # op(x, y), where x, y are constants or variables.
-            return deg2_l0_r0_eval(tree, cX, Val(tree.op), options)
+            return deg2_l0_r0_eval(tree, cX, vals[tree.op], options)
         elseif tree.l.degree == 0
             # op(x, y), where x is a constant or variable but y is not.
-            return deg2_l0_eval(tree, cX, Val(tree.op), options)
+            return deg2_l0_eval(tree, cX, vals[tree.op], options)
         elseif tree.r.degree == 0
             # op(x, y), where y is a constant or variable but x is not.
-            return deg2_r0_eval(tree, cX, Val(tree.op), options)
+            return deg2_r0_eval(tree, cX, vals[tree.op], options)
         else
             # op(x, y), for any x or y
-            return deg2_eval(tree, cX, Val(tree.op), options)
+            return deg2_eval(tree, cX, vals[tree.op], options)
         end
     end
 end
@@ -343,12 +345,15 @@ gives better performance, as we do not need to perform computation
 over an entire array when the values are all the same.
 """
 function _eval_constant_tree(tree::Node{T}, options::Options)::Tuple{T,Bool} where {T<:Real}
+    max_possible_op = max(length(options.binops), length(options.unaops))
+    vals = ntuple(i -> Val(i), max_possible_op)
+
     if tree.degree == 0
         return deg0_eval_constant(tree)
     elseif tree.degree == 1
-        return deg1_eval_constant(tree, Val(tree.op), options)
+        return deg1_eval_constant(tree, vals[tree.op], options)
     else
-        return deg2_eval_constant(tree, Val(tree.op), options)
+        return deg2_eval_constant(tree, vals[tree.op], options)
     end
 end
 

--- a/src/EvaluateEquationDerivative.jl
+++ b/src/EvaluateEquationDerivative.jl
@@ -53,12 +53,15 @@ end
 function _eval_diff_tree_array(
     tree::Node{T}, cX::AbstractMatrix{T}, options::Options, direction::Int
 )::Tuple{AbstractVector{T},AbstractVector{T},Bool} where {T<:Real}
+    max_possible_op = max(length(options.binops), length(options.unaops))
+    vals = ntuple(i -> Val(i), max_possible_op)
+
     if tree.degree == 0
         diff_deg0_eval(tree, cX, options, direction)
     elseif tree.degree == 1
-        diff_deg1_eval(tree, cX, Val(tree.op), options, direction)
+        diff_deg1_eval(tree, cX, vals[tree.op], options, direction)
     else
-        diff_deg2_eval(tree, cX, Val(tree.op), options, direction)
+        diff_deg2_eval(tree, cX, vals[tree.op], options, direction)
     end
 end
 
@@ -179,15 +182,18 @@ function _eval_grad_tree_array(
     options::Options,
     ::Val{variable},
 )::Tuple{AbstractVector{T},AbstractMatrix{T},Bool} where {T<:Real,variable}
+    max_possible_op = max(length(options.binops), length(options.unaops))
+    vals = ntuple(i -> Val(i), max_possible_op)
+
     if tree.degree == 0
         grad_deg0_eval(tree, n, n_gradients, index_tree, cX, options, Val(variable))
     elseif tree.degree == 1
         grad_deg1_eval(
-            tree, n, n_gradients, index_tree, cX, Val(tree.op), options, Val(variable)
+            tree, n, n_gradients, index_tree, cX, vals[tree.op], options, Val(variable)
         )
     else
         grad_deg2_eval(
-            tree, n, n_gradients, index_tree, cX, Val(tree.op), options, Val(variable)
+            tree, n, n_gradients, index_tree, cX, vals[tree.op], options, Val(variable)
         )
     end
 end


### PR DESCRIPTION
I really didn't think it would be possible to get faster evaluation. It turns out you can crank out another ~20% speed improvement for small arrays!

Right now, throughout the evaluation code, I use `Val(operator_index)` to pre-compile kernels for each user-specified operator, since this has a type of `Val{operator_index}` and therefore will be compiled-in.

However, it seems that constructing `Val(operator_index)` can actually be a bit expensive. Thus, this PR pre-constructs all of the `Val` in a compile-time tuple. We know the max possible operator index at compile time, since `Options` type indicates what operators are used. `operator_index` is then simply used to index that tuple - so no construction needed!