### PR TITLE
Fix equation splitting for unicode variables

### DIFF
--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -1,6 +1,7 @@
 module HallOfFameModule
 
 import DynamicExpressions: Node, string_tree
+import ..UtilsModule: split_string
 import ..CoreModule: MAX_DEGREE, Options, Dataset, DATA_TYPE, LOSS_TYPE
 import ..ComplexityModule: compute_complexity
 import ..PopMemberModule: PopMember, copy_pop_member
@@ -158,22 +159,6 @@ function string_dominating_pareto_curve(
     end
     output *= "-"^(twidth - 1)
     return output
-end
-
-"""
-    split_string(s::String, n::Integer)
-
-```jldoctest
-split_string("abcdefgh", 3)
-
-# output
-
-["abc", "def", "gh"]
-```
-"""
-function split_string(s::String, n::Integer)
-    length(s) <= n && return [s]
-    return [s[i:min(i + n - 1, end)] for i in 1:n:length(s)]
 end
 
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -49,6 +49,24 @@ function recursive_merge(x...)
 end
 
 """
+    split_string(s::String, n::Integer)
+
+```jldoctest
+split_string("abcdefgh", 3)
+
+# output
+
+["abc", "def", "gh"]
+```
+"""
+function split_string(s::String, n::Integer)
+    length(s) <= n && return [s]
+    # Due to unicode characters, need to split only at valid indices:
+    I = eachindex(s) |> collect
+    return [s[I[i]:I[min(i + n - 1, end)]] for i in 1:n:length(s)]
+end
+
+"""
 Tiny equivalent to StaticArrays.MVector
 
 This is so we don't have to load StaticArrays, which takes a long time.

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -1,5 +1,6 @@
 using Test
 using SymbolicRegression
+using SymbolicRegression.UtilsModule: split_string
 
 include("test_params.jl")
 
@@ -44,4 +45,13 @@ for binop in [safe_pow, ^]
     )
     minitree = Node(5, Node("x1"), Node("x2"))
     @test string_tree(minitree, opts) == "(x1 ^ x2)"
+end
+
+@testset "Test splitting of strings" begin
+    split_string("abcdefgh", 3) == ["abc", "def", "gh"]
+    split_string("abcdefgh", 100) == ["abcdefgh"]
+    split_string("⋅", 1) == ["⋅"]
+    split_string("⋅⋅", 1) == ["⋅", "⋅"]
+    split_string("⋅⋅⋅⋅", 2) == ["⋅⋅", "⋅⋅"]
+    split_string("ραβγ", 2) == ["ρα", "βγ"]
 end


### PR DESCRIPTION
It seems like the code that splits an equation string into multiple lines for the progress bar was using linear indexing, whereas strings with unicode do not have indices 1, 2, 3...

e.g., the string `"⋅⋅"` has valid indices `1` and `4`.