### PR TITLE
Fix search performance problem #148

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.12.5"
+version = "0.12.6"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -219,12 +219,12 @@ function next_generation(
         oldSize = compute_complexity(prev, options)
         newSize = compute_complexity(tree, options)
         old_frequency = if (oldSize <= options.maxsize)
-            running_search_statistics.frequencies[oldSize]
+            running_search_statistics.normalized_frequencies[oldSize]
         else
             1e-6
         end
         new_frequency = if (newSize <= options.maxsize)
-            running_search_statistics.frequencies[newSize]
+            running_search_statistics.normalized_frequencies[newSize]
         else
             1e-6
         end

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -84,7 +84,7 @@ function best_of_sample(
         for member in 1:(options.ns)
             size = compute_complexity(sample.members[member].tree, options)
             frequency = if (size <= options.maxsize)
-                running_search_statistics.frequencies[size]
+                running_search_statistics.normalized_frequencies[size]
             else
                 T(0)
             end


### PR DESCRIPTION
Turns out the reason for the significantly worse performance as mentioned on #148 is simply because the adaptive parsimony module wasn't normalizing the histogram. This fixes it, and the search fidelity is good again.