### PR TITLE
Fix bug in constraint checking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.15.0"
+version = "0.15.1"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/CheckConstraints.jl
+++ b/src/CheckConstraints.jl
@@ -141,7 +141,7 @@ end
 """Check if user-passed constraints are violated or not"""
 function check_constraints(tree::Node, options::Options, maxsize::Int)::Bool
     size = compute_complexity(tree, options)
-    if 0 > size > maxsize
+    if size > maxsize
         return false
     end
     for i in 1:(options.nbin)

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -86,6 +86,10 @@ end
 function score_func(
     dataset::Dataset{T}, tree::Node{T}, options::Options
 )::Tuple{T,T} where {T<:Real}
+    # Skip evaluation (which might be very slow)
+    if compute_complexity(tree, options) > options.maxsize
+        return T(Inf), T(Inf)
+    end
     result_loss = eval_loss(tree, dataset, options)
     score = loss_to_score(result_loss, dataset.baseline_loss, tree, options)
     return score, result_loss
@@ -95,6 +99,10 @@ end
 function score_func_batch(
     dataset::Dataset{T}, tree::Node{T}, options::Options
 )::Tuple{T,T} where {T<:Real}
+    # Skip evaluation (which might be very slow)
+    if compute_complexity(tree, options) > options.maxsize
+        return T(Inf), T(Inf)
+    end
     batch_idx = StatsBase.sample(1:(dataset.n), options.batch_size; replace=true)
     batch_X = view(dataset.X, :, batch_idx)
     batch_y = view(dataset.y, batch_idx)

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -86,10 +86,6 @@ end
 function score_func(
     dataset::Dataset{T}, tree::Node{T}, options::Options
 )::Tuple{T,T} where {T<:Real}
-    # Skip evaluation (which might be very slow)
-    if compute_complexity(tree, options) > options.maxsize
-        return T(Inf), T(Inf)
-    end
     result_loss = eval_loss(tree, dataset, options)
     score = loss_to_score(result_loss, dataset.baseline_loss, tree, options)
     return score, result_loss
@@ -99,10 +95,6 @@ end
 function score_func_batch(
     dataset::Dataset{T}, tree::Node{T}, options::Options
 )::Tuple{T,T} where {T<:Real}
-    # Skip evaluation (which might be very slow)
-    if compute_complexity(tree, options) > options.maxsize
-        return T(Inf), T(Inf)
-    end
     batch_idx = StatsBase.sample(1:(dataset.n), options.batch_size; replace=true)
     batch_X = view(dataset.X, :, batch_idx)
     batch_y = view(dataset.y, batch_idx)

--- a/test/test_constraints.jl
+++ b/test/test_constraints.jl
@@ -17,3 +17,18 @@ violating_tree = Node(1, tree)
 
 @test check_constraints(tree, options) == true
 @test check_constraints(violating_tree, options) == false
+
+# Test complexity constraints:
+options = Options(; binary_operators=(+, *), maxsize=5)
+@extend_operators options
+x1, x2, x3 = [Node(; feature=i) for i in 1:3]
+tree = x1 + x2 * x3
+violating_tree = 5.1 * tree
+@test check_constraints(tree, options) == true
+@test check_constraints(violating_tree, options) == false
+
+# Also test for custom complexities:
+options = Options(; binary_operators=(+, *), maxsize=5, complexity_of_operators=[(*) => 3])
+@test check_constraints(tree, options) == false
+options = Options(; binary_operators=(+, *), maxsize=5, complexity_of_operators=[(*) => 0])
+@test check_constraints(violating_tree, options) == true


### PR DESCRIPTION
This fixes a _diabolical_ bug:

```diff
-if 0 > size > maxsize
+if size > maxsize
```

It turns out that the function `check_constraints` was **never** checking whether an expression was above the max size, due this flawed inequality.

In actuality, the only part of the code which controlled the size of expressions was the hall of fame creation – since there is an explicit check that expressions are below the max size. The average size of expressions was influenced by the `parsimony` parameter.

I noticed this behavior when I set `parsimony=0.0`: the search would become very very slow. It seems that the crossover operations were creating some very large expressions, and these were being scored normally, and passed back to the population. So it's likely that some expressions ended up being 1000s of nodes in size, and the evaluation of these was extremely slow.

**For some search settings, this fix will result in a massive speedup.** However, it may change the behavior of the search.

TODO:

- [x] Add a unit test.