### PR TITLE
Proper SnoopCompilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build
 *.csv.out*
 pysr_recorder.json
 docs/src/index.md
+*.code-workspace

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.14.4"
+version = "0.14.5"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -15,13 +15,14 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 ProgressBars = "49802e3a-d2f1-5c88-81d8-b72133a6f568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
-DynamicExpressions = "0.4"
+DynamicExpressions = "0.4.2"
 JSON3 = "1"
 LineSearches = "7"
 LossFunctions = "0.6, 0.7, 0.8"
@@ -29,6 +30,7 @@ Optim = "0.19, 1.1"
 Pkg = "1"
 ProgressBars = "1.4"
 Reexport = "1"
+SnoopPrecompile = "1"
 SpecialFunctions = "0.10.1, 1, 2"
 StatsBase = "0.33"
 SymbolicUtils = "0.19"

--- a/example.jl
+++ b/example.jl
@@ -4,27 +4,30 @@ X = randn(Float32, 5, 100)
 y = 2 * cos.(X[4, :]) + X[1, :] .^ 2 .- 2
 
 options = SymbolicRegression.Options(;
-    binary_operators=(+, *, /, -), unary_operators=(cos, exp), npopulations=20
+    binary_operators=(+, *, /, -),
+    unary_operators=(cos, exp),
+    npopulations=20,
+    seed=0,
+    deterministic=true,
+    complexity_of_constants=0.2,
 )
 
-hall_of_fame = EquationSearch(
-    X, y; niterations=40, options=options, parallelism=:multithreading
-)
+hall_of_fame = EquationSearch(X, y; niterations=40, options=options, parallelism=:serial)
 
-dominating = calculate_pareto_frontier(X, y, hall_of_fame, options)
+# dominating = calculate_pareto_frontier(X, y, hall_of_fame, options)
 
-trees = [member.tree for member in dominating]
+# trees = [member.tree for member in dominating]
 
-tree = trees[end]
-output, did_succeed = eval_tree_array(tree, X, options)
+# tree = trees[end]
+# output, did_succeed = eval_tree_array(tree, X, options)
 
-eqn = node_to_symbolic(dominating[end].tree, options)
-println("Complexity\tMSE\tEquation")
+# eqn = node_to_symbolic(dominating[end].tree, options)
+# println("Complexity\tMSE\tEquation")
 
-for member in dominating
-    complexity = compute_complexity(member.tree, options)
-    loss = member.loss
-    string = string_tree(member.tree, options)
+# for member in dominating
+#     complexity = compute_complexity(member.tree, options)
+#     loss = member.loss
+#     string = string_tree(member.tree, options)
 
-    println("$(complexity)\t$(loss)\t$(string)")
-end
+#     println("$(complexity)\t$(loss)\t$(string)")
+# end

--- a/example.jl
+++ b/example.jl
@@ -4,15 +4,17 @@ X = randn(Float32, 5, 100)
 y = 2 * cos.(X[4, :]) + X[1, :] .^ 2 .- 2
 
 options = SymbolicRegression.Options(;
-    binary_operators=(+, *, /, -),
-    unary_operators=(cos, exp),
+    binary_operators=[+, *, /, -],
+    unary_operators=[cos, exp],
     npopulations=20,
-    seed=0,
-    deterministic=true,
-    complexity_of_constants=0.2,
+    #seed=0,
+    #deterministic=true,
+    #complexity_of_constants=0.2,
 )
 
-hall_of_fame = EquationSearch(X, y; niterations=40, options=options, parallelism=:serial)
+hall_of_fame = EquationSearch(
+    X, y; niterations=40, options=options, parallelism=:multithreading
+)
 
 # dominating = calculate_pareto_frontier(X, y, hall_of_fame, options)
 

