### PR TITLE
Add `[compat]` entry for Documenter

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,6 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Gumbo = "708ec375-b3d6-5a57-a7ce-8257bf98657a"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
+
+[compat]
+Documenter = "0.27"


### PR DESCRIPTION
Documenter.jl introduces a number of breaking changes which seems like they weren't accounted for yet. This fixes the `[compat]` settings; we can upgrade later.