### PR TITLE
Turn off safe operators for turbo=true

### DIFF
--- a/src/Operators.jl
+++ b/src/Operators.jl
@@ -97,7 +97,7 @@ function greater(x, y)
     return (x > y)
 end
 function relu(x::T)::T where {T}
-    return (x + abs(x)) * T(0.5)
+    return (x + abs(x)) / T(2)
 end
 
 function logical_or(x::T, y::T)::T where {T}

--- a/src/Operators.jl
+++ b/src/Operators.jl
@@ -34,7 +34,7 @@ end
 function cube(x::T)::T where {T<:Real}
     return x^3
 end
-function safe_pow(x::T, y::T)::T where {T<:Real}
+function safe_pow(x::T, y::T)::T where {T<:AbstractFloat}
     if isinteger(y)
         y < T(0) && x == T(0) && return T(NaN)
     else
@@ -43,35 +43,35 @@ function safe_pow(x::T, y::T)::T where {T<:Real}
     end
     return x^y
 end
-function div(x::T, y::T)::T where {T<:Real}
+function div(x::T, y::T)::T where {T<:AbstractFloat}
     return x / y
 end
-function safe_log(x::T)::T where {T<:Real}
+function safe_log(x::T)::T where {T<:AbstractFloat}
     x <= T(0) && return T(NaN)
     return log(x)
 end
-function safe_log2(x::T)::T where {T<:Real}
+function safe_log2(x::T)::T where {T<:AbstractFloat}
     x <= T(0) && return T(NaN)
     return log2(x)
 end
-function safe_log10(x::T)::T where {T<:Real}
+function safe_log10(x::T)::T where {T<:AbstractFloat}
     x <= T(0) && return T(NaN)
     return log10(x)
 end
-function safe_log1p(x::T)::T where {T<:Real}
+function safe_log1p(x::T)::T where {T<:AbstractFloat}
     x <= T(-1) && return T(NaN)
     return log1p(x)
 end
-function safe_acosh(x::T)::T where {T<:Real}
+function safe_acosh(x::T)::T where {T<:AbstractFloat}
     x < T(1) && return T(NaN)
     return acosh(x)
 end
-function safe_sqrt(x::T)::T where {T<:Real}
+function safe_sqrt(x::T)::T where {T<:AbstractFloat}
     x < T(0) && return T(NaN)
     return sqrt(x)
 end
 
-# Generics:
+# Generics (and SIMD)
 square(x) = x * x
 cube(x) = x * x * x
 plus(x, y) = x + y
@@ -97,7 +97,7 @@ function greater(x, y)
     return (x > y)
 end
 function relu(x::T)::T where {T}
