### PR TITLE
A small update on examples.md for 1-based indexing

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -8,7 +8,7 @@ using MLJ
 ## 1. Simple search
 
 Here's a simple example where we
-find the expression `2 cos(x3) + x0^2 - 2`.
+find the expression `2 cos(x4) + x1^2 - 2`.
 
 ```julia
 X = 2randn(1000, 5)


### PR DESCRIPTION
Since we are in Julia not in Python, the indices of `x3` and `x0` should really be `x4` and `x1` to be consistent with the code to avoid any confusion.