### PR TITLE
Re-compute losses for warm start

### DIFF
--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -558,6 +558,12 @@ function _EquationSearch(
 
             if saved_pop !== nothing && length(saved_pop.members) == options.npop
                 saved_pop::Population{T}
+                ## Update losses:
+                for member in saved_pop.members
+                    score, result_loss = score_func(datasets[j], member.tree, options)
+                    member.score = score
+                    member.loss = result_loss
+                end
                 new_pop = @sr_spawner parallelism worker_idx (
                     saved_pop, HallOfFame(options, T), RecordType(), 0.0
                 )

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -532,6 +532,16 @@ function _EquationSearch(
     hallOfFame = load_saved_hall_of_fame(saved_state)
     if hallOfFame === nothing
         hallOfFame = [HallOfFame(options, T) for j in 1:nout]
+    else
+        # Recompute losses for the hall of fame, in
+        # case the dataset changed:
+        for (hof, dataset) in zip(hallOfFame, datasets)
+            for member in hof.members[hof.exists]
+                score, result_loss = score_func(dataset, member.tree, options)
+                member.score = score
+                member.loss = result_loss
+            end
+        end
     end
     @assert length(hallOfFame) == nout
     hallOfFame::Vector{HallOfFame{T}}

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -535,6 +535,7 @@ function _EquationSearch(
     else
         # Recompute losses for the hall of fame, in
         # case the dataset changed:
+        hallOfFame::Vector{HallOfFame{T}}
         for (hof, dataset) in zip(hallOfFame, datasets)
             for member in hof.members[hof.exists]
                 score, result_loss = score_func(dataset, member.tree, options)

--- a/test/test_fast_cycle.jl
+++ b/test/test_fast_cycle.jl
@@ -14,10 +14,10 @@ options = SymbolicRegression.Options(;
     return_state=true,
 )
 X = randn(MersenneTwister(0), Float32, 5, 100)
-y = 2 * cos.(X[4, :])
+y = 2 * cos.(X[4, :]) .- X[2, :]
 varMap = ["t1", "t2", "t3", "t4", "t5"]
-state, hallOfFame = EquationSearch(X, y; varMap=varMap, niterations=2, options=options)
-dominating = calculate_pareto_frontier(X, y, hallOfFame, options)
+state, hall_of_fame = EquationSearch(X, y; varMap=varMap, niterations=2, options=options)
+dominating = calculate_pareto_frontier(X, y, hall_of_fame, options)
 
 best = dominating[end]
 
@@ -28,11 +28,37 @@ best = dominating[end]
 # We do 0 iterations to make sure the state is used.
 println("Passed.")
 println("Testing whether state saving works.")
-state, hallOfFame = EquationSearch(
-    X, y; varMap=varMap, niterations=0, options=options, saved_state=(state, hallOfFame)
+new_state, new_hall_of_fame = EquationSearch(
+    X,
+    y;
+    varMap=varMap,
+    niterations=0,
+    options=options,
+    saved_state=(deepcopy(state), deepcopy(hall_of_fame)),
 )
 
-dominating = calculate_pareto_frontier(X, y, hallOfFame, options)
+dominating = calculate_pareto_frontier(X, y, new_hall_of_fame, options)
 best = dominating[end]
 print_tree(best.tree, options)
 @test best.loss < maximum_residual / 10
+
+println("Testing whether state saving works with changed loss function.")
+previous_loss = best.loss
+new_loss(x, y) = sum(abs2, x - y) * 0.1
+options = SymbolicRegression.Options(;
+    default_params...,
+    binary_operators=(+, *),
+    unary_operators=(cos,),
+    npopulations=4,
+    constraints=((*) => (-1, 10), cos => (5)),
+    fast_cycle=true,
+    skip_mutation_failures=true,
+    return_state=true,
+    elementwise_loss=new_loss,
+)
+state, hall_of_fame = EquationSearch(
+    X, y; varMap=varMap, niterations=0, options=options, saved_state=(state, hall_of_fame)
+)
+dominating = calculate_pareto_frontier(X, y, hall_of_fame, options)
+best = dominating[end]
+@test best.loss ≈ previous_loss * 0.1


### PR DESCRIPTION
Fixes #176.

Sometimes the user may want to change the data or loss function when doing a warm start. This change makes the search recompute losses for all members of a passed state.