### PR TITLE
Batching inside optimization loop + batching support for custom objectives

### DIFF
--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -5,16 +5,16 @@ using Optim: Optim
 import DynamicExpressions: Node, count_constants
 import ..CoreModule: Options, Dataset, DATA_TYPE, LOSS_TYPE
 import ..UtilsModule: get_birth_order
-import ..LossFunctionsModule: score_func, eval_loss
+import ..LossFunctionsModule: score_func, eval_loss, batch_sample
 import ..PopMemberModule: PopMember
 
 # Proxy function for optimization
-function opt_func(
-    x, dataset::Dataset{T,L}, tree, constant_nodes, options
+@inline function opt_func(
+    x, dataset::Dataset{T,L}, tree, constant_nodes, options, idx
 ) where {T<:DATA_TYPE,L<:LOSS_TYPE}
     _set_constants!(x, constant_nodes)
     # TODO(mcranmer): This should use score_func batching.
-    loss = eval_loss(tree, dataset, options, false)
+    loss = eval_loss(tree, dataset, options; regularization=false, idx=idx)
     return loss::L
 end
 
@@ -29,29 +29,40 @@ end
 function optimize_constants(
     dataset::Dataset{T,L}, member::PopMember{T,L}, options::Options
 )::Tuple{PopMember{T,L},Float64} where {T<:DATA_TYPE,L<:LOSS_TYPE}
+    if options.batching
+        dispatch_optimize_constants(
+            dataset, member, options, batch_sample(dataset, options)
+        )
+    else
+        dispatch_optimize_constants(dataset, member, options, nothing)
+    end
+end
+function dispatch_optimize_constants(
+    dataset::Dataset{T,L}, member::PopMember{T,L}, options::Options, idx
+) where {T<:DATA_TYPE,L<:LOSS_TYPE}
     nconst = count_constants(member.tree)
     nconst == 0 && return (member, 0.0)
     if T <: Complex
         # TODO: Make this more general. Also, do we even need Newton here at all??
         algorithm = Optim.BFGS(; linesearch=LineSearches.BackTracking())#order=3))
         return _optimize_constants(
-            dataset, member, options, algorithm, options.optimizer_options
+            dataset, member, options, algorithm, options.optimizer_options, idx
         )
     elseif nconst == 1
         algorithm = Optim.Newton(; linesearch=LineSearches.BackTracking())
         return _optimize_constants(
-            dataset, member, options, algorithm, options.optimizer_options
+            dataset, member, options, algorithm, options.optimizer_options, idx
         )
     else
         if options.optimizer_algorithm == "NelderMead"
             algorithm = Optim.NelderMead(; linesearch=LineSearches.BackTracking())
             return _optimize_constants(
-                dataset, member, options, algorithm, options.optimizer_options
+                dataset, member, options, algorithm, options.optimizer_options, idx
             )
         elseif options.optimizer_algorithm == "BFGS"
             algorithm = Optim.BFGS(; linesearch=LineSearches.BackTracking())#order=3))
             return _optimize_constants(
-                dataset, member, options, algorithm, options.optimizer_options
+                dataset, member, options, algorithm, options.optimizer_options, idx
             )
         else
             error("Optimization function not implemented.")
@@ -60,12 +71,12 @@ function optimize_constants(
 end
 
 function _optimize_constants(
-    dataset, member::PopMember{T,L}, options, algorithm, optimizer_options
+    dataset, member::PopMember{T,L}, options, algorithm, optimizer_options, idx
 )::Tuple{PopMember{T,L},Float64} where {T,L}
     tree = member.tree
     constant_nodes = filter(t -> t.degree == 0 && t.constant, tree)
     x0 = [n.val::T for n in constant_nodes]
-    f(x) = opt_func(x, dataset, tree, constant_nodes, options)
+    f(x) = opt_func(x, dataset, tree, constant_nodes, options, idx)
     result = Optim.optimize(f, x0, algorithm, optimizer_options)
     num_evals = 0.0
     num_evals += result.f_calls

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -109,7 +109,7 @@ function eval_loss_batched(
 end
 
 function batch_sample(dataset, options)
-    return StatsBase.sample(1:(dataset.n), options.batch_size; replace=true)
+    return StatsBase.sample(1:(dataset.n), options.batch_size; replace=false)
 end
 
 # Just so we can pass either PopMember or Node here:

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -33,8 +33,14 @@ function _weighted_loss(
     end
 end
 
-@inline maybe_getindex(v, ::Nothing) = v
-@inline maybe_getindex(v, i...) = getindex(v, i...)
+"""If any of the indices are `nothing`, just return."""
+@inline function maybe_getindex(v, i...)
+    if any(==(nothing), i)
+        return v
+    else
+        return getindex(v, i...)
+    end
+end
 
 # Evaluate the loss of a particular expression on the input dataset.
 function _eval_loss(

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -78,6 +78,13 @@ function evaluator(
     if static_hasmethod(f, typeof((tree, dataset, options, idx)))
         # If user defines method that accepts batching indices:
         return f(tree, dataset, options, idx)
+    elseif options.batching
+        error(
+            "User-defined loss function must accept batching indices if `options.batching == true`. " *
+            "For example, `f(tree, dataset, options, idx)`, where `idx` " *
+            "is `nothing` if full dataset is to be used, " *
+            "and a vector of indices otherwise.",
+        )
     else
         return f(tree, dataset, options)
     end

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -2,6 +2,7 @@ module LossFunctionsModule
 
 import Random: randperm
 using StatsBase: StatsBase
+import Tricks: static_hasmethod
 import DynamicExpressions: Node
 using LossFunctions: LossFunctions
 import LossFunctions: SupervisedLoss
@@ -32,11 +33,16 @@ function _weighted_loss(
     end
 end
 
+@inline maybe_getindex(v, ::Nothing) = v
+@inline maybe_getindex(v, i...) = getindex(v, i...)
+
 # Evaluate the loss of a particular expression on the input dataset.
 function _eval_loss(
-    tree::Node{T}, dataset::Dataset{T,L,AX,AY}, options::Options, regularization::Bool
-)::L where {T<:DATA_TYPE,L<:LOSS_TYPE,AX<:AbstractArray{T},AY<:AbstractArray{T}}
-    (prediction, completion) = eval_tree_array(tree, dataset.X, options)
+    tree::Node{T}, dataset::Dataset{T,L}, options::Options, regularization::Bool, idx
+)::L where {T<:DATA_TYPE,L<:LOSS_TYPE}
+    (prediction, completion) = eval_tree_array(
+        tree, maybe_getindex(dataset.X, :, idx), options
+    )
     if !completion
         return L(Inf)
     end
@@ -44,12 +50,12 @@ function _eval_loss(
     loss_val = if dataset.weighted
         _weighted_loss(
             prediction,
-            dataset.y::AY,
-            dataset.weights::AbstractVector{T},
+            maybe_getindex(dataset.y, idx),
+            maybe_getindex(dataset.weights, idx),
             options.elementwise_loss,
         )
     else
-        _loss(prediction, dataset.y::AY, options.elementwise_loss)
+        _loss(prediction, maybe_getindex(dataset.y, idx), options.elementwise_loss)
     end
 
     if regularization
@@ -61,52 +67,43 @@ end
 
 # This evaluates function F:
 function evaluator(
-    f::F, tree::Node{T}, dataset::Dataset{T,L}, options::Options
+    f::F, tree::Node{T}, dataset::Dataset{T,L}, options::Options, idx
 )::L where {T<:DATA_TYPE,L<:LOSS_TYPE,F}
-    return f(tree, dataset, options)
+    if static_hasmethod(f, typeof((tree, dataset, options, idx)))
+        # If user defines method that accepts batching indices:
+        return f(tree, dataset, options, idx)
+    else
+        return f(tree, dataset, options)
+    end
 end
 
 # Evaluate the loss of a particular expression on the input dataset.
 function eval_loss(
-    tree::Node{T}, dataset::Dataset{T,L}, options::Options, regularization::Bool=true
+    tree::Node{T},
+    dataset::Dataset{T,L},
+    options::Options;
+    regularization::Bool=true,
+    idx=nothing,
 )::L where {T<:DATA_TYPE,L<:LOSS_TYPE}
     loss_val = if options.loss_function === nothing
-        _eval_loss(tree, dataset, options, regularization)
+        _eval_loss(tree, dataset, options, regularization, idx)
     else
         f = options.loss_function::Function
-        evaluator(f, tree, dataset, options)
+        evaluator(f, tree, dataset, options, idx)
     end
 
     return loss_val
 end
 
 function eval_loss_batched(
-    tree::Node{T}, dataset::Dataset{T,L}, options::Options, regularization::Bool=true
+    tree::Node{T}, dataset::Dataset{T,L}, options::Options; regularization::Bool=true
 )::L where {T<:DATA_TYPE,L<:LOSS_TYPE}
-    if options.loss_function !== nothing
-        error("Batched losses for custom objectives are not yet implemented.")
-    end
-    batch_idx = StatsBase.sample(1:(dataset.n), options.batch_size; replace=true)
-    batch_X = view(dataset.X, :, batch_idx)
-    (prediction, completion) = eval_tree_array(tree, batch_X, options)
-    if !completion
-        return L(Inf)
-    end
+    idx = batch_sample(dataset, options)
+    return eval_loss(tree, dataset, options; regularization=regularization, idx=idx)
+end
 
-    batch_y = view(dataset.y::AbstractVector{T}, batch_idx)
-    loss_val = if !dataset.weighted
-        L(_loss(prediction, batch_y, options.elementwise_loss))
-    else
-        w = dataset.weights::AbstractVector{T}
-        batch_w = view(w, batch_idx)
-        L(_weighted_loss(prediction, batch_y, batch_w, options.elementwise_loss))
-    end
-
-    if regularization
-        loss_val += dimensional_regularization(tree, dataset, options)
-    end
-
-    return loss_val
+function batch_sample(dataset, options)
+    return StatsBase.sample(1:(dataset.n), options.batch_size; replace=true)
 end
 
 # Just so we can pass either PopMember or Node here:
@@ -157,7 +154,7 @@ function score_func(
 end
 
 # Score an equation with a small batch
-function score_func_batch(
+function score_func_batched(
     dataset::Dataset{T,L}, member, options::Options, complexity::Union{Int,Nothing}=nothing
 )::Tuple{L,L} where {T<:DATA_TYPE,L<:LOSS_TYPE}
     result_loss = eval_loss_batched(get_tree(member), dataset, options)

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -116,7 +116,7 @@ function eval_loss_batched(
 end
 
 function batch_sample(dataset, options)
-    return StatsBase.sample(1:(dataset.n), options.batch_size; replace=false)
+    return StatsBase.sample(1:(dataset.n), options.batch_size; replace=true)
 end
 
 # Just so we can pass either PopMember or Node here:

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -5,7 +5,7 @@ import DynamicExpressions:
 import ..CoreModule:
     Options, MutationWeights, Dataset, RecordType, sample_mutation, DATA_TYPE, LOSS_TYPE
 import ..ComplexityModule: compute_complexity
-import ..LossFunctionsModule: score_func, score_func_batch
+import ..LossFunctionsModule: score_func, score_func_batched
 import ..CheckConstraintsModule: check_constraints
 import ..AdaptiveParsimonyModule: RunningSearchStatistics
 import ..PopMemberModule: PopMember
@@ -73,7 +73,7 @@ function next_generation(
     #TODO - reconsider this
     beforeScore, beforeLoss = if options.batching
         num_evals += (options.batch_size / dataset.n)
-        score_func_batch(dataset, member, options)
+        score_func_batched(dataset, member, options)
     else
         member.score, member.loss
     end
@@ -229,7 +229,7 @@ function next_generation(
     end
 
     if options.batching
-        afterScore, afterLoss = score_func_batch(dataset, tree, options)
+        afterScore, afterLoss = score_func_batched(dataset, tree, options)
         num_evals += (options.batch_size / dataset.n)
     else
         afterScore, afterLoss = score_func(dataset, tree, options)
@@ -355,10 +355,10 @@ function crossover_generation(
         num_tries += 1
     end
     if options.batching
-        afterScore1, afterLoss1 = score_func_batch(
+        afterScore1, afterLoss1 = score_func_batched(
             dataset, child_tree1, options, afterSize1
         )
-        afterScore2, afterLoss2 = score_func_batch(
+        afterScore2, afterLoss2 = score_func_batched(
             dataset, child_tree2, options, afterSize2
         )
         num_evals += 2 * (options.batch_size / dataset.n)

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -201,8 +201,21 @@ const OPTION_DESCRIPTIONS = """- `binary_operators`: Vector of binary operators 
     scalar of type `T`. This is useful if you want to use a loss
     that takes into account derivatives, or correlations across
     the dataset. This also means you could use a custom evaluation
-    for a particular expression. Take a look at `_eval_loss` in
-    the file `src/LossFunctions.jl` for an example.
+    for a particular expression. If you are using
+    `batching=true`, then your function should
+    accept a fourth argument `idx`, which is either `nothing`
+    (indicating that the full dataset should be used), or a vector
+    of indices to use for the batch.
+    For example,
+
+        function my_loss(tree, dataset::Dataset{T,L}, options)::L where {T,L}
+            prediction, flag = eval_tree_array(tree, dataset.X, options)
+            if !flag
+                return L(Inf)
+            end
+            return sum((prediction .- dataset.y) .^ 2) / dataset.n
+        end
+
 - `npopulations`: How many populations of equations to use. By default
     this is set equal to the number of cores
 - `npop`: How many equations in each population.

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -47,6 +47,13 @@ function s_r_cycle(
         for member in pop.members
             size = compute_complexity(member, options)
             score = member.score
+            # TODO: Note that this per-population hall of fame only uses the batched
+            #       loss, and is therefore innaccurate. Therefore, some expressions
+            #       may be loss if a very small batch size is used.
+            # - Could have different batch size for different things (smaller for constant opt)
+            # - Could just recompute losses here (expensive)
+            # - Average over a few batches
+            # - Store multiple expressions in hall of fame
             if 0 < size <= options.maxsize && (
                 !best_examples_seen.exists[size] ||
                 score < best_examples_seen.members[size].score
@@ -77,6 +84,7 @@ function optimize_and_simplify_population(
             pop.members[j].tree = tree
         end
         if options.should_optimize_constants && do_optimization[j]
+            # TODO: Might want to do full batch optimization here?
             pop.members[j], array_num_evals[j] = optimize_constants(
                 dataset, pop.members[j], options
             )

--- a/test/test_losses.jl
+++ b/test/test_losses.jl
@@ -47,3 +47,13 @@ let options = Options(; binary_operators=[+, *], loss_function=custom_objective_
     @test eval_loss(Node(; val=1.0), d, options) === 1.0
     @test eval_loss(Node(; val=1.0), d, options; idx=[1, 2]) == sum(d.X[:, [1, 2]])
 end
+
+custom_objective_bad_batched(tree, dataset, options) = sum(dataset.X)
+
+let options = Options(;
+        binary_operators=[+, *], loss_function=custom_objective_bad_batched, batching=true
+    ),
+    d = Dataset(randn(3, 10), randn(10))
+
+    @test_throws ErrorException eval_loss(Node(; val=1.0), d, options; idx=[1, 2])
+end


### PR DESCRIPTION
This fixes the batching implementation so that batches are also used in the constant optimizer. In a single optimization loop, a single set of batch indices is used. 

This also allows the user to specify a custom objective and also use batching. basically the user will need to have a fourth argument in their custom objective – that argument will either be `nothing` (full batch), or an array of indices, in which case the user should compute the sliced array in their objectives.

TODO:

- [x] Implement specific tests on batched loss
- [x] Implement test with custom objective
- [x] Verify `finalize_scores` is ran on intermediate hall of fames.
- [x] Add example to docs, and update docstring description.