### PR TITLE
Add `@extend_operators` from DynamicExpressions.jl v0.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.13.3"
+version = "0.14.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/InterfaceDynamicExpressions.jl
+++ b/src/InterfaceDynamicExpressions.jl
@@ -1,5 +1,5 @@
 using SymbolicUtils: SymbolicUtils
-import DynamicExpressions
+using DynamicExpressions: DynamicExpressions
 
 """
     eval_tree_array(tree::Node, X::AbstractMatrix, options::Options; kws...)

--- a/src/InterfaceDynamicExpressions.jl
+++ b/src/InterfaceDynamicExpressions.jl
@@ -1,4 +1,5 @@
 using SymbolicUtils: SymbolicUtils
+import DynamicExpressions
 
 """
     eval_tree_array(tree::Node, X::AbstractMatrix, options::Options; kws...)
@@ -177,4 +178,21 @@ function symbolic_to_node(
     eqn::T, options::Options; kws...
 ) where {T<:SymbolicUtils.Symbolic}
     return symbolic_to_node(eqn, options.operators; kws...)
+end
+
+"""
+    @extend_operators options
+
+Extends all operators defined in this options object to work on the
+`Node` type. While by default this is already done for operators defined
+in `Base` when you create an options and pass `define_helper_functions=true`,
+this does not apply to the user-defined operators. Thus, to do so, you must
+apply this macro to the operator enum in the same module you have the operators
+defined.
+"""
+macro extend_operators(options)
+    operators = :($(esc(options)).operators)
+    quote
+        DynamicExpressions.@extend_operators $operators
+    end
 end

--- a/src/InterfaceDynamicExpressions.jl
+++ b/src/InterfaceDynamicExpressions.jl
@@ -192,7 +192,11 @@ defined.
 """
 macro extend_operators(options)
     operators = :($(esc(options)).operators)
+    type_requirements = Options
     quote
+        if !isa($(esc(options)), $type_requirements)
+            error("You must pass an options type to `@extend_operators`.")
+        end
         DynamicExpressions.@extend_operators $operators
     end
 end

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -295,10 +295,6 @@ https://github.com/MilesCranmer/PySR/discussions/115.
     in serial mode.
 - `define_helper_functions`: Whether to define helper functions
     for constructing and evaluating trees.
-- `extend_user_operators`: Whether to extend the user's operators
-    to `Node` type, so it is easier to construct
-    trees manually. By default, all operators 
-    defined in `Base` are extended automatically.
 """
 function Options(;
     binary_operators=[+, -, /, *],
@@ -358,7 +354,6 @@ function Options(;
     deterministic=false,
     # Not search options; just construction options:
     define_helper_functions=true,
-    extend_user_operators=false,
     # Deprecated args:
     kws...,
 )
@@ -555,7 +550,6 @@ function Options(;
         binary_operators=binary_operators,
         unary_operators=unary_operators,
         enable_autodiff=enable_autodiff,
-        extend_user_operators=extend_user_operators,
         define_helper_functions=define_helper_functions,
     )
 

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -28,6 +28,7 @@ export Population,
     combine_operators,
     gen_random_tree,
     gen_random_tree_fixed_size,
+    @extend_operators,
 
     #Operators
     plus,

--- a/test/test_custom_operators.jl
+++ b/test/test_custom_operators.jl
@@ -1,0 +1,77 @@
+using SymbolicRegression
+using Test
+using Random
+
+# Test that we can work with custom operators:
+function op1(x::T, y::T)::T where {T<:Real}
+    return x + y
+end
+function op2(x::T, y::T)::T where {T<:Real}
+    return x^2 + 1 / ((y)^2 + 0.1)
+end
+function op3(x::T)::T where {T<:Real}
+    return sin(x) + cos(x)
+end
+local operators, tree
+options = Options(; binary_operators=[op1, op2], unary_operators=[op3])
+@extend_operators options
+x1 = Node(; feature=1)
+x2 = Node(; feature=2)
+tree = op1(op2(x1, x2), op3(x1))
+@test repr(tree) == "op1(op2(x1, x2), op3(x1))"
+# Test evaluation:
+X = randn(MersenneTwister(0), Float32, 2, 10);
+@test tree(X) ≈ ((x1, x2) -> op1(op2(x1, x2), op3(x1))).(X[1, :], X[2, :])
+
+# Now, test that we can work with operators defined in modules
+module A
+
+using SymbolicRegression
+using Random
+
+function my_func_a(x::T, y::T) where {T<:Real}
+    return x^2 * y
+end
+
+function my_func_b(x::T) where {T<:Real}
+    return x^3
+end
+
+options = Options(; binary_operators=[my_func_a], unary_operators=[my_func_b])
+@extend_operators options
+
+function create_and_eval_tree()
+    x1 = Node(Float64; feature=1)
+    x2 = Node(Float64; feature=2)
+    c1 = Node(Float64; val=0.2)
+    tree = my_func_a(my_func_a(x2, 0.2), my_func_b(x1))
+    func = (x1, x2) -> my_func_a(my_func_a(x2, 0.2), my_func_b(x1))
+    X = randn(MersenneTwister(0), 2, 20)
+    return tree(X), func.(X[1, :], X[2, :])
+end
+
+end
+
+import .A: create_and_eval_tree
+prediction, truth = create_and_eval_tree()
+@test prediction ≈ truth
+
+# Now, test that we can work with operators defined in other modules
+module B
+
+my_func_c(x::T, y::T) where {T<:Real} = x * y + T(0.3)
+my_func_d(x::T) where {T<:Real} = x / (abs(x)^T(0.2) + 0.1)
+
+end
+
+import .B: my_func_c, my_func_d
+options = Options(; binary_operators=[my_func_c], unary_operators=[my_func_d])
+@extend_operators options
+
+x1 = Node(Float64; feature=1)
+x2 = Node(Float64; feature=2)
+c1 = Node(Float64; val=0.2)
+tree = my_func_c(my_func_c(x2, 0.2), my_func_d(x1))
+func = (x1, x2) -> my_func_c(my_func_c(x2, 0.2), my_func_d(x1))
+X = randn(MersenneTwister(0), 2, 20)
+@test tree(X) ≈ func.(X[1, :], X[2, :])


### PR DESCRIPTION
This enables easy expression creations from the REPL with user-defined operators. Before this change, only operators defined in `Base` could be used in this way.

```julia
using SymbolicRegression

pow_abs(x, y) = abs(x) ^ y
options = Options(; binary_operators=(+, -, /, *, pow_abs), unary_operators=(cos, sin))

# New addition:
@extend_operators options

x1, x2, x3 = [Node(; feature=i) for i=1:3]

tree = pow_abs(x1, x2) * 1.3 - 2.5 * x3

X = randn(3, 100);
tree(X)  # evaluate.
```
Here, internally, when you call `pow_abs` on `Node` types, it will automatically return a new `Node` linking the two children, with `op` set to the index of `pow_abs` in `options.operators.binops`. Before this was only possible for `Base` operators, but by rewriting this as a macro, it becomes possible to extend user-operators.

This functionality isn't necessary, it's just convenient.