### PR TITLE
Make it easier to select expression from Pareto front for evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,16 +153,20 @@ predict(mach, X)
 ```
 
 This will make predictions using the expression
-selected using the function passed to `selection_method`.
-By default this selection is made a mix of accuracy and complexity.
-For example, we can make predictions using expression 2 with:
+selected by `model.selection_method`,
+which by default is a mix of accuracy and complexity.
+
+You can override this selection and select an equation from
+the Pareto front manually with:
 
 ```julia
-mach.model.selection_method = Returns(2)
-predict(mach, X)
+predict(mach, (data=X, idx=2))
 ```
 
-For fitting multiple outputs, one can use `MultitargetSRRegressor`.
+where here we choose to evaluate the second equation.
+
+For fitting multiple outputs, one can use `MultitargetSRRegressor`
+(and pass an array of indices to `idx` in `predict` for selecting specific equations).
 For a full list of options available to each regressor, see the [API page](https://astroautomata.com/SymbolicRegression.jl/dev/api/).
 
 ### Low-Level Interface

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -291,7 +291,7 @@ function prediction_fallback(
             fill!(similar(Xnew_t, T, axes(Xnew_t, 2)), zero(T)), fitresult.y_units, i
         ) for i in 1:(fitresult.num_targets)
     ]
-    out_matrix = reduce(hcat, out_cols)
+    out_matrix = hcat(out_cols...)
     if !fitresult.y_is_table
         return out_matrix
     else
@@ -369,7 +369,9 @@ function MMI.predict(m::M, fitresult, Xnew; idx=nothing) where {M<:AbstractSRReg
     idx = idx === nothing ? params.best_idx : idx
 
     if M <: SRRegressor
-        eval_tree_mlj(params.equations[idx], Xnew_t, m, T, fitresult, nothing, prototype)
+        return eval_tree_mlj(
+            params.equations[idx], Xnew_t, m, T, fitresult, nothing, prototype
+        )
     elseif M <: MultitargetSRRegressor
         outs = [
             eval_tree_mlj(

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -353,9 +353,9 @@ function MMI.predict(m::M, fitresult, Xnew; idx=nothing) where {M<:AbstractSRReg
     end
 
     params = full_report(m, fitresult; v_with_strings=Val(false))
+    prototype = MMI.istable(Xnew) ? Xnew : nothing
     Xnew_t, variable_names, X_units = get_matrix_and_info(Xnew, m.dimensions_type)
     T = promote_type(eltype(Xnew_t), fitresult.types.T)
-    prototype = MMI.istable(Xnew) ? Xnew : nothing
 
     if isempty(params.equations) || any(isempty, params.equations)
         @warn "Equations not found. Returning 0s for prediction."

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -112,10 +112,12 @@ function full_report(
     )
 end
 
-#! format: off
-empty_equations(::SRRegressor, params) = length(params.equations) == 0
-empty_equations(::MultitargetSRRegressor, params) = any(t -> length(t) == 0, params.equations)
-#! format: on
+function incomplete_equations(::SRRegressor, params)
+    return length(params.equations) == 0
+end
+function incomplete_equations(::MultitargetSRRegressor, params)
+    return any(t -> length(t) == 0, params.equations)
+end
 
 MMI.clean!(::AbstractSRRegressor) = ""
 
@@ -363,7 +365,7 @@ function MMI.predict(m::M, fitresult, Xnew; idx=nothing) where {M<:AbstractSRReg
     prototype = MMI.istable(Xnew) ? Xnew : nothing
 
     # Return if have empty search state:
-    if empty_equations(m, params)
+    if incomplete_equations(m, params)
         @warn "No equations found. Returning 0s for prediction."
         return prediction_fallback(T, m, Xnew_t, fitresult, prototype)
     end

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -112,13 +112,6 @@ function full_report(
     )
 end
 
-function incomplete_equations(::SRRegressor, params)
-    return length(params.equations) == 0
-end
-function incomplete_equations(::MultitargetSRRegressor, params)
-    return any(t -> length(t) == 0, params.equations)
-end
-
 MMI.clean!(::AbstractSRRegressor) = ""
 
 # TODO: Enable `verbosity` being passed to `equation_search`
@@ -364,9 +357,8 @@ function MMI.predict(m::M, fitresult, Xnew; idx=nothing) where {M<:AbstractSRReg
     T = promote_type(eltype(Xnew_t), fitresult.types.T)
     prototype = MMI.istable(Xnew) ? Xnew : nothing
 
-    # Return if have empty search state:
-    if incomplete_equations(m, params)
-        @warn "No equations found. Returning 0s for prediction."
+    if isempty(params.equations) || any(isempty, params.equations)
+        @warn "Equations not found. Returning 0s for prediction."
         return prediction_fallback(T, m, Xnew_t, fitresult, prototype)
     end
 

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -500,11 +500,14 @@ function tag_with_docstring(model_name::Symbol, description::String, bottom_matt
         Note that if you pass complex data `::Complex{L}`, then the loss
         type will automatically be set to `L`.
     - `selection_method::Function`: Function to selection expression from
-        the Pareto frontier for use in `predict`. See `SymbolicRegression.MLJInterfaceModule.choose_best`
-        for an example. This function should return a single integer specifying
-        the index of the expression to use. By default, `choose_best` maximizes
+        the Pareto frontier for use in `predict`.
+        See `SymbolicRegression.MLJInterfaceModule.choose_best` for an example.
+        This function should return a single integer specifying
+        the index of the expression to use. By default, this maximizes
         the score (a pound-for-pound rating) of expressions reaching the threshold
-        of 1.5x the minimum loss. To fix the index at `5`, you could just write `Returns(5)`.
+        of 1.5x the minimum loss. To override this at prediction time, you can pass
+        a named tuple with keys `data` and `idx` to `predict`. See the Operations
+        section for details.
     - `dimensions_type::AbstractDimensions`: The type of dimensions to use when storing
         the units of the data. By default this is `DynamicQuantities.SymbolicDimensions`.
     """
@@ -515,7 +518,7 @@ function tag_with_docstring(model_name::Symbol, description::String, bottom_matt
     - `predict(mach, Xnew)`: Return predictions of the target given features `Xnew`, which
       should have same scitype as `X` above. The expression used for prediction is defined
       by the `selection_method` function, which can be seen by viewing `report(mach).best_idx`.
-    - `predict(mach, (; data=Xnew, idx=i))`: Return predictions of the target given features
+    - `predict(mach, (data=Xnew, idx=i))`: Return predictions of the target given features
       `Xnew`, which should have same scitype as `X` above. By passing a named tuple with keys
       `data` and `idx`, you are able to specify the equation you wish to evaluate in `idx`.
 
@@ -578,7 +581,8 @@ eval(
     Note that unlike other regressors, symbolic regression stores a list of
     trained models. The model chosen from this list is defined by the function
     `selection_method` keyword argument, which by default balances accuracy
-    and complexity.
+    and complexity. You can override this at prediction time by passing a named
+    tuple with keys `data` and `idx`.
 
     """,
             r"^    " => "",
@@ -590,7 +594,8 @@ eval(
     The fields of `fitted_params(mach)` are:
 
     - `best_idx::Int`: The index of the best expression in the Pareto frontier,
-       as determined by the `selection_method` function.
+       as determined by the `selection_method` function. Override in `predict` by passing
+        a named tuple with keys `data` and `idx`.
     - `equations::Vector{Node{T}}`: The expressions discovered by the search, represented
       in a dominating Pareto frontier (i.e., the best expressions found for
       each complexity). `T` is equal to the element type
@@ -701,7 +706,8 @@ eval(
     Note that unlike other regressors, symbolic regression stores a list of lists of
     trained models. The models chosen from each of these lists is defined by the function
     `selection_method` keyword argument, which by default balances accuracy
-    and complexity.
+    and complexity. You can override this at prediction time by passing a named
+    tuple with keys `data` and `idx`.
 
     """,
             r"^    " => "",
@@ -713,7 +719,8 @@ eval(
     The fields of `fitted_params(mach)` are:
 
     - `best_idx::Vector{Int}`: The index of the best expression in each Pareto frontier,
-      as determined by the `selection_method` function.
+      as determined by the `selection_method` function. Override in `predict` by passing
+      a named tuple with keys `data` and `idx`.
     - `equations::Vector{Vector{Node{T}}}`: The expressions discovered by the search, represented
       in a dominating Pareto frontier (i.e., the best expressions found for
       each complexity). The outer vector is indexed by target variable, and the inner
@@ -727,7 +734,8 @@ eval(
     The fields of `report(mach)` are:
 
     - `best_idx::Vector{Int}`: The index of the best expression in each Pareto frontier,
-       as determined by the `selection_method` function.
+       as determined by the `selection_method` function. Override in `predict` by passing
+       a named tuple with keys `data` and `idx`.
     - `equations::Vector{Vector{Node{T}}}`: The expressions discovered by the search, represented
       in a dominating Pareto frontier (i.e., the best expressions found for
       each complexity). The outer vector is indexed by target variable, and the inner

--- a/test/test_mlj.jl
+++ b/test/test_mlj.jl
@@ -43,7 +43,16 @@ end
         fit!(mach)
         rep = report(mach)
         @test occursin("a", rep.equation_strings[rep.best_idx])
+        ypred_good = predict(mach, X)
         @test sum(abs2, predict(mach, X) .- y) / length(y) < 1e-5
+
+        @testset "Check that we can choose the equation" begin
+            ypred_same = predict(mach, (data=X, idx=rep.best_idx))
+            @test ypred_good == ypred_same
+
+            ypred_bad = predict(mach, (data=X, idx=1))
+            @test ypred_good != ypred_bad
+        end
 
         @testset "Smoke test SymbolicUtils" begin
             eqn = node_to_symbolic(rep.equations[rep.best_idx], model)
@@ -63,6 +72,28 @@ end
         @test all(
             eq -> occursin("a", eq), [rep.equation_strings[i][rep.best_idx[i]] for i in 1:3]
         )
+        ypred_good = predict(mach, X)
+
+        @testset "Test that we can choose the equation" begin
+            ypred_same = predict(mach, (data=X, idx=rep.best_idx))
+            @test ypred_good == ypred_same
+
+            ypred_bad = predict(mach, (data=X, idx=[1, 1, 1]))
+            @test ypred_good != ypred_bad
+
+            ypred_mixed = predict(mach, (data=X, idx=[rep.best_idx[1], 1, rep.best_idx[3]]))
+            @test ypred_mixed == hcat(ypred_good[:, 1], ypred_bad[:, 2], ypred_good[:, 3])
+
+            @test_throws AssertionError predict(mach, (data=X,))
+            VERSION >= v"1.8" &&
+                @test_throws "If specifying an equation index during" predict(
+                    mach, (data=X,)
+                )
+            VERSION >= v"1.8" &&
+                @test_throws "If specifying an equation index during" predict(
+                    mach, (X=X, idx=1)
+                )
+        end
     end
 
     @testset "Named outputs" begin


### PR DESCRIPTION
This enables the following syntax:

```julia
model = SRRegressor()
mach = machine(model, X, y)
fit!(mach)

# Predict with 3rd equation:
predict(mach, (data=X, idx=3))

# Predict with most complex equation:
r = report(mach)
predict(mach, (data=X, idx=lastindex(r.equations)))
```

which lets the user specify the equation they wish to use for prediction from the Pareto front.

For multiple outputs:

```julia
model = MultitargetSRRegressor()
mach = machine(model, X, y)
fit!(mach)


# Choose the 1st equation for output 1, 10th for output 2, and 5th for output 3:
predict(mach, (data=X, idx=[1, 10, 5]))
```

TODO:

- [x] Add example to documentation
- [x] Add example to README
- [x] Remove discussion of modifying `selection_method` (Seems to not work, see https://github.com/MilesCranmer/PySR/discussions/543 by @MrChewi)

---

@ablaom I would be interested to know if there is any way to make this sort of behavior compatible with MLJ? As it stands I think this might break some MLJ interfaces for users who wish to use this. (They would still be able to use `selection_method` parameter, but only before `fit!`)

