### PR TITLE
Fix worldage issues by avoiding `static_hasmethod` when not needed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.22.3"
+version = "0.22.4"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -2,7 +2,6 @@ module LossFunctionsModule
 
 import Random: MersenneTwister
 using StatsBase: StatsBase
-import Tricks: static_hasmethod
 import DynamicExpressions: Node
 using LossFunctions: LossFunctions
 import LossFunctions: SupervisedLoss
@@ -75,7 +74,7 @@ end
 function evaluator(
     f::F, tree::Node{T}, dataset::Dataset{T,L}, options::Options, idx
 )::L where {T<:DATA_TYPE,L<:LOSS_TYPE,F}
-    if static_hasmethod(f, typeof((tree, dataset, options, idx)))
+    if hasmethod(f, typeof((tree, dataset, options, idx)))
         # If user defines method that accepts batching indices:
         return f(tree, dataset, options, idx)
     elseif options.batching


### PR DESCRIPTION
Should fix this issue: https://github.com/MilesCranmer/PySR/issues/411

Also seen in some unittests.

Normal `hasmethod` is 100 ns, which should not be an issue because:

1. It's only called once per expression evaluation, so does not bottleneck anything.
2. Is automatically static on Julia 1.10, so this only slows down earlier Julia versions slightly.
3. Only affects custom objective functions.