--- a/example.jl
+++ b/example.jl
@@ -4,32 +4,27 @@ X = randn(Float32, 5, 100)
 y = 2 * cos.(X[4, :]) + X[1, :] .^ 2 .- 2
 
 options = SymbolicRegression.Options(;
-    binary_operators=[+, *, /, -],
-    unary_operators=[cos, exp],
-    npopulations=20,
-    #seed=0,
-    #deterministic=true,
-    #complexity_of_constants=0.2,
+    binary_operators=(+, *, /, -), unary_operators=(cos, exp), npopulations=20
 )
 
 hall_of_fame = EquationSearch(
     X, y; niterations=40, options=options, parallelism=:multithreading
 )
 
-# dominating = calculate_pareto_frontier(X, y, hall_of_fame, options)
+dominating = calculate_pareto_frontier(X, y, hall_of_fame, options)
 
-# trees = [member.tree for member in dominating]
+trees = [member.tree for member in dominating]
 
-# tree = trees[end]
-# output, did_succeed = eval_tree_array(tree, X, options)
+tree = trees[end]
+output, did_succeed = eval_tree_array(tree, X, options)
 
-# eqn = node_to_symbolic(dominating[end].tree, options)
-# println("Complexity\tMSE\tEquation")
+eqn = node_to_symbolic(dominating[end].tree, options)
+println("Complexity\tMSE\tEquation")
 
-# for member in dominating
-#     complexity = compute_complexity(member.tree, options)
-#     loss = member.loss
-#     string = string_tree(member.tree, options)
+for member in dominating
+    complexity = compute_complexity(member.tree, options)
+    loss = member.loss
+    string = string_tree(member.tree, options)
 
-#     println("$(complexity)\t$(loss)\t$(string)")
-# end
+    println("$(complexity)\t$(loss)\t$(string)")
+end

--- a/src/AdaptiveParsimony.jl
+++ b/src/AdaptiveParsimony.jl
@@ -42,7 +42,7 @@ for an equation at size `size`.
 @inline function update_frequencies!(
     running_search_statistics::RunningSearchStatistics; size=nothing
 )
-    if size <= length(running_search_statistics.frequencies)
+    if 0 < size <= length(running_search_statistics.frequencies)
         running_search_statistics.frequencies[size] += 1
     end
     return nothing

--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -140,7 +140,8 @@ end
 
 """Check if user-passed constraints are violated or not"""
 function check_constraints(tree::Node, options::Options, maxsize::Int)::Bool
-    if compute_complexity(tree, options) > maxsize
+    size = compute_complexity(tree, options)
+    if 0 > size > maxsize
         return false
     end
     for i in 1:(options.nbin)

--- a/src/Complexity.jl
+++ b/src/Complexity.jl
@@ -19,8 +19,8 @@ function compute_complexity(tree::Node, options::Options)::Int
 end
 
 function _compute_complexity(
-    tree::Node, options::Options{C,complexity_type}
-)::complexity_type where {C,complexity_type<:Real}
+    tree::Node, options::Options{complexity_type}
+)::complexity_type where {complexity_type<:Real}
     if tree.degree == 0
         if tree.constant
             return options.complexity_mapping.constant_complexity

--- a/src/Complexity.jl
+++ b/src/Complexity.jl
@@ -18,9 +18,7 @@ function compute_complexity(tree::Node, options::Options)::Int
     end
 end
 
-function _compute_complexity(
-    tree::Node, options::Options{complexity_type}
-)::complexity_type where {complexity_type<:Real}
+function _compute_complexity(tree::Node, options::Options{CT})::CT where {CT<:Real}
     if tree.degree == 0
         if tree.constant
             return options.complexity_mapping.constant_complexity

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -7,15 +7,7 @@ include("OptionsStruct.jl")
 include("Operators.jl")
 include("Options.jl")
 
