### PR TITLE
Do optimizations as a low-probability mutation

### DIFF
--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -17,6 +17,7 @@ import ..MutationFunctionsModule:
     insert_random_op,
     delete_random_op,
     crossover_trees
+import ..ConstantOptimizationModule: optimize_constants
 import ..RecorderModule: @recorder
 
 # Go through one simulated options.annealing mutation cycle
@@ -130,6 +131,21 @@ function next_generation(
             tree_size_to_generate = rand(1:curmaxsize)
             tree = gen_random_tree_fixed_size(tree_size_to_generate, options, nfeatures, T)
             @recorder tmp_recorder["type"] = "regenerate"
+
+            is_success_always_possible = true
+        elseif mutation_choice == :optimize
+            cur_member = PopMember(
+                tree,
+                beforeScore,
+                beforeLoss;
+                parent=parent_ref,
+                deterministic=options.deterministic,
+            )
+            cur_member, new_num_evals = optimize_constants(dataset, cur_member, options)
+            num_evals += new_num_evals
+            @recorder tmp_recorder["type"] = "optimize"
+            mutation_accepted = true
+            return (cur_member, mutation_accepted, num_evals)
 
             is_success_always_possible = true
         elseif mutation_choice == :do_nothing

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -21,7 +21,7 @@ import ..OperatorsModule:
     safe_sqrt,
     safe_acosh,
     atanh_clip
-import ..OptionsStructModule: Options, ComplexityMapping, MutationWeights
+import ..OptionsStructModule: Options, ComplexityMapping, MutationWeights, mutations
 import ..UtilsModule: max_ops
 
 """
@@ -389,7 +389,15 @@ function Options(;
         k == :ns && (tournament_selection_n = kws[k]; true) && continue
         if k == :mutationWeights
             if typeof(kws[k]) <: AbstractVector
-                mutation_weights = MutationWeights(kws[k]...)
+                _mutation_weights = kws[k]
+                if length(_mutation_weights) < length(mutations)
+                    # Pad with zeros:
+                    _mutation_weights = vcat(
+                        _mutation_weights,
+                        zeros(length(mutations) - length(_mutation_weights))
+                    )
+                end
+                mutation_weights = MutationWeights(_mutation_weights...)
             else
                 mutation_weights = kws[k]
             end

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -14,6 +14,7 @@ mutable struct MutationWeights
     simplify::Float64
     randomize::Float64
     do_nothing::Float64
+    optimize::Float64
 end
 
 const mutations = [fieldnames(MutationWeights)...]
@@ -32,6 +33,9 @@ will be normalized to sum to 1.0 after initialization.
 - `simplify::Float64`: How often to simplify the tree.
 - `randomize::Float64`: How often to create a random tree.
 - `do_nothing::Float64`: How often to do nothing.
+- `optimize::Float64`: How often to optimize the constants in the tree, as a mutation.
+  Note that this is different from `optimizer_probability`, which is
+  performed at the end of an iteration for all individuals.
 """
 @generated function MutationWeights(;
     mutate_constant=0.048,
@@ -42,6 +46,7 @@ will be normalized to sum to 1.0 after initialization.
     simplify=0.0020,
     randomize=0.00023,
     do_nothing=0.21,
+    optimize=0.0005,
 )
     return :(MutationWeights($(mutations...)))
 end

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -46,7 +46,7 @@ will be normalized to sum to 1.0 after initialization.
     simplify=0.0020,
     randomize=0.00023,
     do_nothing=0.21,
-    optimize=0.0005,
+    optimize=0.0,
 )
     return :(MutationWeights($(mutations...)))
 end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -926,4 +926,8 @@ function _EquationSearch(
     end
 end
 
+macro ignore(args...) end
+# Hack to get static analysis to work from within tests:
+@ignore include("../test/runtests.jl")
+
 end #module SR

--- a/test/test_deprecation.jl
+++ b/test/test_deprecation.jl
@@ -12,5 +12,5 @@ options = Options(;
 @test options.fraction_replaced_hof == 0.01f0
 @test options.should_optimize_constants == true
 
-options = Options(; mutationWeights=[1.0 for i in 1:8])
+options = Options(; mutationWeights=[1.0 for i in 1:9])
 @test options.mutation_weights.add_node == 1.0

--- a/test/test_deprecation.jl
+++ b/test/test_deprecation.jl
@@ -12,5 +12,5 @@ options = Options(;
 @test options.fraction_replaced_hof == 0.01f0
 @test options.should_optimize_constants == true
 
-options = Options(; mutationWeights=[1.0 for i in 1:9])
+options = Options(; mutationWeights=[1.0 for i in 1:8])
 @test options.mutation_weights.add_node == 1.0

--- a/test/test_optimizer_mutation.jl
+++ b/test/test_optimizer_mutation.jl
@@ -1,0 +1,41 @@
+using SymbolicRegression
+using SymbolicRegression: SymbolicRegression
+using SymbolicRegression: Dataset, RunningSearchStatistics, RecordType
+using Optim: Optim
+import SymbolicRegression.MutateModule: next_generation
+import DynamicExpressions: get_constants
+using Test
+
+mutation_weights = MutationWeights(; optimize=Inf)
+options = Options(;
+    binary_operators=(+, -, *),
+    unary_operators=(cos,),
+    mutation_weights=mutation_weights,
+    optimizer_options=Optim.Options(),
+)
+
+X = randn(5, 100)
+y = cos.(X[1, :] .* 2.1 .- 0.8) .+ X[2, :] .^ 2
+dataset = Dataset(X, y)
+
+x1 = Node(; feature=1)
+x2 = Node(; feature=2)
+tree = cos(x1 * 1.9 - 0.2) + x2 * x2
+
+member = PopMember(dataset, tree, options; deterministic=false)
+temperature = 1.0
+maxsize = 20
+
+new_member, _, _ = next_generation(
+    dataset,
+    member,
+    temperature,
+    maxsize,
+    RunningSearchStatistics(; options=options),
+    options;
+    tmp_recorder=RecordType(),
+)
+
+resultant_constants = get_constants(new_member.tree)
+@test resultant_constants[1] ≈ 2.1 atol = 1e-3
+@test resultant_constants[2] ≈ 0.8 atol = 1e-3

--- a/test/test_optimizer_mutation.jl
+++ b/test/test_optimizer_mutation.jl
@@ -9,18 +9,18 @@ using Test
 mutation_weights = MutationWeights(; optimize=Inf)
 options = Options(;
     binary_operators=(+, -, *),
-    unary_operators=(cos,),
+    unary_operators=(sin,),
     mutation_weights=mutation_weights,
     optimizer_options=Optim.Options(),
 )
 
 X = randn(5, 100)
-y = cos.(X[1, :] .* 2.1 .- 0.8) .+ X[2, :] .^ 2
+y = sin.(X[1, :] .* 2.1 .+ 0.8) .+ X[2, :] .^ 2
 dataset = Dataset(X, y)
 
 x1 = Node(; feature=1)
 x2 = Node(; feature=2)
-tree = cos(x1 * 1.9 - 0.2) + x2 * x2
+tree = sin(x1 * 1.9 + 0.2) + x2 * x2
 
 member = PopMember(dataset, tree, options; deterministic=false)
 temperature = 1.0
@@ -38,4 +38,4 @@ new_member, _, _ = next_generation(
 
 resultant_constants = get_constants(new_member.tree)
 @test resultant_constants[1] ≈ 2.1 atol = 1e-3
-@test resultant_constants[2] ≈ 0.8 atol = 1e-3
+@test sin(resultant_constants[2]) ≈ sin(0.8) atol = 1e-3

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -79,3 +79,7 @@ end
 @safetestset "Test deprecated options" begin
     include("test_deprecation.jl")
 end
+
+@safetestset "Test optimization mutation" begin
+    include("test_optimizer_mutation.jl")
+end


### PR DESCRIPTION
Right now, optimization is performed after an iteration for all population members. However, this seems suboptimal for cases where `ncyclesperiteration` is large - so this introduces optimization as a new type of mutation operator. Optimization is expensive so this is very low probability by default.

This should be useful for distributed searches, where you want to have limited communication with the head node - and therefore want to be performing constant optimization as part of the mutations.