### PR TITLE
refactor: fix some more type instabilities

### DIFF
--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -2,7 +2,7 @@ module ConstantOptimizationModule
 
 using LineSearches: LineSearches
 using Optim: Optim
-using DynamicExpressions: Node, count_constants, get_constant_refs
+using DynamicExpressions: Node, count_constants
 using ..CoreModule: Options, Dataset, DATA_TYPE, LOSS_TYPE
 using ..UtilsModule: get_birth_order
 using ..LossFunctionsModule: eval_loss, loss_to_score, batch_sample

--- a/src/MutationFunctions.jl
+++ b/src/MutationFunctions.jl
@@ -327,16 +327,21 @@ function form_random_connection!(tree::AbstractNode, rng::AbstractRNG=default_rn
         return tree
     end
     # Set one of the children to be this new child:
-    side = (parent.degree == 1 || rand(rng, Bool)) ? :l : :r
-    setproperty!(parent, side, new_child)
+    if parent.degree == 1 || rand(rng, Bool)
+        parent.l = new_child
+    else
+        parent.r = new_child
+    end
     return tree
 end
 function break_random_connection!(tree::AbstractNode, rng::AbstractRNG=default_rng())
     tree.degree == 0 && return tree
     parent = rand(rng, NodeSampler(; tree, filter=t -> t.degree != 0))
-    side = (parent.degree == 1 || rand(rng, Bool)) ? :l : :r
-    unshared_child = copy(getproperty(parent, side))
-    setproperty!(parent, side, unshared_child)
+    if parent.degree == 1 || rand(rng, Bool)
+        parent.l = copy(parent.l)
+    else
+        parent.r = copy(parent.r)
+    end
     return tree
 end
 

--- a/src/MutationFunctions.jl
+++ b/src/MutationFunctions.jl
@@ -302,25 +302,25 @@ function crossover_trees(
     return tree1, tree2
 end
 
+function get_two_nodes_without_loop(tree::AbstractNode, rng::AbstractRNG; max_attempts=10)
+    for _ in 1:max_attempts
+        parent = rand(rng, NodeSampler(; tree, filter=t -> t.degree != 0))
+        new_child = rand(rng, NodeSampler(; tree, filter=t -> t !== tree))
+
+        would_form_loop = any(t -> t === parent, new_child)
+        if !would_form_loop
+            return (parent, new_child, false)
+        end
+    end
+    return (tree, tree, true)
+end
+
 function form_random_connection!(tree::AbstractNode, rng::AbstractRNG=default_rng())
     if length(tree) < 5
         return tree
     end
 
-    attempt_number = 0
-    max_attempts = 10
-
-    parent = rand(rng, NodeSampler(; tree, filter=t -> t.degree != 0))
-    new_child = rand(rng, NodeSampler(; tree, filter=t -> t !== tree))
-    attempt_number += 1
-    would_form_loop = any(t -> t === parent, new_child)
-
-    while would_form_loop && attempt_number <= max_attempts
-        parent = rand(rng, NodeSampler(; tree, filter=t -> t.degree != 0))
-        new_child = rand(rng, NodeSampler(; tree, filter=t -> t !== tree))
-        attempt_number += 1
-        would_form_loop = any(t -> t === parent, new_child)
-    end
+    parent, new_child, would_form_loop = get_two_nodes_without_loop(tree, rng)
 
     if would_form_loop
         return tree

--- a/src/MutationFunctions.jl
+++ b/src/MutationFunctions.jl
@@ -307,25 +307,25 @@ function form_random_connection!(tree::AbstractNode, rng::AbstractRNG=default_rn
         return tree
     end
 
-    local parent, new_child, would_form_loop
-
     attempt_number = 0
     max_attempts = 10
 
-    while true
+    parent = rand(rng, NodeSampler(; tree, filter=t -> t.degree != 0))
+    new_child = rand(rng, NodeSampler(; tree, filter=t -> t !== tree))
+    attempt_number += 1
+    would_form_loop = any(t -> t === parent, new_child)
+
+    while would_form_loop && attempt_number <= max_attempts
         parent = rand(rng, NodeSampler(; tree, filter=t -> t.degree != 0))
         new_child = rand(rng, NodeSampler(; tree, filter=t -> t !== tree))
         attempt_number += 1
         would_form_loop = any(t -> t === parent, new_child)
-        if would_form_loop && attempt_number <= max_attempts
-            continue
-        else
-            break
-        end
     end
+
     if would_form_loop
         return tree
     end
+
     # Set one of the children to be this new child:
     if parent.degree == 1 || rand(rng, Bool)
         parent.l = new_child

--- a/src/ProgressBars.jl
+++ b/src/ProgressBars.jl
@@ -19,16 +19,13 @@ mutable struct WrappedProgressBar
 end
 
 """Iterate a progress bar without needing to store cycle/state externally."""
-function manually_iterate!(progress_bar::WrappedProgressBar)
-    cur_cycle = progress_bar.cycle
-    cur_state = progress_bar.state
+function manually_iterate!(pbar::WrappedProgressBar)
+    cur_cycle = pbar.cycle
     if cur_cycle === nothing
-        cur_cycle, cur_state = iterate(progress_bar.bar)
+        pbar.cycle, pbar.state = iterate(pbar.bar)
     else
-        cur_cycle, cur_state = iterate(progress_bar.bar, cur_state)
+        pbar.cycle, pbar.state = iterate(pbar.bar, pbar.state)
     end
-    progress_bar.cycle = cur_cycle
-    progress_bar.state = cur_state
     return nothing
 end
 

--- a/src/SearchUtils.jl
+++ b/src/SearchUtils.jl
@@ -181,18 +181,24 @@ function check_for_user_quit(reader::StdinReader)::Bool
     return false
 end
 
-function check_for_loss_threshold(hallOfFame, options::Options)::Bool
-    options.early_stop_condition === nothing && return false
+function check_for_loss_threshold(hall_of_fame, options::Options)::Bool
+    return _check_for_loss_threshold(hall_of_fame, options.early_stop_condition, options)
+end
 
-    # Check if all nout are below stopping condition.
-    for hof in hallOfFame
-        stop_conditions = [
-            exists &&
-            options.early_stop_condition(member.loss, compute_complexity(member, options))
-            for (exists, member) in zip(hof.exists, hof.members)
+function _check_for_loss_threshold(_, ::Nothing, ::Options)
+    return false
+end
+function _check_for_loss_threshold(hall_of_fame, f::F, options::Options) where {F}
+    for hof in hall_of_fame
+        stop_conditions = Bool[
+            if exists
+                f(member.loss, compute_complexity(member, options))::Bool
+            else
+                false
+            end for (exists, member) in zip(hof.exists, hof.members)
         ]
         if any(stop_conditions)
-            # This means some expressions hit the stop condition.
+            continue
         else
             return false
         end
@@ -202,11 +208,11 @@ end
 
 function check_for_timeout(start_time::Float64, options::Options)::Bool
     return options.timeout_in_seconds !== nothing &&
-           time() - start_time > options.timeout_in_seconds
+           time() - start_time > options.timeout_in_seconds::Float64
 end
 
 function check_max_evals(num_evals, options::Options)::Bool
-    return options.max_evals !== nothing && options.max_evals <= sum(sum, num_evals)
+    return options.max_evals !== nothing && options.max_evals::Int <= sum(sum, num_evals)
 end
 
 const TIME_TYPE = Float64

--- a/src/SearchUtils.jl
+++ b/src/SearchUtils.jl
@@ -181,29 +181,19 @@ function check_for_user_quit(reader::StdinReader)::Bool
     return false
 end
 
-function check_for_loss_threshold(hall_of_fame, options::Options)::Bool
-    return _check_for_loss_threshold(hall_of_fame, options.early_stop_condition, options)
+function check_for_loss_threshold(halls_of_fame, options::Options)::Bool
+    return _check_for_loss_threshold(halls_of_fame, options.early_stop_condition, options)
 end
 
 function _check_for_loss_threshold(_, ::Nothing, ::Options)
     return false
 end
-function _check_for_loss_threshold(hall_of_fame, f::F, options::Options) where {F}
-    for hof in hall_of_fame
-        stop_conditions = Bool[
-            if exists
-                f(member.loss, compute_complexity(member, options))::Bool
-            else
-                false
-            end for (exists, member) in zip(hof.exists, hof.members)
-        ]
-        if any(stop_conditions)
-            continue
-        else
-            return false
+function _check_for_loss_threshold(halls_of_fame, f::F, options::Options) where {F}
+    return all(halls_of_fame) do hof
+        any(hof.members[hof.exists]) do member
+            f(member.loss, compute_complexity(member, options))::Bool
         end
     end
-    return true
 end
 
 function check_for_timeout(start_time::Float64, options::Options)::Bool


### PR DESCRIPTION
Fixes some instabilities found via `JET.@report_opt equation_search(randn(5, 100), randn(100))`.

Also will be further improved once https://github.com/SymbolicML/DynamicExpressions.jl/pull/70 is merged.