### PR TITLE
Turn off simplification when constraints given

### DIFF
--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -60,6 +60,10 @@ function next_generation(
         weights.insert_node = 0.0
     end
 
+    if !options.should_simplify
+        weights.simplify = 0.0
+    end
+
     mutation_choice = sample_mutation(weights)
 
     successful_mutation = false
@@ -104,6 +108,7 @@ function next_generation(
             @recorder tmp_recorder["type"] = "delete_op"
             is_success_always_possible = true
         elseif mutation_choice == :simplify
+            @assert options.should_simplify
             tree = simplify_tree(tree, options.operators)
             tree = combine_operators(tree, options.operators)
             @recorder tmp_recorder["type"] = "partial_simplify"

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -258,6 +258,8 @@ https://github.com/MilesCranmer/PySR/discussions/115.
     migrated equations at the end of each cycle.
 - `fraction_replaced_hof`: What fraction to replace with hall of fame
     equations at the end of each cycle.
+- `should_simplify`: Whether to simplify equations. If you
+    pass a custom objective, this will be set to `false`.
 - `should_optimize_constants`: Whether to use an optimization algorithm
     to periodically optimize constants in equations.
 - `optimizer_nrestarts`: How many different random starting positions to consider
@@ -333,6 +335,7 @@ function Options(;
     turbo=false,
     migration=true,
     hof_migration=true,
+    should_simplify=nothing,
     should_optimize_constants=true,
     output_file=nothing,
     npopulations=15,
@@ -433,6 +436,16 @@ function Options(;
         if loss_function !== nothing
             error("You cannot specify both `elementwise_loss` and `loss_function`.")
         end
+    end
+
+    if should_simplify === nothing
+        should_simplify = (
+            loss_function === nothing &&
+            nested_constraints === nothing &&
+            constraints === nothing &&
+            bin_constraints === nothing &&
+            una_constraints === nothing
+        )
     end
 
     if output_file === nothing
@@ -640,6 +653,7 @@ function Options(;
         turbo,
         migration,
         hof_migration,
+        should_simplify,
         should_optimize_constants,
         output_file,
         npopulations,

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -118,6 +118,7 @@ struct Options{CT}
     turbo::Bool
     migration::Bool
     hof_migration::Bool
+    should_simplify::Bool
     should_optimize_constants::Bool
     output_file::String
     npopulations::Int

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -70,8 +70,10 @@ function optimize_and_simplify_population(
     array_num_evals = zeros(Float64, pop.n)
     do_optimization = rand(pop.n) .< options.optimizer_probability
     for j in 1:(pop.n)
-        pop.members[j].tree = simplify_tree(pop.members[j].tree, options.operators)
-        pop.members[j].tree = combine_operators(pop.members[j].tree, options.operators)
+        if options.should_simplify
+            pop.members[j].tree = simplify_tree(pop.members[j].tree, options.operators)
+            pop.members[j].tree = combine_operators(pop.members[j].tree, options.operators)
+        end
         if options.should_optimize_constants && do_optimization[j]
             pop.members[j], array_num_evals[j] = optimize_constants(
                 dataset, pop.members[j], options

--- a/test/test_custom_objectives.jl
+++ b/test/test_custom_objectives.jl
@@ -23,6 +23,8 @@ options = Options(;
     mutation_weights=MutationWeights(; optimize=0.01),
 )
 
+@test options.should_simplify == false
+
 X = rand(2, 100) .* 10
 y = X[1, :] .+ X[2, :]
 

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -8,6 +8,7 @@ binary_operators = (+, -, /, *)
 index_of_mult = [i for (i, op) in enumerate(binary_operators) if op == *][1]
 
 options = Options(; binary_operators=binary_operators)
+@test options.should_simplify  # Default is true
 
 tree = Node("x1") + Node("x1")
 


### PR DESCRIPTION
Fixes #188. Whenever a constraint is given, algebraic simplification should be turned off, to avoid messing up the constraint.