### PR TITLE
Refactor monitoring of resources

### DIFF
--- a/src/SearchUtils.jl
+++ b/src/SearchUtils.jl
@@ -144,7 +144,9 @@ function get_load_string(;
 
     out = @sprintf("Head worker occupation: %.1f%%", head_node_occupation)
     if raise_usage_warning
-        out *= ". This is high, and will prevent efficient resource usage. Increase `ncyclesperiteration` to reduce load on the head worker."
+        out *= "."
+        out *= " This is high, and will prevent efficient resource usage."
+        out *= " Increase `ncyclesperiteration` to reduce load on head worker."
     end
     out *= "\n"
     return out

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -843,8 +843,9 @@ function _EquationSearch(
                     progress_bar;
                     hall_of_fame=hallOfFame[j],
                     dataset=datasets[j],
-                    options=options,
-                    head_node_occupation=head_node_occupation,
+                    options,
+                    head_node_occupation,
+                    ConcurrencyType,
                 )
             end
             head_node_end_work = time()
@@ -870,12 +871,13 @@ function _EquationSearch(
             if (options.verbosity > 0) || (options.progress && nout > 1)
                 print_search_state(
                     hallOfFame,
-                    datasets,
-                    options;
-                    equation_speed=equation_speed,
-                    total_cycles=total_cycles,
-                    cycles_remaining=cycles_remaining,
-                    head_node_occupation=head_node_occupation,
+                    datasets;
+                    options,
+                    equation_speed,
+                    total_cycles,
+                    cycles_remaining,
+                    head_node_occupation,
+                    ConcurrencyType,
                 )
             end
             last_print_time = time()

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -841,11 +841,12 @@ function _EquationSearch(
                     100 * head_node_occupied_for / (time() - head_node_start)
                 update_progress_bar!(
                     progress_bar;
-                    hall_of_fame=hallOfFame[j],
-                    dataset=datasets[j],
+                    hall_of_fame=only(hallOfFame),
+                    dataset=only(datasets),
                     options,
                     head_node_occupation,
                     ConcurrencyType,
+                    raise_usage_warning=head_node_occupation > 50,
                 )
             end
             head_node_end_work = time()
@@ -878,6 +879,7 @@ function _EquationSearch(
                     cycles_remaining,
                     head_node_occupation,
                     ConcurrencyType,
+                    raise_usage_warning=head_node_occupation > 50,
                 )
             end
             last_print_time = time()
@@ -916,12 +918,12 @@ function _EquationSearch(
     end
 
     if options.return_state
-        state = (returnPops, (nout == 1 ? hallOfFame[1] : hallOfFame))
+        state = (returnPops, (nout == 1 ? only(hallOfFame) : hallOfFame))
         state::StateType{T}
         return state
     else
         if nout == 1
-            return hallOfFame[1]
+            return only(hallOfFame)
         else
             return hallOfFame
         end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -204,6 +204,10 @@ import .SearchUtilsModule:
     check_for_loss_threshold,
     check_for_timeout,
     check_max_evals,
+    ResourceMonitor,
+    start_work_monitor!,
+    stop_work_monitor!,
+    estimate_work_fraction,
     update_progress_bar!,
     print_search_state,
     init_dummy_pops,
@@ -658,8 +662,12 @@ function _EquationSearch(
     all_idx = [(j, i) for j in 1:nout for i in 1:(options.npopulations)]
     shuffle!(all_idx)
     kappa = 0
-    head_node_occupied_for = 0.0
-    head_node_start = time()
+    resource_monitor = ResourceMonitor(;
+        absolute_start_time=time(),
+        # Storing n times as many monitoring intervals as populations seems like it will
+        # help get accurate resource estimates:
+        num_intervals_to_store=options.npopulations * 100 * nout,
+    )
     while sum(cycles_remaining) > 0
         kappa += 1
         if kappa > options.npopulations * nout
@@ -682,7 +690,7 @@ function _EquationSearch(
         # TODO - this might skip extra cycles?
         population_ready &= (cycles_remaining[j] > 0)
         if population_ready
-            head_node_start_work = time()
+            start_work_monitor!(resource_monitor)
             # Take the fetch operation from the channel since its ready
             (cur_pop, best_seen, cur_record, cur_num_evals) =
                 if ConcurrencyType in [SRDistributed, SRThreaded]
@@ -836,9 +844,10 @@ function _EquationSearch(
             end
             num_equations += options.ncycles_per_iteration * options.npop / 10.0
 
+            stop_work_monitor!(resource_monitor)
+            move_window!(all_running_search_statistics[j])
             if options.progress && nout == 1
-                head_node_occupation =
-                    100 * head_node_occupied_for / (time() - head_node_start)
+                head_node_occupation = estimate_work_fraction(resource_monitor)
                 update_progress_bar!(
                     progress_bar;
                     hall_of_fame=only(hallOfFame),
@@ -846,13 +855,8 @@ function _EquationSearch(
                     options,
                     head_node_occupation,
                     ConcurrencyType,
-                    raise_usage_warning=head_node_occupation > 50,
                 )
             end
-            head_node_end_work = time()
-            head_node_occupied_for += (head_node_end_work - head_node_start_work)
-
-            move_window!(all_running_search_statistics[j])
         end
         sleep(1e-6)
 
@@ -862,7 +866,6 @@ function _EquationSearch(
         #Update if time has passed, and some new equations generated.
         if elapsed > print_every_n_seconds && num_equations > 0.0
             # Dominating pareto curve - must be better than all simpler equations
-            head_node_occupation = 100 * head_node_occupied_for / (time() - head_node_start)
             current_speed = num_equations / elapsed
             average_over_m_measurements = 10 #for print_every...=5, this gives 50 second running average
             push!(equation_speed, current_speed)
@@ -870,6 +873,7 @@ function _EquationSearch(
                 deleteat!(equation_speed, 1)
             end
             if (options.verbosity > 0) || (options.progress && nout > 1)
+                head_node_occupation = estimate_work_fraction(resource_monitor)
                 print_search_state(
                     hallOfFame,
                     datasets;
@@ -879,7 +883,6 @@ function _EquationSearch(
                     cycles_remaining,
                     head_node_occupation,
                     ConcurrencyType,
-                    raise_usage_warning=head_node_occupation > 50,
                 )
             end
             last_print_time = time()


### PR DESCRIPTION
This refactors functionality around the printing of this string:
```
Head worker occupation: 9.0% 
```

This PR makes the following changes to make this number (1) more accurate, and (2) more useful to the user.

- Creates `ResourceMonitor` struct for storing information related to this.
- Only prints worker occupation over past n intervals, rather than over entire search history.
- Now prints a warning if the worker occupation gets above 20%, and suggests that the user increases `ncyclesperiteration`.
- Skips the first work interval in calculating resource usage, since the first one has a lot of time dedicated to JIT compilation and is inaccurate.