### PR TITLE
Add option to force dimensionless constants

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -225,6 +225,9 @@ which can cancel out other units in the expression.) For example,
 would indicate that the expression is dimensionally consistent, with
 a constant `"2.6353e-22[m s⁻²]"`.
 
+Note that you can also search for dimensionless units by settings
+`dimensionless_constants_only` to `true`.
+
 ## 7. Additional features
 
 For the many other features available in SymbolicRegression.jl,

--- a/src/InterfaceDynamicExpressions.jl
+++ b/src/InterfaceDynamicExpressions.jl
@@ -170,7 +170,11 @@ Convert an equation to a string.
             tree,
             options.operators;
             f_variable=(feature, vname) -> string_variable(feature, vname, X_sym_units),
-            f_constant=(val,) -> string_constant(val, vprecision, WILDCARD_UNIT_STRING),
+            f_constant=let
+                unit_placeholder =
+                    options.dimensionless_constants_only ? "" : WILDCARD_UNIT_STRING
+                (val,) -> string_constant(val, vprecision, unit_placeholder)
+            end,
             variable_names=display_variable_names,
             kws...,
         )

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -277,6 +277,8 @@ const OPTION_DESCRIPTIONS = """- `binary_operators`: Vector of binary operators 
     punished.
 - `dimensional_constraint_penalty`: An additive factor if the dimensional
     constraint is violated.
+- `dimensionless_constants_only`: Whether to only allow dimensionless
+    constants.
 - `use_frequency`: Whether to use a parsimony that adapts to the
     relative proportion of equations at each complexity; this will
     ensure that there are a balanced number of equations considered
@@ -387,6 +389,7 @@ function Options end
     complexity_of_variables::Union{Nothing,Real}=nothing,
     parsimony::Real=0.0032,
     dimensional_constraint_penalty::Union{Nothing,Real}=nothing,
+    dimensionless_constants_only::Bool=false,
     alpha::Real=0.100000,
     maxsize::Integer=20,
     maxdepth::Union{Nothing,Integer}=nothing,
@@ -780,6 +783,7 @@ function Options end
         tournament_selection_weights,
         parsimony,
         dimensional_constraint_penalty,
+        dimensionless_constants_only,
         alpha,
         maxsize,
         maxdepth,

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -59,6 +59,7 @@ struct Options{
     tournament_selection_weights::W
     parsimony::Float32
     dimensional_constraint_penalty::Union{Float32,Nothing}
+    dimensionless_constants_only::Bool
     alpha::Float32
     maxsize::Int
     maxdepth::Int

--- a/test/test_units.jl
+++ b/test/test_units.jl
@@ -33,6 +33,7 @@ using DynamicQuantities:
 using Test
 using MLJBase: MLJBase as MLJ
 using MLJModelInterface: MLJModelInterface as MMI
+include("utils.jl")
 
 custom_op(x, y) = x + y
 
@@ -369,6 +370,57 @@ end
         X_sym_units=dataset2.X_sym_units,
         y_sym_units=dataset2.y_sym_units,
     ) == "x₅[5.0 m] * 3.2[?]"
+
+    # With dimensionless_constants_only, it will not print the [?]:
+    options = Options(;
+        binary_operators=[+, -, *, /],
+        unary_operators=[cos, sin],
+        dimensionless_constants_only=true,
+    )
+    @test string_tree(
+        x5 * 3.2,
+        options;
+        raw=false,
+        display_variable_names=dataset2.display_variable_names,
+        X_sym_units=dataset2.X_sym_units,
+        y_sym_units=dataset2.y_sym_units,
+    ) == "x₅[5.0 m] * 3.2"
+end
+
+@testset "Dimensionless constants" begin
+    options = Options(;
+        binary_operators=[+, -, *, /, square, cube],
+        unary_operators=[cos, sin],
+        dimensionless_constants_only=true,
+    )
+    X = randn(5, 64)
+    y = randn(64)
+    dataset = Dataset(X, y; X_units=["m^3", "km/s", "kg", "hr", "1"], y_units="kg")
+    x1, x2, x3, x4, x5 = [Node(Float64; feature=i) for i in 1:5]
+
+    dimensionally_valid_equations = [
+        1.5 * x1 / (cube(x2) * cube(x4)) * x3, x3, (square(x3) / x3) + x3
+    ]
+    for tree in dimensionally_valid_equations
+        onfail(@test !violates_dimensional_constraints(tree, dataset, options)) do
+            @warn "Failed on" tree
+        end
+    end
+    dimensionally_invalid_equations = [Node(Float64; val=1.5), 1.5 * x1, x3 - 1.0 * x1]
+    for tree in dimensionally_invalid_equations
+        onfail(@test violates_dimensional_constraints(tree, dataset, options)) do
+            @warn "Failed on" tree
+        end
+    end
+    # But, all of these would be fine if we allow dimensionless constants:
+    let
+        options = Options(; binary_operators=[+, -, *, /], unary_operators=[cos, sin])
+        for tree in dimensionally_invalid_equations
+            onfail(@test !violates_dimensional_constraints(tree, dataset, options)) do
+                @warn "Failed on" tree
+            end
+        end
+    end
 end
 
 @testset "Miscellaneous" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,2 @@
+onfail(f, ::Test.Fail) = f()
+onfail(_, ::Test.Pass) = nothing


### PR DESCRIPTION
Feature request from the forums: https://github.com/MilesCranmer/PySR/discussions/606

Seems like a good idea to have this, so this PR enables such an option under `dimensionless_constants_only`, which allows the user to disable the "wildcard" unit behavior.