### PR TITLE
refactor: remove unused Tricks dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,6 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [weakdeps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
@@ -57,7 +56,6 @@ SpecialFunctions = "0.10.1, 1, 2"
 StatsBase = "0.33, 0.34"
 SymbolicUtils = "0.19, ^1.0.5"
 TOML = "1"
-Tricks = "0.1"
 julia = "1.6"
 
 [extras]

--- a/src/DimensionalAnalysis.jl
+++ b/src/DimensionalAnalysis.jl
@@ -2,7 +2,6 @@ module DimensionalAnalysisModule
 
 using DynamicExpressions: AbstractExpressionNode
 using DynamicQuantities: Quantity, DimensionError, AbstractQuantity, uparse, constructorof
-using Tricks: static_hasmethod
 
 using ..CoreModule: Options, Dataset
 using ..UtilsModule: safe_call
@@ -130,7 +129,7 @@ end
     l.violates && return l
     !isfinite(l) && return W(one(Q), false, true)
 
-    static_hasmethod(op, Tuple{W}) && @maybe_return_call(W, op, (l,))
+    hasmethod(op, Tuple{W}) && @maybe_return_call(W, op, (l,))
     l.wildcard && return W(Quantity(op(ustrip(l))::T), false, false)
     return W(one(Q), false, true)
 end
@@ -140,13 +139,9 @@ end
     l.violates && return l
     r.violates && return r
     (!isfinite(l) || !isfinite(r)) && return W(one(Q), false, true)
-    static_hasmethod(op, Tuple{W,W}) && @maybe_return_call(W, op, (l, r))
-    static_hasmethod(op, Tuple{T,W}) &&
-        l.wildcard &&
-        @maybe_return_call(W, op, (ustrip(l), r))
-    static_hasmethod(op, Tuple{W,T}) &&
-        r.wildcard &&
-        @maybe_return_call(W, op, (l, ustrip(r)))
+    hasmethod(op, Tuple{W,W}) && @maybe_return_call(W, op, (l, r))
+    hasmethod(op, Tuple{T,W}) && l.wildcard && @maybe_return_call(W, op, (ustrip(l), r))
+    hasmethod(op, Tuple{W,T}) && r.wildcard && @maybe_return_call(W, op, (l, ustrip(r)))
     l.wildcard &&
         r.wildcard &&
         return W(Quantity(op(ustrip(l), ustrip(r))::T), false, false)


### PR DESCRIPTION
No longer needed on Julia 1.10+