-    return convert(T, (x > 0)) * x
+    return (x + abs(x)) * T(0.5)
 end
 
 function logical_or(x::T, y::T)::T where {T}

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -83,7 +83,7 @@ function build_constraints(
     return una_constraints, bin_constraints
 end
 
-function binopmap(op; turbo)
+function binopmap(op)
     if op == plus
         return +
     elseif op == mult
@@ -93,17 +93,14 @@ function binopmap(op; turbo)
     elseif op == div
         return /
     elseif op == ^
-        turbo && return (^)
         return safe_pow
     elseif op == pow
-        turbo && return (^)
         return safe_pow
     end
     return op
 end
 
-function unaopmap(op; turbo)
-    turbo && return op
+function unaopmap(op)
     if op == log
         return safe_log
     elseif op == log10
@@ -561,8 +558,8 @@ function Options(;
         npopulations = nworkers()
     end
 
-    binary_operators = map(op -> binopmap(op; turbo=turbo), binary_operators)
-    unary_operators = map(op -> unaopmap(op; turbo=turbo), unary_operators)
+    binary_operators = map(binopmap, binary_operators)
+    unary_operators = map(unaopmap, unary_operators)
 
     operators = OperatorEnum(;
         binary_operators=binary_operators,

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -83,7 +83,7 @@ function build_constraints(
     return una_constraints, bin_constraints
 end
 
-function binopmap(op)
+function binopmap(op; turbo)
     if op == plus
         return +
     elseif op == mult
@@ -93,14 +93,17 @@ function binopmap(op)
     elseif op == div
         return /
     elseif op == ^
+        turbo && return (^)
         return safe_pow
     elseif op == pow
+        turbo && return (^)
         return safe_pow
     end
     return op
 end
 
-function unaopmap(op)
+function unaopmap(op; turbo)
+    turbo && return op
     if op == log
         return safe_log
     elseif op == log10
@@ -154,7 +157,6 @@ https://github.com/MilesCranmer/PySR/discussions/115.
     and one output scalar. All operators
     need to be defined over the entire real line (excluding infinity - these
     are stopped before they are input), or return `NaN` where not defined.
-    Thus, `log` should be replaced with `safe_log`, etc.
     For speed, define it so it takes two reals
     of the same type as input, and outputs the same type. For the SymbolicUtils
     simplification backend, you will need to define a generic method of the
@@ -559,8 +561,8 @@ function Options(;
         npopulations = nworkers()
     end
 
-    binary_operators = map(binopmap, binary_operators)
-    unary_operators = map(unaopmap, unary_operators)
+    binary_operators = map(op -> binopmap(op; turbo=turbo), binary_operators)
+    unary_operators = map(op -> unaopmap(op; turbo=turbo), unary_operators)
 
     operators = OperatorEnum(;
         binary_operators=binary_operators,

--- a/test/test_nan_detection.jl
+++ b/test/test_nan_detection.jl
@@ -7,8 +7,9 @@ for T in [Float16, Float32, Float64], turbo in [true, false]
     local options, tree, X
 
     options = Options(;
-        binary_operators=(+, *, /, -), unary_operators=(cos, sin, exp), turbo=turbo
+        binary_operators=(+, *, /, -, ^), unary_operators=(cos, sin, exp, sqrt), turbo=turbo
     )
+    @extend_operators options
     # Creating a NaN via computation.
     tree = exp(exp(exp(exp(Node(T; feature=1) + 1))))
     tree = convert(Node{T}, tree)
@@ -19,6 +20,28 @@ for T in [Float16, Float32, Float64], turbo in [true, false]
     # Creating a NaN/Inf via division by constant zero.
     tree = cos(Node(T; feature=1) / zero(T))
     tree = convert(Node{T}, tree)
+    output, flag = eval_tree_array(tree, X, options)
+    @test !flag
+
+    # Creating a NaN via sqrt(-1):
+    tree = if turbo
+        sqrt(Node(T; feature=1) - 1)
+    else
+        safe_sqrt(Node(T; feature=1) - 1)
+    end
+    tree = convert(Node{T}, tree)
+    X = fill(T(0), 1, 10)
+    output, flag = eval_tree_array(tree, X, options)
+    @test !flag
+
+    # Creating a NaN via pow(-1, 0.5):
+    tree = if turbo
+        (Node(T; feature=1) - 1)^0.5
+    else
+        safe_pow(Node(T; feature=1) - 1, 0.5)
+    end
+    tree = convert(Node{T}, tree)
+    X = fill(T(0), 1, 10)
     output, flag = eval_tree_array(tree, X, options)
     @test !flag
 

--- a/test/test_nan_detection.jl
+++ b/test/test_nan_detection.jl
@@ -24,22 +24,14 @@ for T in [Float16, Float32, Float64], turbo in [true, false]
     @test !flag
 
     # Creating a NaN via sqrt(-1):
-    tree = if turbo
-        sqrt(Node(T; feature=1) - 1)
-    else
-        safe_sqrt(Node(T; feature=1) - 1)
-    end
+    tree = safe_sqrt(Node(T; feature=1) - 1)
     tree = convert(Node{T}, tree)
     X = fill(T(0), 1, 10)
     output, flag = eval_tree_array(tree, X, options)
     @test !flag
 
     # Creating a NaN via pow(-1, 0.5):
-    tree = if turbo
-        (Node(T; feature=1) - 1)^0.5
-    else
-        safe_pow(Node(T; feature=1) - 1, 0.5)
-    end
+    tree = safe_pow(Node(T; feature=1) - 1, 0.5)
     tree = convert(Node{T}, tree)
     X = fill(T(0), 1, 10)
     output, flag = eval_tree_array(tree, X, options)

--- a/test/test_turbo_nan.jl
+++ b/test/test_turbo_nan.jl
@@ -1,0 +1,33 @@
+using SymbolicRegression
+using Test
+
+bad_op(x::T) where {T} = (x >= 0) ? x : T(0)
+
+options = Options(;
+    unary_operators=(sin, exp, sqrt, bad_op),
+    binary_operators=(+, *),
+    turbo=true,
+    nested_constraints=[sin => [sin => 0], exp => [exp => 0]],
+    maxsize=30,
+    npopulations=40,
+    parsimony=0.01,
+)
+
+tree = Node(3, Node(1, Node(; val=-π / 2)))
+
+# Should still be safe against domain errors:
+try
+    tree([0.0]')
+    @test true
+catch e
+    @test false
+end
+
+tree = Node(3, Node(1, Node(; feature=1)))
+
+try
+    tree([-π / 2]')
+    @test true
+catch e
+    @test false
+end

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -36,6 +36,10 @@ end
     include("test_evaluation.jl")
 end
 
+@safetestset "Test turbo mode with NaN" begin
+    include("test_turbo_nan.jl")
+end
+
 @safetestset "Test validity of integer expression evaluation" begin
     include("test_integer_evaluation.jl")
 end


### PR DESCRIPTION
@johanbluecreek do you think you could review this? 

Basically since `@turbo` is incompatible with the safe operators, this only switches them only when `turbo=false`.

The one tricky thing is I'm not sure what will happen if operators are fused together, and only one of the operators is not capable of being SIMDified. If that happens, then `@turbo` will be changed to `@inbounds @simd`, and I think `DomainError` will be raised again. Will be good to test this.

Maybe I should do a test run in `Options` for each operator, and, if it fails, then I turn `turbo=false`?

---

Edit: yep, it seems to not work with, e.g., `sqrt(sin(-1))` - this tree will raise a domain error, since it goes to the non-turbo eval.

Maybe the `maybe_turbo` macro should replace safe operators with their non-safe equivalents, but all other steps should just leave them as is?

---

Edit 2: Fixed it by changing, e.g.,
```diff
+ function safe_log(x::T)::T where {T<:AbstractFloat}
- function safe_log(x::T)::T where {T<:Real}
```

Then, the SIMD types get passed to the unsafe generic operation, so all is good!