### PR TITLE
Quiet progress bar during CI

### DIFF
--- a/src/ProgressBars.jl
+++ b/src/ProgressBars.jl
@@ -9,6 +9,11 @@ mutable struct WrappedProgressBar
     cycle::Union{Int,Nothing}
 
     function WrappedProgressBar(args...; kwargs...)
+        if haskey(ENV, "SYMBOLIC_REGRESSION_TEST") &&
+            ENV["SYMBOLIC_REGRESSION_TEST"] == "true"
+            output_stream = devnull
+            return new(ProgressBar(args...; output_stream, kwargs...), nothing, nothing)
+        end
         return new(ProgressBar(args...; kwargs...), nothing, nothing)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using SafeTestsets
 using Test
 
+ENV["SYMBOLIC_REGRESSION_TEST"] = "true"
+
 @safetestset "Unit tests" begin
     include("unittest.jl")
 end


### PR DESCRIPTION
<details><summary>(See here for old version of this PR)</summary>

This should fix #159. Essentially it just pipes the stdout and stderr of `EquationSearch` into `/dev/null` during the tests. Thus, the print statements still get hit, they just won't show up in the test logging. It does this by creating a macro for the tests:

```julia
macro ignore_output(ex)
    quote
        redirect_stdout(devnull) do
            redirect_stderr(devnull) do
                $(esc(ex))
            end
        end
    end
end
```

and wrapping every call to `EquationSearch` with this.

@maleadt could you review this?

</details>

**Update (Monday Nov 28)**: This PR gets `WrappedProgressBar` to check for `SYMBOLIC_REGRESSION_TEST`, an env variable, and if set to `true`, the progress bar is directed to `/dev/null`. This fixes #159.
