### PR TITLE
Fixes for Julia 1.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,8 @@ jobs:
         include:
           - os: windows-latest
             julia-version: "1"
+          - os: ubuntu-latest
+            julia-version: "~1.11.0-0"
 
     steps:
       - uses: actions/checkout@v4

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -246,12 +246,7 @@ function import_module_on_workers(procs, filename::String, options::Options, ver
     else
         @info "Importing SymbolicRegression on workers as well as extensions $(join(relevant_extensions, ',' * ' '))."
     end
-    if VERSION < v"1.11.0-alpha1"
-        @everywhere procs Base.MainInclude.eval($expr)
-    else
-        # See https://github.com/JuliaLang/julia/issues/54057
-        @everywhere procs Core.eval(Base.MainInclude, $expr)
-    end
+    @everywhere procs Core.eval(Core.Main, $expr)
     return verbosity > 0 && @info "Finished!"
 end
 

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -246,7 +246,12 @@ function import_module_on_workers(procs, filename::String, options::Options, ver
     else
         @info "Importing SymbolicRegression on workers as well as extensions $(join(relevant_extensions, ',' * ' '))."
     end
-    @everywhere procs Base.MainInclude.eval($expr)
+    if VERSION < v"1.11.0-alpha1"
+        @everywhere procs Base.MainInclude.eval($expr)
+    else
+        # See https://github.com/JuliaLang/julia/issues/54057
+        @everywhere procs Core.eval(Base.MainInclude, $expr)
+    end
     return verbosity > 0 && @info "Finished!"
 end
 


### PR DESCRIPTION
Julia 1.11 didn't work out-of-the-box so this PR fixes some issues with it and adds it to testing.

Seems like `Base.MainInclude.eval` was removed: https://github.com/JuliaLang/julia/issues/54057 so we can replace with `Core.eval(Base.MainInclude, ...)`. (Isn't this part of the public API though?)