### PR TITLE
Include datetime in default filename

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
 version = "0.15.3"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 DynamicExpressions = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -1,6 +1,7 @@
 module OptionsModule
 
 using Optim: Optim
+using Dates: Dates
 import DynamicExpressions: OperatorEnum, Node, string_tree
 import Distributed: nworkers
 import LossFunctions: L2DistLoss
@@ -435,7 +436,9 @@ function Options(;
     end
 
     if output_file === nothing
-        output_file = "hall_of_fame.csv" #TODO - put in date/time string here
+        # "%Y-%m-%d_%H%M%S.%f"
+        date_time_str = Dates.format(Dates.now(), "yyyy-mm-dd_HHMMSS.sss")
+        output_file = "hall_of_fame_" * date_time_str * ".csv"
     end
 
     nuna = length(unary_operators)


### PR DESCRIPTION
Right now the default filename is just `hall_of_fame.csv`. This is not great if you forget to set a filename, as it will just be overwritten by the next search.