### PR TITLE
Enable compatibility with MLJTuning.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -62,10 +62,11 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJTestInterface = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "SafeTestsets", "ForwardDiff", "LinearAlgebra", "JSON3", "MLJBase", "MLJTestInterface", "SymbolicUtils", "Zygote"]
+test = ["Test", "SafeTestsets", "ForwardDiff", "LinearAlgebra", "JSON3", "MLJBase", "MLJTestInterface", "Suppressor", "SymbolicUtils", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -65,7 +65,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -51,7 +51,7 @@ end
 
 # Check for errors before they happen
 function test_dataset_configuration(
-    dataset::Dataset{T}, options::Options
+    dataset::Dataset{T}, options::Options, verbosity
 ) where {T<:DATA_TYPE}
     n = dataset.n
     if n != size(dataset.X, 2) ||
@@ -66,7 +66,7 @@ function test_dataset_configuration(
     if size(dataset.X, 2) > 10000
         if !options.batching
             debug(
-                (options.verbosity > 0 || options.progress),
+                verbosity > 0,
                 "Note: you are running with more than 10,000 datapoints. You should consider turning on batching (`options.batching`), and also if you need that many datapoints. Unless you have a large amount of noise (in which case you should smooth your dataset first), generally < 10,000 datapoints is enough to find a functional form.",
             )
         end
@@ -86,7 +86,9 @@ function test_dataset_configuration(
 end
 
 """ Move custom operators and loss functions to workers, if undefined """
-function move_functions_to_workers(procs, options::Options, dataset::Dataset{T}) where {T}
+function move_functions_to_workers(
+    procs, options::Options, dataset::Dataset{T}, verbosity
+) where {T}
     enable_autodiff =
         :diff_binops in fieldnames(typeof(options.operators)) &&
         :diff_unaops in fieldnames(typeof(options.operators)) &&
@@ -156,7 +158,7 @@ function move_functions_to_workers(procs, options::Options, dataset::Dataset{T})
             catch e
                 undefined_on_workers = isa(e.captured.ex, UndefVarError)
                 if undefined_on_workers
-                    copy_definition_to_workers(op, procs, options)
+                    copy_definition_to_workers(op, procs, options, verbosity)
                 else
                     throw(e)
                 end
@@ -166,19 +168,16 @@ function move_functions_to_workers(procs, options::Options, dataset::Dataset{T})
     end
 end
 
-function copy_definition_to_workers(op, procs, options::Options)
+function copy_definition_to_workers(op, procs, options::Options, verbosity)
     name = nameof(op)
-    debug_inline(
-        (options.verbosity > 0 || options.progress),
-        "Copying definition of $op to workers...",
-    )
+    debug_inline(verbosity > 0, "Copying definition of $op to workers...")
     src_ms = methods(op).ms
     # Thanks https://discourse.julialang.org/t/easy-way-to-send-custom-function-to-distributed-workers/22118/2
     @everywhere procs @eval function $name end
     for m in src_ms
         @everywhere procs @eval $m
     end
-    return debug((options.verbosity > 0 || options.progress), "Finished!")
+    return debug(verbosity > 0, "Finished!")
 end
 
 function test_function_on_workers(example_inputs, op, procs)
@@ -191,8 +190,8 @@ function test_function_on_workers(example_inputs, op, procs)
     end
 end
 
-function activate_env_on_workers(procs, project_path::String, options::Options)
-    debug((options.verbosity > 0 || options.progress), "Activating environment on workers.")
+function activate_env_on_workers(procs, project_path::String, options::Options, verbosity)
+    debug(verbosity > 0, "Activating environment on workers.")
     @everywhere procs begin
         Base.MainInclude.eval(
             quote
@@ -203,13 +202,10 @@ function activate_env_on_workers(procs, project_path::String, options::Options)
     end
 end
 
-function import_module_on_workers(procs, filename::String, options::Options)
+function import_module_on_workers(procs, filename::String, options::Options, verbosity)
     included_local = !("SymbolicRegression" in [k.name for (k, v) in Base.loaded_modules])
     if included_local
-        debug_inline(
-            (options.verbosity > 0 || options.progress),
-            "Importing local module ($filename) on workers...",
-        )
+        debug_inline(verbosity > 0, "Importing local module ($filename) on workers...")
         @everywhere procs begin
             # Parse functions on every worker node
             Base.MainInclude.eval(
@@ -219,23 +215,18 @@ function import_module_on_workers(procs, filename::String, options::Options)
                 end,
             )
         end
-        debug((options.verbosity > 0 || options.progress), "Finished!")
+        debug(verbosity > 0, "Finished!")
     else
-        debug_inline(
-            (options.verbosity > 0 || options.progress),
-            "Importing installed module on workers...",
-        )
+        debug_inline(verbosity > 0, "Importing installed module on workers...")
         @everywhere procs begin
             Base.MainInclude.eval(using SymbolicRegression)
         end
-        debug((options.verbosity > 0 || options.progress), "Finished!")
+        debug(verbosity > 0, "Finished!")
     end
 end
 
-function test_module_on_workers(procs, options::Options)
-    debug_inline(
-        (options.verbosity > 0 || options.progress), "Testing module on workers..."
-    )
+function test_module_on_workers(procs, options::Options, verbosity)
+    debug_inline(verbosity > 0, "Testing module on workers...")
     futures = []
     for proc in procs
         push!(
@@ -246,16 +237,14 @@ function test_module_on_workers(procs, options::Options)
     for future in futures
         fetch(future)
     end
-    return debug((options.verbosity > 0 || options.progress), "Finished!")
+    return debug(verbosity > 0, "Finished!")
 end
 
 function test_entire_pipeline(
-    procs, dataset::Dataset{T}, options::Options
+    procs, dataset::Dataset{T}, options::Options, verbosity
 ) where {T<:DATA_TYPE}
     futures = []
-    debug_inline(
-        (options.verbosity > 0 || options.progress), "Testing entire pipeline on workers..."
-    )
+    debug_inline(verbosity > 0, "Testing entire pipeline on workers...")
     for proc in procs
         push!(
             futures,
@@ -273,7 +262,7 @@ function test_entire_pipeline(
                     5,
                     5,
                     RunningSearchStatistics(; options=options);
-                    verbosity=options.verbosity,
+                    verbosity=verbosity,
                     options=options,
                     record=RecordType(),
                 )[1]
@@ -286,5 +275,5 @@ function test_entire_pipeline(
     for future in futures
         fetch(future)
     end
-    return debug((options.verbosity > 0 || options.progress), "Finished!")
+    return debug(verbosity > 0, "Finished!")
 end

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -177,6 +177,7 @@ function _update(m, verbosity, old_fitresult, old_cache, X, y, w, options)
         loss_type=m.loss_type,
         X_units=X_units_clean,
         y_units=y_units_clean,
+        verbosity=verbosity,
         # Help out with inference:
         v_dim_out=isa(m, SRRegressor) ? Val(1) : Val(2),
     )

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -404,6 +404,7 @@ MMI.metadata_pkg(
     is_wrapper=false,
 )
 
+# TODO: Allow for Count data, and coerce it into Continuous as needed.
 MMI.metadata_model(
     SRRegressor;
     input_scitype=Union{MMI.Table(MMI.Continuous),AbstractMatrix{<:MMI.Continuous}},

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -251,6 +251,9 @@ end
 dimension_fallback(q::Union{<:Quantity{T,D}}, ::Type{D}) where {T,D} = dimension(q)::D
 dimension_fallback(_, ::Type{D}) where {D} = D()
 
+function unwrap_units_single(A::AbstractMatrix{T}, ::Type{D}) where {D,T<:Number}
+    return A, [D() for _ in eachrow(A)]
+end
 function unwrap_units_single(A::AbstractMatrix, ::Type{D}) where {D}
     for (i, row) in enumerate(eachrow(A))
         allequal(Base.Fix2(dimension_fallback, D).(row)) ||
@@ -258,6 +261,9 @@ function unwrap_units_single(A::AbstractMatrix, ::Type{D}) where {D}
     end
     dims = map(Base.Fix2(dimension_fallback, D) ∘ first, eachrow(A))
     return stack([ustrip.(row) for row in eachrow(A)]; dims=1), dims
+end
+function unwrap_units_single(v::AbstractVector{T}, ::Type{D}) where {D,T<:Number}
+    return v, D()
 end
 function unwrap_units_single(v::AbstractVector, ::Type{D}) where {D}
     allequal(Base.Fix2(dimension_fallback, D).(v)) || error("Inconsistent units in vector.")

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -377,14 +377,14 @@ function Options end
     ncycles_per_iteration::Integer=550,
     fraction_replaced::Real=0.00036,
     fraction_replaced_hof::Real=0.035,
-    verbosity::Real=convert(Int, 1e9),
+    verbosity::Union{Integer,Nothing}=nothing,
     print_precision::Integer=5,
     save_to_file::Bool=true,
     probability_negate_constant::Real=0.01,
     seed=nothing,
     bin_constraints=nothing,
     una_constraints=nothing,
-    progress::Bool=true,
+    progress::Union{Bool,Nothing}=nothing,
     terminal_width::Union{Nothing,Integer}=nothing,
     optimizer_algorithm::AbstractString="BFGS",
     optimizer_nrestarts::Integer=2,
@@ -656,10 +656,6 @@ function Options end
         enable_autodiff=enable_autodiff,
         define_helper_functions=define_helper_functions,
     )
-
-    if progress
-        verbosity = 0
-    end
 
     early_stop_condition = if typeof(early_stop_condition) <: Real
         # Need to make explicit copy here for this to work:

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -155,7 +155,7 @@ struct Options{CT,OP<:AbstractOperatorEnum,use_recorder,OPT<:Optim.Options,W}
     fraction_replaced::Float32
     fraction_replaced_hof::Float32
     topn::Int
-    verbosity::Int
+    verbosity::Union{Int,Nothing}
     print_precision::Int
     save_to_file::Bool
     probability_negate_constant::Float32
@@ -164,7 +164,7 @@ struct Options{CT,OP<:AbstractOperatorEnum,use_recorder,OPT<:Optim.Options,W}
     seed::Union{Int,Nothing}
     elementwise_loss::Union{SupervisedLoss,Function}
     loss_function::Union{Nothing,Function}
-    progress::Bool
+    progress::Union{Bool,Nothing}
     terminal_width::Union{Int,Nothing}
     optimizer_algorithm::String
     optimizer_probability::Float32

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -301,6 +301,9 @@ which is useful for debugging and profiling.
     for the loss than for the data you passed, specify the type here.
     Note that if you pass complex data `::Complex{L}`, then the loss
     type will automatically be set to `L`.
+- `verbosity`: Whether to print debugging statements or not.
+- `progress`: Whether to use a progress bar output. Only available for
+    single target output.
 - `X_units::Union{AbstractVector,Nothing}=nothing`: The units of the dataset,
     to be used for dimensional constraints. For example, if `X_units=["kg", "m"]`,
     then the first feature will have units of kilograms, and the second will
@@ -334,7 +337,6 @@ function equation_search(
     loss_type::Type{Linit}=Nothing,
     verbosity::Union{Integer,Nothing}=nothing,
     progress::Union{Bool,Nothing}=nothing,
-    # TODO: ^ These are undocumented
     X_units::Union{AbstractVector,Nothing}=nothing,
     y_units=nothing,
     v_dim_out::Val{dim_out}=Val(nothing),

--- a/test/test_mlj.jl
+++ b/test/test_mlj.jl
@@ -4,6 +4,7 @@ import MLJTestInterface as MTI
 import MLJBase: machine, fit!, report, predict
 using Test
 using SymbolicUtils: SymbolicUtils
+import Suppressor: @capture_err
 
 macro quiet(ex)
     return quote
@@ -99,4 +100,26 @@ end
     @test_throws AssertionError @quiet(fit!(mach))
     VERSION >= v"1.8" &&
         @test_throws "For multi-output regression, please" @quiet(fit!(mach))
+end
+
+@testset "Unfinished search" begin
+    model = SRRegressor(; timeout_in_seconds=1e-10)
+    mach = machine(model, randn(32, 3), randn(32))
+    fit!(mach)
+    @test report(mach).best_idx == 0
+    @test predict(mach, randn(32, 3)) == zeros(32)
+    msg = @capture_err begin
+        predict(mach, randn(32, 3))
+    end
+    @test occursin("Evaluation failed either due to", msg)
+
+    model = MultitargetSRRegressor(; timeout_in_seconds=1e-10)
+    mach = machine(model, randn(32, 3), randn(32, 3))
+    fit!(mach)
+    @test report(mach).best_idx == [0, 0, 0]
+    @test predict(mach, randn(32, 3)) == zeros(32, 3)
+    msg = @capture_err begin
+        predict(mach, randn(32, 3))
+    end
+    @test occursin("Evaluation failed either due to", msg)
 end

--- a/test/test_mlj.jl
+++ b/test/test_mlj.jl
@@ -110,6 +110,9 @@ end
     model = SRRegressor(; timeout_in_seconds=1e-10)
     mach = machine(model, randn(32, 3), randn(32))
     fit!(mach)
+    # Ensure that the hall of fame is empty:
+    _, hof = mach.fitresult.state
+    hof.exists .= false
     @test report(mach).best_idx == 0
     @test predict(mach, randn(32, 3)) == zeros(32)
     msg = @capture_err begin
@@ -120,6 +123,11 @@ end
     model = MultitargetSRRegressor(; timeout_in_seconds=1e-10)
     mach = machine(model, randn(32, 3), randn(32, 3))
     fit!(mach)
+    # Ensure that the hall of fame is empty:
+    _, hofs = mach.fitresult.state
+    foreach(hofs) do hof
+        hof.exists .= false
+    end
     @test report(mach).best_idx == [0, 0, 0]
     @test predict(mach, randn(32, 3)) == zeros(32, 3)
     msg = @capture_err begin

--- a/test/test_mlj.jl
+++ b/test/test_mlj.jl
@@ -100,6 +100,10 @@ end
     @test_throws AssertionError @quiet(fit!(mach))
     VERSION >= v"1.8" &&
         @test_throws "For multi-output regression, please" @quiet(fit!(mach))
+
+    model = SRRegressor(; verbosity=0)
+    mach = machine(model, randn(32, 3), randn(32))
+    @test_throws ErrorException @quiet(fit!(mach; verbosity=0))
 end
 
 @testset "Unfinished search" begin


### PR DESCRIPTION
This enables compatibility with MLJTuning.jl via the following changes:

- Even if a search has not found a valid equation, `MLJ.predict` will still return a correctly-shaped array (by default, just `zero`). The current error will instead be replaced by a warning.
- Refactored `verbosity` and `progress` so that they can be set upon calls to `equation_search`. This correctly propagates `verbosity` from MLJ.

Other:

- Improves type inference in MLJ interface
- Removes unnecessary DynamicQuantities.jl calls in MLJ interface (speeds up `MLJ.predict`)
- Refactors the hall of fame printing to remove duplicated code

TODO:

- [x] Add test that `verbosity=0` works as expected.
- [x] Add MLJTuning unittest?
- [x] Add unittest for new configuration errors.
- [x] Document `verbosity` and `progress` in `equation_search`.