### PR TITLE
Update DynamicExpressions.jl version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ SymbolicRegressionSymbolicUtilsExt = "SymbolicUtils"
 
 [compat]
 Compat = "^4.2"
-DynamicExpressions = "0.10"
+DynamicExpressions = "0.11"
 DynamicQuantities = "^0.6.2"
 JSON3 = "1"
 LineSearches = "7"

--- a/test/test_custom_operators_multiprocessing.jl
+++ b/test/test_custom_operators_multiprocessing.jl
@@ -19,7 +19,6 @@ options = SymbolicRegression.Options(;
     unary_operators=(_cos, _exp),
     npopulations=20,
     early_stop_condition=early_stop,
-    enable_autodiff=true,
     elementwise_loss=my_loss,
 )
 


### PR DESCRIPTION
This makes Zygote.jl an extension which should get another few hundred ms off the load time.