### PR TITLE
Evaluate on fixed batch when building per-pop hall of fame

### DIFF
--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -356,15 +356,19 @@ function crossover_generation(
     end
     if options.batching
         afterScore1, afterLoss1 = score_func_batched(
-            dataset, child_tree1, options, afterSize1
+            dataset, child_tree1, options; complexity=afterSize1
         )
         afterScore2, afterLoss2 = score_func_batched(
-            dataset, child_tree2, options, afterSize2
+            dataset, child_tree2, options; complexity=afterSize2
         )
         num_evals += 2 * (options.batch_size / dataset.n)
     else
-        afterScore1, afterLoss1 = score_func(dataset, child_tree1, options, afterSize1)
-        afterScore2, afterLoss2 = score_func(dataset, child_tree2, options, afterSize2)
+        afterScore1, afterLoss1 = score_func(
+            dataset, child_tree1, options; complexity=afterSize1
+        )
+        afterScore2, afterLoss2 = score_func(
+            dataset, child_tree2, options; complexity=afterSize2
+        )
         num_evals += options.batch_size / dataset.n
     end
 

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -254,9 +254,6 @@ const OPTION_DESCRIPTIONS = """- `binary_operators`: Vector of binary operators 
 - `adaptive_parsimony_scaling`: How much to scale the adaptive parsimony term
     in the loss. Increase this if the search is spending too much time
     optimizing the most complex equations.
-- `fast_cycle`: Whether to thread over subsamples of equations during
-    regularized evolution. Slightly improves performance, but is a different
-    algorithm.
 - `turbo`: Whether to use `LoopVectorization.@turbo` to evaluate expressions.
     This can be significantly faster, but is only compatible with certain
     operators. *Experimental!*
@@ -355,7 +352,6 @@ function Options end
     alpha::Real=0.100000,
     maxsize::Integer=20,
     maxdepth::Union{Nothing,Integer}=nothing,
-    fast_cycle::Bool=false,
     turbo::Bool=false,
     migration::Bool=true,
     hof_migration::Bool=true,
@@ -404,6 +400,7 @@ function Options end
     define_helper_functions::Bool=true,
     deprecated_return_state=nothing,
     # Deprecated args:
+    fast_cycle::Bool=false,
     kws...,
 ) where {use_recorder}
     for k in keys(kws)
@@ -460,6 +457,7 @@ function Options end
             "Unknown deprecated keyword argument: $k. Please update `Options(;)` to transfer this key.",
         )
     end
+    fast_cycle && Base.depwarn("`fast_cycle` is deprecated and has no effect.", :Options)
 
     if elementwise_loss === nothing
         elementwise_loss = L2DistLoss()

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -718,7 +718,6 @@ function Options end
         alpha,
         maxsize,
         maxdepth,
-        fast_cycle,
         turbo,
         migration,
         hof_migration,

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -132,7 +132,6 @@ struct Options{CT,OP<:AbstractOperatorEnum,use_recorder,OPT<:Optim.Options,W}
     alpha::Float32
     maxsize::Int
     maxdepth::Int
-    fast_cycle::Bool
     turbo::Bool
     migration::Bool
     hof_migration::Bool

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -96,7 +96,7 @@ function PopMember(
 ) where {T<:DATA_TYPE,L<:LOSS_TYPE}
     set_complexity = complexity === nothing ? compute_complexity(t, options) : complexity
     @assert set_complexity != -1
-    score, loss = score_func(dataset, t, options, set_complexity)
+    score, loss = score_func(dataset, t, options; complexity=set_complexity)
     return PopMember(
         t,
         score,

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -31,35 +31,11 @@ function reg_evol_cycle(
     num_evals = 0.0
     n_evol_cycles = ceil(Int, pop.n / options.tournament_selection_n)
 
-    if options.fast_cycle
-
-        # These options are not implemented for fast_cycle:
-        @recorder error(
-            "You cannot have the recorder and fast_cycle set to true at the same time!"
-        )
-        @assert options.prob_pick_first == 1.0
-        @assert options.crossover_probability == 0.0
-
-        shuffle!(pop.members)
-        babies = Array{PopMember}(undef, n_evol_cycles)
-        accepted = Array{Bool}(undef, n_evol_cycles)
-        array_num_evals = Array{Float64}(undef, n_evol_cycles)
-
-        # Iterate each tournament_selection_n-member sub-sample
-        Threads.@threads for i in 1:n_evol_cycles
-            best_score = Inf
-            best_idx = 1 + (i - 1) * options.tournament_selection_n
-            # Calculate best member of the subsample:
-            for sub_i in
-                (1 + (i - 1) * options.tournament_selection_n):(i * options.tournament_selection_n)
-                if pop.members[sub_i].score < best_score
-                    best_score = pop.members[sub_i].score
-                    best_idx = sub_i
-                end
-            end
-            allstar = pop.members[best_idx]
+    for i in 1:n_evol_cycles
+        if rand() > options.crossover_probability
+            allstar = best_of_sample(pop, running_search_statistics, options)
             mutation_recorder = RecordType()
-            babies[i], accepted[i], array_num_evals[i] = next_generation(
+            baby, mutation_accepted, tmp_num_evals = next_generation(
                 dataset,
                 allstar,
                 temperature,
@@ -68,91 +44,65 @@ function reg_evol_cycle(
                 options;
                 tmp_recorder=mutation_recorder,
             )
-        end
-        num_evals = sum(array_num_evals)
+            num_evals += tmp_num_evals
 
-        # Replace the n_evol_cycles-oldest members of each population
-        for i in 1:n_evol_cycles
+            if !mutation_accepted && options.skip_mutation_failures
+                # Skip this mutation rather than replacing oldest member with unchanged member
+                continue
+            end
+
             oldest = argmin_fast([pop.members[member].birth for member in 1:(pop.n)])
-            if accepted[i] || !options.skip_mutation_failures
-                pop.members[oldest] = babies[i]
-            end
-        end
-    else
-        for i in 1:n_evol_cycles
-            if rand() > options.crossover_probability
-                allstar = best_of_sample(pop, running_search_statistics, options)
-                mutation_recorder = RecordType()
-                baby, mutation_accepted, tmp_num_evals = next_generation(
-                    dataset,
-                    allstar,
-                    temperature,
-                    curmaxsize,
-                    running_search_statistics,
-                    options;
-                    tmp_recorder=mutation_recorder,
-                )
-                num_evals += tmp_num_evals
 
-                if !mutation_accepted && options.skip_mutation_failures
-                    # Skip this mutation rather than replacing oldest member with unchanged member
-                    continue
+            @recorder begin
+                if !haskey(record, "mutations")
+                    record["mutations"] = RecordType()
                 end
-
-                oldest = argmin_fast([pop.members[member].birth for member in 1:(pop.n)])
-
-                @recorder begin
-                    if !haskey(record, "mutations")
-                        record["mutations"] = RecordType()
+                for member in [allstar, baby, pop.members[oldest]]
+                    if !haskey(record["mutations"], "$(member.ref)")
+                        record["mutations"]["$(member.ref)"] = RecordType(
+                            "events" => Vector{RecordType}(),
+                            "tree" => string_tree(member.tree, options),
+                            "score" => member.score,
+                            "loss" => member.loss,
+                            "parent" => member.parent,
+                        )
                     end
-                    for member in [allstar, baby, pop.members[oldest]]
-                        if !haskey(record["mutations"], "$(member.ref)")
-                            record["mutations"]["$(member.ref)"] = RecordType(
-                                "events" => Vector{RecordType}(),
-                                "tree" => string_tree(member.tree, options),
-                                "score" => member.score,
-                                "loss" => member.loss,
-                                "parent" => member.parent,
-                            )
-                        end
-                    end
-                    mutate_event = RecordType(
-                        "type" => "mutate",
-                        "time" => time(),
-                        "child" => baby.ref,
-                        "mutation" => mutation_recorder,
-                    )
-                    death_event = RecordType("type" => "death", "time" => time())
-
-                    # Put in random key rather than vector; otherwise there are collisions!
-                    push!(record["mutations"]["$(allstar.ref)"]["events"], mutate_event)
-                    push!(
-                        record["mutations"]["$(pop.members[oldest].ref)"]["events"],
-                        death_event,
-                    )
                 end
-
-                pop.members[oldest] = baby
-
-            else # Crossover
-                allstar1 = best_of_sample(pop, running_search_statistics, options)
-                allstar2 = best_of_sample(pop, running_search_statistics, options)
-
-                baby1, baby2, crossover_accepted, tmp_num_evals = crossover_generation(
-                    allstar1, allstar2, dataset, curmaxsize, options
+                mutate_event = RecordType(
+                    "type" => "mutate",
+                    "time" => time(),
+                    "child" => baby.ref,
+                    "mutation" => mutation_recorder,
                 )
-                num_evals += tmp_num_evals
+                death_event = RecordType("type" => "death", "time" => time())
 
-                if !crossover_accepted && options.skip_mutation_failures
-                    continue
-                end
-
-                # Replace old members with new ones:
-                oldest = argmin_fast([pop.members[member].birth for member in 1:(pop.n)])
-                pop.members[oldest] = baby1
-                oldest = argmin_fast([pop.members[member].birth for member in 1:(pop.n)])
-                pop.members[oldest] = baby2
+                # Put in random key rather than vector; otherwise there are collisions!
+                push!(record["mutations"]["$(allstar.ref)"]["events"], mutate_event)
+                push!(
+                    record["mutations"]["$(pop.members[oldest].ref)"]["events"], death_event
+                )
             end
+
+            pop.members[oldest] = baby
+
+        else # Crossover
+            allstar1 = best_of_sample(pop, running_search_statistics, options)
+            allstar2 = best_of_sample(pop, running_search_statistics, options)
+
+            baby1, baby2, crossover_accepted, tmp_num_evals = crossover_generation(
+                allstar1, allstar2, dataset, curmaxsize, options
+            )
+            num_evals += tmp_num_evals
+
+            if !crossover_accepted && options.skip_mutation_failures
+                continue
+            end
+
+            # Replace old members with new ones:
+            oldest = argmin_fast([pop.members[member].birth for member in 1:(pop.n)])
+            pop.members[oldest] = baby1
+            oldest = argmin_fast([pop.members[member].birth for member in 1:(pop.n)])
+            pop.members[oldest] = baby2
         end
     end
 

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -9,7 +9,7 @@ import ..PopulationModule: Population, finalize_scores, best_sub_pop
 import ..HallOfFameModule: HallOfFame
 import ..AdaptiveParsimonyModule: RunningSearchStatistics
 import ..RegularizedEvolutionModule: reg_evol_cycle
-import ..LossFunctionsModule: score_func_batched
+import ..LossFunctionsModule: score_func_batched, batch_sample
 import ..ConstantOptimizationModule: optimize_constants
 import ..RecorderModule: @recorder
 
@@ -35,7 +35,7 @@ function s_r_cycle(
     num_evals = 0.0
 
     # For evaluating on a fixed batch (for batching)
-    fixed_batch_seed = rand(UInt64)
+    idx = options.batching ? batch_sample(dataset, options) : Int[]
     loss_cache = [(oid=zero(UInt64), score=zero(L)) for _ in pop.members]
     first_loop = true
 
@@ -60,7 +60,7 @@ function s_r_cycle(
                     # changes each iteration, and we evaluate on full-batch outside,
                     # so this is not biased).
                     _score, _ = score_func_batched(
-                        dataset, member, options; complexity=size, seed=fixed_batch_seed
+                        dataset, member, options; complexity=size, idx=idx
                     )
                     loss_cache[i] = (oid=oid, score=_score)
                     _score

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -53,7 +53,7 @@ function s_r_cycle(
         for (i, member) in enumerate(pop.members)
             size = compute_complexity(member, options)
             score = if options.batching
-                oid = objectid(member)
+                oid = hash(member)
                 if loss_cache[i].oid != oid || first_loop
                     # Evaluate on fixed batch so that we can more accurately
                     # compare expressions with a batched loss (though the batch

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -9,6 +9,7 @@ import ..PopulationModule: Population, finalize_scores, best_sub_pop
 import ..HallOfFameModule: HallOfFame
 import ..AdaptiveParsimonyModule: RunningSearchStatistics
 import ..RegularizedEvolutionModule: reg_evol_cycle
+import ..LossFunctionsModule: score_func_batched
 import ..ConstantOptimizationModule: optimize_constants
 import ..RecorderModule: @recorder
 
@@ -33,6 +34,11 @@ function s_r_cycle(
     best_examples_seen = HallOfFame(options, T, L)
     num_evals = 0.0
 
+    # For evaluating on a fixed batch (for batching)
+    fixed_batch_seed = rand(UInt64)
+    loss_cache = [(oid=zero(UInt64), score=zero(L)) for _ in pop.members]
+    first_loop = true
+
     for temperature in all_temperatures
         pop, tmp_num_evals = reg_evol_cycle(
             dataset,
@@ -44,9 +50,28 @@ function s_r_cycle(
             record,
         )
         num_evals += tmp_num_evals
-        for member in pop.members
+        for (i, member) in enumerate(pop.members)
             size = compute_complexity(member, options)
-            score = member.score
+            score = if options.batching
+                oid = objectid(member)
+                if loss_cache[i].oid != oid || first_loop
+                    # Evaluate on fixed batch so that we can more accurately
+                    # compare expressions with a batched loss (though the batch
+                    # changes each iteration, and we evaluate on full-batch outside,
+                    # so this is not biased).
+                    _score, _ = score_func_batched(
+                        dataset, member, options; complexity=size, seed=fixed_batch_seed
+                    )
+                    loss_cache[i] = (oid=oid, score=_score)
+                    _score
+                else
+                    # Already evaluated this particular expression, so just use
+                    # the cached score
+                    loss_cache[i].score
+                end
+            else
+                member.score
+            end
             # TODO: Note that this per-population hall of fame only uses the batched
             #       loss, and is therefore innaccurate. Therefore, some expressions
             #       may be loss if a very small batch size is used.
@@ -62,6 +87,7 @@ function s_r_cycle(
                 best_examples_seen.members[size] = copy_pop_member(member)
             end
         end
+        first_loop = false
     end
 
     return (pop, best_examples_seen, num_evals)


### PR DESCRIPTION
1. This change should greatly improve the effectiveness of batched losses, as the per-population hall of fame will not simply end up being the expression which got evaluated on the nicest batch.
2. This also removes the `fast_cycle` functionality to ease maintenance burden, as I don't think anybody was using it.