### PR TITLE
Fix data race in state saving

### DIFF
--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -701,11 +701,11 @@ function _EquationSearch(
                 else
                     allPops[j][i]
                 end
-            returnPops[j][i] = cur_pop
             cur_pop::Population
             best_seen::HallOfFame
             cur_record::RecordType
             cur_num_evals::Float64
+            returnPops[j][i] = copy_population(cur_pop)
             bestSubPops[j][i] = best_sub_pop(cur_pop; topn=options.topn)
             @recorder record = recursive_merge(record, cur_record)
             num_evals[j][i] += cur_num_evals


### PR DESCRIPTION
For early stopping, it is currently possible that threads still modify a population even after that population has been returned to the user. Thus, this change fixes this data race by performing an explicit copy when checkpointing the state.