### PR TITLE
Force safe closing of threads

### DIFF
--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -911,10 +911,14 @@ function _EquationSearch(
 
     close_reader!(stdin_reader)
 
-    if we_created_procs
-        rmprocs(procs)
+    # Safely close all processes or threads
+    if parallelism == :multiprocessing
+        we_created_procs && rmprocs(procs)
+    elseif parallelism == :multithreading
+        for j in 1:nout, i in 1:(options.npopulations)
+            wait(allPops[j][i])
+        end
     end
-    # TODO - also stop threads here?
 
     ##########################################################################
     ### Distributed code^


### PR DESCRIPTION
This fixes another potential source of bugs due to data races. In short: threads were not being killed, even if the search was stopped early. This adds a simple `wait` to each thread (which is what `rmprocs` already does for processes) at the end of `EquationSearch`.