-import .ProgramConstantsModule:
-    MAX_DEGREE,
-    BATCH_DIM,
-    FEATURE_DIM,
-    RecordType,
-    SRConcurrency,
-    SRSerial,
-    SRThreaded,
-    SRDistributed
+import .ProgramConstantsModule: MAX_DEGREE, BATCH_DIM, FEATURE_DIM, RecordType
 import .DatasetModule: Dataset
 import .OptionsStructModule: Options, MutationWeights, sample_mutation
 import .OptionsModule: Options

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -231,12 +231,12 @@ function next_generation(
     if options.use_frequency
         oldSize = compute_complexity(prev, options)
         newSize = compute_complexity(tree, options)
-        old_frequency = if (oldSize <= options.maxsize)
+        old_frequency = if (0 < oldSize <= options.maxsize)
             running_search_statistics.normalized_frequencies[oldSize]
         else
             1e-6
         end
-        new_frequency = if (newSize <= options.maxsize)
+        new_frequency = if (0 < newSize <= options.maxsize)
             running_search_statistics.normalized_frequencies[newSize]
         else
             1e-6

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -601,7 +601,6 @@ function Options(;
     end
 
     options = Options{
-        typeof(loss),
         eltype(complexity_mapping),
         tournament_selection_p,
         tournament_selection_n,

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -600,9 +600,7 @@ function Options(;
         end
     end
 
-    options = Options{
-        eltype(complexity_mapping),
-    }(
+    options = Options{eltype(complexity_mapping)}(
         operators,
         bin_constraints,
         una_constraints,
@@ -657,6 +655,7 @@ function Options(;
         skip_mutation_failures,
         nested_constraints,
         deterministic,
+        define_helper_functions,
     )
 
     return options

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -602,14 +602,13 @@ function Options(;
 
     options = Options{
         eltype(complexity_mapping),
-        tournament_selection_p,
-        tournament_selection_n,
     }(
         operators,
         bin_constraints,
         una_constraints,
         complexity_mapping,
         tournament_selection_n,
+        tournament_selection_p,
         parsimony,
         alpha,
         maxsize,

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -103,12 +103,13 @@ function ComplexityMapping(;
     )
 end
 
-struct Options{ComplexityType,_prob_pick_first,_ns}
+struct Options{CT}
     operators::AbstractOperatorEnum
     bin_constraints::Vector{Tuple{Int,Int}}
     una_constraints::Vector{Int}
-    complexity_mapping::ComplexityMapping{ComplexityType}
+    complexity_mapping::ComplexityMapping{CT}
     tournament_selection_n::Int
+    tournament_selection_p::Float32
     parsimony::Float32
     alpha::Float32
     maxsize::Int

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -158,6 +158,7 @@ struct Options{CT}
     skip_mutation_failures::Bool
     nested_constraints::Union{Vector{Tuple{Int,Int,Vector{Tuple{Int,Int,Int}}}},Nothing}
     deterministic::Bool
+    define_helper_functions::Bool
 end
 
 function Base.print(io::IO, options::Options)

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -103,7 +103,7 @@ function ComplexityMapping(;
     )
 end
 
-struct Options{LossType<:Union{SupervisedLoss,Function},ComplexityType,_prob_pick_first,_ns}
+struct Options{ComplexityType,_prob_pick_first,_ns}
     operators::AbstractOperatorEnum
     bin_constraints::Vector{Tuple{Int,Int}}
     una_constraints::Vector{Int}
@@ -140,7 +140,7 @@ struct Options{LossType<:Union{SupervisedLoss,Function},ComplexityType,_prob_pic
     nuna::Int
     nbin::Int
     seed::Union{Int,Nothing}
-    loss::LossType
+    loss::Union{SupervisedLoss,Function}
     progress::Bool
     terminal_width::Union{Int,Nothing}
     optimizer_algorithm::String

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -92,7 +92,7 @@ function best_of_sample(
         scores = Vector{T}(undef, tournament_selection_n)
         for (i, member) in enumerate(sample.members)
             size = compute_complexity(member.tree, options)
-            frequency = if (size <= options.maxsize)
+            frequency = if (0 < size <= options.maxsize)
                 running_search_statistics.normalized_frequencies[size]
             else
                 T(0)

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -79,9 +79,12 @@ end
 function best_of_sample(
     pop::Population{T},
     running_search_statistics::RunningSearchStatistics,
-    options::Options{B,p,tournament_selection_n},
-)::PopMember where {T<:Real,B,p,tournament_selection_n}
+    options::Options{CT},
+)::PopMember where {T<:Real,CT}
     sample = sample_pop(pop, options)
+
+    p = options.tournament_selection_p
+    tournament_selection_n = options.tournament_selection_n
 
     if options.use_frequency_in_tournament
         # Score based on frequency of that size occuring.

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -79,8 +79,8 @@ end
 function best_of_sample(
     pop::Population{T},
     running_search_statistics::RunningSearchStatistics,
-    options::Options{A,B,p,tournament_selection_n},
-)::PopMember where {T<:Real,A,B,p,tournament_selection_n}
+    options::Options{B,p,tournament_selection_n},
+)::PopMember where {T<:Real,B,p,tournament_selection_n}
     sample = sample_pop(pop, options)
 
     if options.use_frequency_in_tournament

--- a/src/ProgramConstants.jl
+++ b/src/ProgramConstants.jl
@@ -5,10 +5,4 @@ const BATCH_DIM = 2
 const FEATURE_DIM = 1
 const RecordType = Dict{String,Any}
 
-"""Enum for concurrency type (to get function specialization)"""
-abstract type SRConcurrency end
-struct SRSerial <: SRConcurrency end
-struct SRThreaded <: SRConcurrency end
-struct SRDistributed <: SRConcurrency end
-
 end

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -47,7 +47,7 @@ function s_r_cycle(
         for member in pop.members
             size = compute_complexity(member.tree, options)
             score = member.score
-            if size <= options.maxsize && (
+            if 0 < size <= options.maxsize && (
                 !best_examples_seen.exists[size] ||
                 score < best_examples_seen.members[size].score
             )

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -418,15 +418,17 @@ function _EquationSearch(
     stdin_reader = watch_stream(stdin)
 
     # Redefine print, show:
-    @eval begin
+    options.define_helper_functions && @eval begin
         function Base.print(io::IO, tree::Node)
             return print(
-                io, string_tree(tree, $(options.operators); varMap=$(datasets[1].varMap))
+                io,
+                string_tree(tree, $(options.operators); varMap=$(datasets[1].varMap)),
             )
         end
         function Base.show(io::IO, tree::Node)
             return print(
-                io, string_tree(tree, $(options.operators); varMap=$(datasets[1].varMap))
+                io,
+                string_tree(tree, $(options.operators); varMap=$(datasets[1].varMap)),
             )
         end
     end
@@ -936,5 +938,8 @@ end
 macro ignore(args...) end
 # Hack to get static analysis to work from within tests:
 @ignore include("../test/runtests.jl")
+
+include("precompile.jl")
+do_precompilation(; mode=:precompile)
 
 end #module SR

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -458,7 +458,7 @@ function _EquationSearch(
     allPops = [allPopsType[] for j in 1:nout]
     init_pops = [allPopsType[] for j in 1:nout]
     # Set up a channel to send finished populations back to head node
-    if parallelism in [:multiprocessing, :multithreading]
+    if parallelism in (:multiprocessing, :multithreading)
         if parallelism == :multiprocessing
             channels = [
                 [RemoteChannel(1) for i in 1:(options.npopulations)] for j in 1:nout
@@ -585,7 +585,7 @@ function _EquationSearch(
             # TODO - why is this needed??
             # Multi-threaded doesn't like to fetch within a new task:
             updated_pop = @sr_spawner parallelism worker_idx let
-                in_pop = if parallelism in [:multiprocessing, :multithreading]
+                in_pop = if parallelism in (:multiprocessing, :multithreading)
                     fetch(init_pops[j][i])[1]
                 else
                     init_pops[j][i][1]
@@ -645,7 +645,7 @@ function _EquationSearch(
     print_every_n_seconds = 5
     equation_speed = Float32[]
 
-    if parallelism in [:multiprocessing, :multithreading]
+    if parallelism in (:multiprocessing, :multithreading)
         for j in 1:nout
             for i in 1:(options.npopulations)
                 # Start listening for each population to finish:
@@ -675,14 +675,14 @@ function _EquationSearch(
         j, i = all_idx[kappa]
 
         # Check if error on population:
-        if parallelism in [:multiprocessing, :multithreading]
+        if parallelism in (:multiprocessing, :multithreading)
             if istaskfailed(tasks[j][i])
                 fetch(tasks[j][i])
                 error("Task failed for population")
             end
         end
         # Non-blocking check if a population is ready:
-        population_ready = if parallelism in [:multiprocessing, :multithreading]
+        population_ready = if parallelism in (:multiprocessing, :multithreading)
             # TODO: Implement type assertions based on parallelism.
             isready(channels[j][i])
         else
@@ -695,7 +695,7 @@ function _EquationSearch(
             start_work_monitor!(resource_monitor)
             # Take the fetch operation from the channel since its ready
             (cur_pop, best_seen, cur_record, cur_num_evals) =
-                if parallelism in [:multiprocessing, :multithreading]
+                if parallelism in (:multiprocessing, :multithreading)
                     take!(channels[j][i])
                 else
                     allPops[j][i]
@@ -749,7 +749,7 @@ function _EquationSearch(
                 output_file = output_file * ".out$j"
             end
             # Write file twice in case exit in middle of filewrite
-            for out_file in [output_file, output_file * ".bkup"]
+            for out_file in (output_file, output_file * ".bkup")
                 open(out_file, "w") do io
                     println(io, "Complexity,Loss,Equation")
                     for member in dominating
@@ -826,7 +826,7 @@ function _EquationSearch(
 
                 (tmp_pop, tmp_best_seen, cur_record, tmp_num_evals)
             end
-            if parallelism in [:multiprocessing, :multithreading]
+            if parallelism in (:multiprocessing, :multithreading)
                 tasks[j][i] = @async put!(channels[j][i], fetch(allPops[j][i]))
             end
 

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -728,7 +728,7 @@ function _EquationSearch(
                 end
                 actualMaxsize = options.maxsize + MAX_DEGREE
 
-                valid_size = size < actualMaxsize
+                valid_size = 0 < size < actualMaxsize
                 if valid_size
                     already_filled = hallOfFame[j].exists[size]
                     better_than_current = member.score < hallOfFame[j].members[size].score

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -683,6 +683,7 @@ function _EquationSearch(
         end
         # Non-blocking check if a population is ready:
         population_ready = if parallelism in [:multiprocessing, :multithreading]
+            # TODO: Implement type assertions based on parallelism.
             isready(channels[j][i])
         else
             true

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -168,11 +168,7 @@ import .CoreModule:
     gamma,
     erf,
     erfc,
-    atanh_clip,
-    SRConcurrency,
-    SRSerial,
-    SRThreaded,
-    SRDistributed
+    atanh_clip
 import .UtilsModule: debug, debug_inline, is_anonymous_function, recursive_merge
 import .ComplexityModule: compute_complexity
 import .CheckConstraintsModule: check_constraints
@@ -357,18 +353,18 @@ function EquationSearch(
     saved_state::Union{StateType{T},Nothing}=nothing,
 ) where {T<:Real}
     concurrency = if parallelism in (:multithreading, "multithreading")
-        SRThreaded()
+        :multithreading
     elseif parallelism in (:multiprocessing, "multiprocessing")
-        SRDistributed()
+        :multiprocessing
     elseif parallelism in (:serial, "serial")
-        SRSerial()
+        :serial
     else
         error(
             "Invalid parallelism mode: $parallelism. " *
             "You must choose one of :multithreading, :multiprocessing, or :serial.",
         )
     end
-    not_distributed = isa(concurrency, Union{SRSerial,SRThreaded})
+    not_distributed = concurrency in (:multithreading, :serial)
     not_distributed &&
         procs !== nothing &&
         error(
@@ -394,7 +390,7 @@ function EquationSearch(
 end
 
 function _EquationSearch(
-    ::ConcurrencyType,
+    parallelism::Symbol,
     datasets::Vector{Dataset{T}};
     niterations::Int,
     options::Options,
@@ -403,13 +399,13 @@ function _EquationSearch(
     addprocs_function::Union{Function,Nothing},
     runtests::Bool,
     saved_state::Union{StateType{T},Nothing},
-) where {T<:Real,ConcurrencyType<:SRConcurrency}
+) where {T<:Real}
     if options.deterministic
-        if ConcurrencyType != SRSerial
+        if parallelism != :serial
             error("Determinism is only guaranteed for serial mode.")
         end
     end
-    if ConcurrencyType == SRThreaded
+    if parallelism == :multithreading
         if Threads.nthreads() == 1
             @warn "You are using multithreading mode, but only one thread is available. Try starting julia with `--threads=auto`."
         end
@@ -451,9 +447,9 @@ function _EquationSearch(
     end
     # Start a population on every process
     #    Store the population, hall of fame
-    allPopsType = if ConcurrencyType == SRSerial
+    allPopsType = if parallelism == :serial
         Tuple{Population,HallOfFame,RecordType,Float64}
-    elseif ConcurrencyType == SRDistributed
+    elseif parallelism == :multiprocessing
         Future
     else
         Task
@@ -462,8 +458,8 @@ function _EquationSearch(
     allPops = [allPopsType[] for j in 1:nout]
     init_pops = [allPopsType[] for j in 1:nout]
     # Set up a channel to send finished populations back to head node
-    if ConcurrencyType in [SRDistributed, SRThreaded]
-        if ConcurrencyType == SRDistributed
+    if parallelism in [:multiprocessing, :multithreading]
+        if parallelism == :multiprocessing
             channels = [
                 [RemoteChannel(1) for i in 1:(options.npopulations)] for j in 1:nout
             ]
@@ -500,7 +496,7 @@ function _EquationSearch(
     ##########################################################################
     ### Distributed code:
     ##########################################################################
-    if ConcurrencyType == SRDistributed
+    if parallelism == :multiprocessing
         if addprocs_function === nothing
             addprocs_function = addprocs
         end
@@ -542,7 +538,7 @@ function _EquationSearch(
     for j in 1:nout
         for i in 1:(options.npopulations)
             worker_idx = next_worker(worker_assignment, procs)
-            if ConcurrencyType == SRDistributed
+            if parallelism == :multiprocessing
                 worker_assignment[(j, i)] = worker_idx
             end
 
@@ -550,14 +546,14 @@ function _EquationSearch(
 
             if saved_pop !== nothing && length(saved_pop.members) == options.npop
                 saved_pop::Population{T}
-                new_pop = @sr_spawner ConcurrencyType worker_idx (
+                new_pop = @sr_spawner parallelism worker_idx (
                     saved_pop, HallOfFame(options, T), RecordType(), 0.0
                 )
             else
                 if saved_pop !== nothing
                     @warn "Recreating population (output=$(j), population=$(i)), as the saved one doesn't have the correct number of members."
                 end
-                new_pop = @sr_spawner ConcurrencyType worker_idx (
+                new_pop = @sr_spawner parallelism worker_idx (
                     Population(
                         datasets[j];
                         npop=options.npop,
@@ -582,14 +578,14 @@ function _EquationSearch(
         for i in 1:(options.npopulations)
             @recorder record["out$(j)_pop$(i)"] = RecordType()
             worker_idx = next_worker(worker_assignment, procs)
-            if ConcurrencyType == SRDistributed
+            if parallelism == :multiprocessing
                 worker_assignment[(j, i)] = worker_idx
             end
 
             # TODO - why is this needed??
             # Multi-threaded doesn't like to fetch within a new task:
-            updated_pop = @sr_spawner ConcurrencyType worker_idx let
-                in_pop = if ConcurrencyType in [SRDistributed, SRThreaded]
+            updated_pop = @sr_spawner parallelism worker_idx let
+                in_pop = if parallelism in [:multiprocessing, :multithreading]
                     fetch(init_pops[j][i])[1]
                 else
                     init_pops[j][i][1]
@@ -649,7 +645,7 @@ function _EquationSearch(
     print_every_n_seconds = 5
     equation_speed = Float32[]
 
-    if ConcurrencyType in [SRDistributed, SRThreaded]
+    if parallelism in [:multiprocessing, :multithreading]
         for j in 1:nout
             for i in 1:(options.npopulations)
                 # Start listening for each population to finish:
@@ -679,15 +675,18 @@ function _EquationSearch(
         j, i = all_idx[kappa]
 
         # Check if error on population:
-        if ConcurrencyType in [SRDistributed, SRThreaded]
+        if parallelism in [:multiprocessing, :multithreading]
             if istaskfailed(tasks[j][i])
                 fetch(tasks[j][i])
                 error("Task failed for population")
             end
         end
         # Non-blocking check if a population is ready:
-        population_ready =
-            ConcurrencyType in [SRDistributed, SRThreaded] ? isready(channels[j][i]) : true
+        population_ready = if parallelism in [:multiprocessing, :multithreading]
+            isready(channels[j][i])
+        else
+            true
+        end
         # Don't start more if this output has finished its cycles:
         # TODO - this might skip extra cycles?
         population_ready &= (cycles_remaining[j] > 0)
@@ -695,7 +694,7 @@ function _EquationSearch(
             start_work_monitor!(resource_monitor)
             # Take the fetch operation from the channel since its ready
             (cur_pop, best_seen, cur_record, cur_num_evals) =
-                if ConcurrencyType in [SRDistributed, SRThreaded]
+                if parallelism in [:multiprocessing, :multithreading]
                     take!(channels[j][i])
                 else
                     allPops[j][i]
@@ -779,7 +778,7 @@ function _EquationSearch(
                 break
             end
             worker_idx = next_worker(worker_assignment, procs)
-            if ConcurrencyType == SRDistributed
+            if parallelism == :multiprocessing
                 worker_assignment[(j, i)] = worker_idx
             end
             @recorder begin
@@ -787,7 +786,7 @@ function _EquationSearch(
                 iteration = find_iteration_from_record(key, record) + 1
             end
 
-            allPops[j][i] = @sr_spawner ConcurrencyType worker_idx let
+            allPops[j][i] = @sr_spawner parallelism worker_idx let
                 cur_record = RecordType()
                 @recorder cur_record[key] = RecordType(
                     "iteration$(iteration)" => record_population(cur_pop, options)
@@ -826,7 +825,7 @@ function _EquationSearch(
 
                 (tmp_pop, tmp_best_seen, cur_record, tmp_num_evals)
             end
-            if ConcurrencyType in [SRDistributed, SRThreaded]
+            if parallelism in [:multiprocessing, :multithreading]
                 tasks[j][i] = @async put!(channels[j][i], fetch(allPops[j][i]))
             end
 
@@ -856,7 +855,7 @@ function _EquationSearch(
                     dataset=only(datasets),
                     options,
                     head_node_occupation,
-                    ConcurrencyType,
+                    parallelism,
                 )
             end
         end
@@ -884,7 +883,7 @@ function _EquationSearch(
                     total_cycles,
                     cycles_remaining,
                     head_node_occupation,
-                    ConcurrencyType,
+                    parallelism,
                 )
             end
             last_print_time = time()

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,78 @@
+import SnoopPrecompile: @precompile_all_calls, @precompile_setup
+
+macro maybe_precompile_setup(mode, ex)
+    precompile_ex = Expr(
+        :macrocall, Symbol("@precompile_setup"), LineNumberNode(@__LINE__), ex
+    )
+    return quote
+        if $(esc(mode)) == :compile
+            $(esc(ex))
+        elseif $(esc(mode)) == :precompile
+            $(esc(precompile_ex))
+        else
+            error("Invalid value for mode: " * show($(esc(mode))))
+        end
+    end
+end
+
+macro maybe_precompile_all_calls(mode, ex)
+    precompile_ex = Expr(
+        :macrocall, Symbol("@precompile_all_calls"), LineNumberNode(@__LINE__), ex
+    )
+    return quote
+        if $(esc(mode)) == :compile
+            $(esc(ex))
+        elseif $(esc(mode)) == :precompile
+            $(esc(precompile_ex))
+        else
+            error("Invalid value for mode: " * show($(esc(mode))))
+        end
+    end
+end
+
+"""`mode=:precompile` will use `@precompile_*` directives; `mode=:compile` runs."""
+function do_precompilation(; mode=:precompile)
+    @maybe_precompile_setup mode begin
+        types = [Float32, Float64]
+        for T in types
+            @maybe_precompile_all_calls mode begin
+                X = randn(T, 5, 100)
+                y = 2 * cos.(X[4, :]) + X[1, :] .^ 2 .- 2
+                options = SymbolicRegression.Options(;
+                    binary_operators=[+, *, /, -],
+                    unary_operators=[cos, exp],
+                    npopulations=3,
+                    npop=50,
+                    ncycles_per_iteration=100,
+                    mutation_weights=MutationWeights(;
+                        mutate_constant=1.0,
+                        mutate_operator=1.0,
+                        add_node=1.0,
+                        insert_node=1.0,
+                        delete_node=1.0,
+                        simplify=1.0,
+                        randomize=1.0,
+                        do_nothing=1.0,
+                        optimize=1.0,
+                    ),
+                    fraction_replaced=0.2,
+                    fraction_replaced_hof=0.2,
+                    define_helper_functions=false,
+                    optimize_probability=0.05,
+                )
+                redirect_stderr(devnull) do
+                    redirect_stdout(devnull) do
+                        hall_of_fame = EquationSearch(
+                            X,
+                            y;
+                            niterations=3,
+                            options=options,
+                            parallelism=:multithreading,
+                        )
+                        calculate_pareto_frontier(X, y, hall_of_fame, options)
+                    end
+                end
+            end
+        end
+    end
+end

--- a/test/full.jl
+++ b/test/full.jl
@@ -35,3 +35,7 @@ end
 @testset "Testing whether we can move operators to workers." begin
     include("test_custom_operators_multiprocessing.jl")
 end
+
+@testset "Test whether the precompilation script works." begin
+    include("test_precompilation.jl")
+end

--- a/test/test_precompilation.jl
+++ b/test/test_precompilation.jl
@@ -1,0 +1,3 @@
+using SymbolicRegression
+
+SymbolicRegression.do_precompilation(; mode=:compile)


### PR DESCRIPTION
This does a few things which give vastly better startup times:

1. `SnoopPrecompile.@precompile_all_calls` used to precompile all relevant functions.\
2. DynamicExpressions.jl is also using SnoopCompile for better pre-compilation as of 0.4.2, and startup is pretty much instantaneous (aside from `using`). See https://github.com/SymbolicML/DynamicExpressions.jl/pull/11.
3. DynamicExpressions.jl now does not specialize to the order of operators, only individual functions, so all common operators can now be pre-compiled.
4. Most type specialization from `Options` has been removed, where it did not improve the speed. The only remaining type specialization is the numeric type for complexity

The time of `using SymbolicRegression` is now the most expensive, so it's worth it to build a sysimage with the following snippet:

```bash
julia -O3 --threads=auto --startup-file="no" -e 'using Pkg; Pkg.activate(;temp=true); pkg"add SymbolicRegression.jl#snoop-compile2"; pkg"add DynamicExpressions"; pkg"add PackageCompiler"; open("precompile_file.jl", "w") do io; write(io, "using DynamicExpressions; using SymbolicRegression"); end; using PackageCompiler; create_sysimage(["SymbolicRegression", "DynamicExpressions"]; sysimage_path="SymbolicRegression.so", precompile_execution_file="precompile_file.jl")'
```

which can then be loaded with
```bash
julia -O3 --threads=auto -J SymbolicRegression.so
```

To take full advantage of the improved startup time, `Options` should be loaded with `define_helper_functions=false`.

---

This also fixes an issue where equations with complexity 0 (say you define constants to have 0 complexity) were causing bounds errors.

---

To-do:

- [x] Check if type specialization to parallelism type can be turned off.