### PR TITLE
Modify for allocation mobility model search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ docs/src/index.md
 *.code-workspace
 .vscode
 **/*.json
+.DS_Store

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -8,9 +8,6 @@ export Population,
     Dataset,
     MutationWeights,
     Node,
-    GraphNode,
-    NodeSampler,
-    AbstractExpressionNode,
     SRRegressor,
     MultitargetSRRegressor,
     LOSS_TYPE,
@@ -32,7 +29,7 @@ export Population,
     copy_node,
     node_to_symbolic,
     symbolic_to_node,
-    simplify_tree!,
+    simplify_tree,
     tree_mapreduce,
     combine_operators,
     gen_random_tree,
@@ -75,9 +72,6 @@ using Random: seed!, shuffle!
 using Reexport
 using DynamicExpressions:
     Node,
-    GraphNode,
-    NodeSampler,
-    AbstractExpressionNode,
     copy_node,
     set_node!,
     string_tree,
@@ -94,10 +88,9 @@ using DynamicExpressions:
     node_to_symbolic,
     symbolic_to_node,
     combine_operators,
-    simplify_tree!,
+    simplify_tree,
     tree_mapreduce,
     set_default_variable_names!
-using DynamicExpressions.EquationModule: with_type_parameters
 @reexport using LossFunctions:
     MarginLoss,
     DistanceLoss,
@@ -128,13 +121,8 @@ using DynamicExpressions.EquationModule: with_type_parameters
 
 # https://discourse.julialang.org/t/how-to-find-out-the-version-of-a-package-from-its-module/37755/15
 const PACKAGE_VERSION = try
-    root = pkgdir(@__MODULE__)
-    if root == String
-        let project = parsefile(joinpath(root, "Project.toml"))
-            VersionNumber(project["version"])
-        end
-    else
-        VersionNumber(0, 0, 0)
+    let project = parsefile(joinpath(pkgdir(@__MODULE__), "Project.toml"))
+        VersionNumber(project["version"])
     end
 catch
     VersionNumber(0, 0, 0)
@@ -149,31 +137,27 @@ function deprecate_varmap(variable_names, varMap, func_name)
     return variable_names
 end
 
-using DispatchDoctor: @stable
-
-@stable default_mode = "disable" begin
-    include("Utils.jl")
-    include("InterfaceDynamicQuantities.jl")
-    include("Core.jl")
-    include("InterfaceDynamicExpressions.jl")
-    include("Recorder.jl")
-    include("Complexity.jl")
-    include("DimensionalAnalysis.jl")
-    include("CheckConstraints.jl")
-    include("AdaptiveParsimony.jl")
-    include("MutationFunctions.jl")
-    include("LossFunctions.jl")
-    include("PopMember.jl")
-    include("ConstantOptimization.jl")
-    include("Population.jl")
-    include("HallOfFame.jl")
-    include("Mutate.jl")
-    include("RegularizedEvolution.jl")
-    include("SingleIteration.jl")
-    include("ProgressBars.jl")
-    include("Migration.jl")
-    include("SearchUtils.jl")
-end
+include("Utils.jl")
+include("InterfaceDynamicQuantities.jl")
+include("Core.jl")
+include("InterfaceDynamicExpressions.jl")
+include("Recorder.jl")
+include("Complexity.jl")
+include("DimensionalAnalysis.jl")
+include("CheckConstraints.jl")
+include("AdaptiveParsimony.jl")
+include("MutationFunctions.jl")
+include("LossFunctions.jl")
+include("PopMember.jl")
+include("ConstantOptimization.jl")
+include("Population.jl")
+include("HallOfFame.jl")
+include("Mutate.jl")
+include("RegularizedEvolution.jl")
+include("SingleIteration.jl")
+include("ProgressBars.jl")
+include("Migration.jl")
+include("SearchUtils.jl")
 
 using .CoreModule:
     MAX_DEGREE,
@@ -226,19 +210,14 @@ using .PopulationModule: Population, best_sub_pop, record_population, best_of_sa
 using .HallOfFameModule:
     HallOfFame, calculate_pareto_frontier, string_dominating_pareto_curve
 using .SingleIterationModule: s_r_cycle, optimize_and_simplify_population
+using .ConstantOptimizationModule: dispatch_optimize_constants
 using .ProgressBarsModule: WrappedProgressBar
-using .RecorderModule: @recorder, find_iteration_from_record
+using .RecorderModule: @recorder, is_recording, find_iteration_from_record
 using .MigrationModule: migrate!
 using .SearchUtilsModule:
-    SearchState,
-    RuntimeOptions,
-    WorkerAssignments,
-    DefaultWorkerOutputType,
     assign_next_worker!,
-    get_worker_output_type,
-    extract_from_worker,
+    initialize_worker_assignment,
     @sr_spawner,
-    StdinReader,
     watch_stream,
     close_reader!,
     check_for_user_quit,
@@ -255,14 +234,11 @@ using .SearchUtilsModule:
     load_saved_hall_of_fame,
     load_saved_population,
     construct_datasets,
-    save_to_file,
     get_cur_maxsize,
     update_hall_of_fame!
 
-@stable default_mode = "disable" begin
-    include("deprecates.jl")
-    include("Configure.jl")
-end
+include("deprecates.jl")
+include("Configure.jl")
 
 """
     equation_search(X, y[; kws...])
@@ -373,7 +349,7 @@ function equation_search(
     heap_size_hint_in_bytes::Union{Integer,Nothing}=nothing,
     runtests::Bool=true,
     saved_state=nothing,
-    return_state::Union{Bool,Nothing,Val}=nothing,
+    return_state::Union{Bool,Nothing}=nothing,
     loss_type::Type{L}=Nothing,
     verbosity::Union{Integer,Nothing}=nothing,
     progress::Union{Bool,Nothing}=nothing,
@@ -457,23 +433,22 @@ function equation_search(
     heap_size_hint_in_bytes::Union{Integer,Nothing}=nothing,
     runtests::Bool=true,
     saved_state=nothing,
-    return_state::Union{Bool,Nothing,Val}=nothing,
+    return_state::Union{Bool,Nothing}=nothing,
     verbosity::Union{Int,Nothing}=nothing,
     progress::Union{Bool,Nothing}=nothing,
     v_dim_out::Val{DIM_OUT}=Val(nothing),
 ) where {DIM_OUT,T<:DATA_TYPE,L<:LOSS_TYPE,D<:Dataset{T,L}}
-    concurrency = if parallelism in (:multithreading, "multithreading")
-        :multithreading
+    v_concurrency, concurrency = if parallelism in (:multithreading, "multithreading")
+        (Val(:multithreading), :multithreading)
     elseif parallelism in (:multiprocessing, "multiprocessing")
-        :multiprocessing
+        (Val(:multiprocessing), :multiprocessing)
     elseif parallelism in (:serial, "serial")
-        :serial
+        (Val(:serial), :serial)
     else
         error(
             "Invalid parallelism mode: $parallelism. " *
             "You must choose one of :multithreading, :multiprocessing, or :serial.",
         )
-        :serial
     end
     not_distributed = concurrency in (:multithreading, :serial)
     not_distributed &&
@@ -487,45 +462,38 @@ function equation_search(
             "`numprocs` should not be set when using `parallelism=$(parallelism)`. Please use `:multiprocessing`.",
         )
 
-    _return_state = if return_state isa Val
-        first(typeof(return_state).parameters)
+    # TODO: Still not type stable. Should be able to pass `Val{return_state}`.
+    _return_state = if options.return_state === nothing
+        return_state === nothing ? false : return_state
     else
-        if options.return_state === Val(nothing)
-            return_state === nothing ? false : return_state
-        else
-            @assert(
-                return_state === nothing,
-                "You cannot set `return_state` in both the `Options` and in the passed arguments."
-            )
-            first(typeof(options.return_state).parameters)
-        end
+        @assert(
+            return_state === nothing,
+            "You cannot set `return_state` in both the `Options` and in the passed arguments."
+        )
+        options.return_state
     end
 
-    dim_out = if DIM_OUT === nothing
-        length(datasets) > 1 ? 2 : 1
+    v_dim_out = if DIM_OUT === nothing
+        length(datasets) > 1 ? Val(2) : Val(1)
     else
-        DIM_OUT
+        Val(DIM_OUT)
     end
-    _numprocs::Int = if numprocs === nothing
-        if procs === nothing
-            4
-        else
-            length(procs)
-        end
+    _numprocs::Int = if numprocs === nothing && procs === nothing
+        4
+    elseif numprocs !== nothing && procs === nothing
+        numprocs
+    elseif numprocs === nothing && procs !== nothing
+        length(procs)
     else
-        if procs === nothing
-            numprocs
-        else
-            @assert length(procs) == numprocs
-            numprocs
-        end
+        @assert length(procs) == numprocs
+        numprocs
     end
 
     _verbosity = if verbosity === nothing && options.verbosity === nothing
         1
-    elseif verbosity === nothing && options.verbosity !== nothing
+    elseif verbosity === nothing
         options.verbosity
-    elseif verbosity !== nothing && options.verbosity === nothing
+    elseif options.verbosity === nothing
         verbosity
     else
         error(
@@ -533,17 +501,24 @@ function equation_search(
         )
         1
     end
-    _progress::Bool = if progress === nothing && options.progress === nothing
+    _progress = if progress === nothing && options.progress === nothing
         (_verbosity > 0) && length(datasets) == 1
-    elseif progress === nothing && options.progress !== nothing
+    elseif progress === nothing
         options.progress
-    elseif progress !== nothing && options.progress === nothing
+    elseif options.progress === nothing
         progress
     else
         error(
             "You cannot set `progress` in both the search parameters `Options` and the call to `equation_search`.",
         )
         false
+    end
+    if _progress
+        @assert(
+            length(datasets) == 1,
+            "You cannot display a progress bar for multi-output searches."
+        )
+        @assert(_verbosity > 0, "You cannot display a progress bar with `verbosity=0`.")
     end
 
     _addprocs_function = addprocs_function === nothing ? addprocs : addprocs_function
@@ -569,188 +544,149 @@ function equation_search(
 
     # Underscores here mean that we have mutated the variable
     return _equation_search(
+        v_concurrency,
+        v_dim_out,
         datasets,
-        RuntimeOptions(;
-            niterations=niterations,
-            total_cycles=options.populations * niterations,
-            numprocs=_numprocs,
-            init_procs=procs,
-            addprocs_function=_addprocs_function,
-            exeflags=exeflags,
-            runtests=runtests,
-            verbosity=_verbosity,
-            progress=_progress,
-            parallelism=Val(concurrency),
-            dim_out=Val(dim_out),
-            return_state=Val(_return_state),
-        ),
+        niterations,
         options,
+        _numprocs,
+        procs,
+        _addprocs_function,
+        exeflags,
+        runtests,
         saved_state,
+        _verbosity,
+        _progress,
+        Val(_return_state),
     )
 end
 
-@stable default_mode = "disable" @noinline function _equation_search(
-    datasets::Vector{D}, ropt::RuntimeOptions, options::Options, saved_state
-) where {D<:Dataset}
-    _validate_options(datasets, ropt, options)
-    state = _create_workers(datasets, ropt, options)
-    _initialize_search!(state, datasets, ropt, options, saved_state)
-    _warmup_search!(state, datasets, ropt, options)
-    _main_search_loop!(state, datasets, ropt, options)
-    _tear_down!(state, ropt, options)
-    return _format_output(state, ropt)
-end
+function _equation_search(
+    ::Val{PARALLELISM},
+    ::Val{DIM_OUT},
+    datasets::Vector{D}, # zwy: multiple datasets, each's type is Dataset{T,L} (defined in where.)
+    niterations::Int,
+    options::Options,
+    numprocs::Int,
+    procs::Union{Vector{Int},Nothing}, # zwy: ?
+    addprocs_function::Function,
+    exeflags::Cmd,
+    runtests::Bool,
+    saved_state,
+    verbosity,
+    progress,
+    ::Val{RETURN_STATE},
+) where {T<:DATA_TYPE,L<:LOSS_TYPE,D<:Dataset{T,L},PARALLELISM,RETURN_STATE,DIM_OUT}
+    stdin_reader = watch_stream(stdin) # zwy: listening
 
-function _validate_options(
-    datasets::Vector{D}, ropt::RuntimeOptions, options::Options
-) where {T,L,D<:Dataset{T,L}}
-    example_dataset = first(datasets)
-    nout = length(datasets)
-    @assert nout >= 1
-    @assert (nout == 1 || ropt.dim_out == 2)
-    @assert options.populations >= 1
-    if ropt.progress
-        @assert(nout == 1, "You cannot display a progress bar for multi-output searches.")
-        @assert(ropt.verbosity > 0, "You cannot display a progress bar with `verbosity=0`.")
-    end
-    if options.node_type <: GraphNode && ropt.verbosity > 0
-        @warn "The `GraphNode` interface and mutation operators are experimental and will change in future versions."
-    end
-    if ropt.runtests
-        test_option_configuration(ropt.parallelism, datasets, options, ropt.verbosity)
-        test_dataset_configuration(example_dataset, options, ropt.verbosity)
-    end
-    for dataset in datasets
-        update_baseline_loss!(dataset, options)
-    end
     if options.define_helper_functions
         set_default_variable_names!(first(datasets).variable_names)
     end
+
+    example_dataset = datasets[1]
+    nout = size(datasets, 1) # zwy: In Julia, the first dimension is 1 but not 0.
+    @assert (nout == 1 || DIM_OUT == 2)
+
+    if runtests
+        test_option_configuration(PARALLELISM, datasets, saved_state, options)
+        test_dataset_configuration(example_dataset, options, verbosity)
+    end
+
+    for dataset in datasets
+        update_baseline_loss!(dataset, options) # zwy: ! means the function will change the input, here, dataset.
+    end
+
     if options.seed !== nothing
         seed!(options.seed)
     end
-    return nothing
-end
-@stable default_mode = "disable" function _create_workers(
-    datasets::Vector{D}, ropt::RuntimeOptions, options::Options
-) where {T,L,D<:Dataset{T,L}}
-    stdin_reader = watch_stream(stdin)
+    # Start a population on every process
+    #    Store the population, hall of fame
+    WorkerOutputType = if PARALLELISM == :serial
+        Tuple{Population{T,L},HallOfFame{T,L},RecordType,Float64}
+    elseif PARALLELISM == :multiprocessing
+        Future 
+    else
+        Task
+    end
 
-    record = RecordType()
-    @recorder record["options"] = "$(options)"
-
-    nout = length(datasets)
-    example_dataset = first(datasets)
-    NT = with_type_parameters(options.node_type, T)
-    PopType = Population{T,L,NT}
-    HallOfFameType = HallOfFame{T,L,NT}
-    WorkerOutputType = get_worker_output_type(
-        Val(ropt.parallelism), PopType, HallOfFameType
-    )
-    ChannelType = ropt.parallelism == :multiprocessing ? RemoteChannel : Channel
+    # Persistent storage of last-saved population for final return:
+    returnPops = init_dummy_pops(options.populations, datasets, options)
+    # Best 10 members from each population for migration:
+    bestSubPops = init_dummy_pops(options.populations, datasets, options)
 
     # Pointers to populations on each worker:
-    worker_output = Vector{WorkerOutputType}[WorkerOutputType[] for j in 1:nout]
+    worker_output = [WorkerOutputType[] for j in 1:nout]
     # Initialize storage for workers
     tasks = [Task[] for j in 1:nout]
     # Set up a channel to send finished populations back to head node
-    channels = [[ChannelType(1) for i in 1:(options.populations)] for j in 1:nout]
-    (procs, we_created_procs) = if ropt.parallelism == :multiprocessing
-        configure_workers(;
-            procs=ropt.init_procs,
-            ropt.numprocs,
-            ropt.addprocs_function,
-            options,
-            project_path=splitdir(Pkg.project().path)[1],
-            file=@__FILE__,
-            ropt.exeflags,
-            ropt.verbosity,
-            example_dataset,
-            ropt.runtests,
-        )
+    channels = if PARALLELISM == :multiprocessing
+        [[RemoteChannel(1) for i in 1:(options.populations)] for j in 1:nout]
     else
-        Int[], false
+        [[Channel(1) for i in 1:(options.populations)] for j in 1:nout]
+        # (Unused for :serial)
     end
-    # Get the next worker process to give a job:
-    worker_assignment = WorkerAssignments()
-    # Randomly order which order to check populations:
-    # This is done so that we do work on all nout equally.
-    task_order = [(j, i) for j in 1:nout for i in 1:(options.populations)]
-    shuffle!(task_order)
 
-    # Persistent storage of last-saved population for final return:
-    last_pops = init_dummy_pops(options.populations, datasets, options)
-    # Best 10 members from each population for migration:
-    best_sub_pops = init_dummy_pops(options.populations, datasets, options)
     # TODO: Should really be one per population too.
     all_running_search_statistics = [
         RunningSearchStatistics(; options=options) for j in 1:nout
     ]
+
+    record = RecordType()
+    @recorder record["options"] = "$(options)"
+
     # Records the number of evaluations:
     # Real numbers indicate use of batching.
     num_evals = [[0.0 for i in 1:(options.populations)] for j in 1:nout]
 
-    halls_of_fame = Vector{HallOfFameType}(undef, nout)
+    we_created_procs = false
+    ##########################################################################
+    ### Distributed code:
+    ##########################################################################
+    if PARALLELISM == :multiprocessing
+        (procs, we_created_procs) = configure_workers(;
+            procs,
+            numprocs,
+            addprocs_function,
+            options,
+            project_path=splitdir(Pkg.project().path)[1],
+            file=@__FILE__,
+            exeflags,
+            verbosity,
+            example_dataset,
+            runtests,
+        )
+    end
+    # Get the next worker process to give a job:
+    worker_assignment = initialize_worker_assignment()
 
-    cycles_remaining = [ropt.total_cycles for j in 1:nout]
-    cur_maxsizes = [
-        get_cur_maxsize(; options, ropt.total_cycles, cycles_remaining=cycles_remaining[j])
-        for j in 1:nout
-    ]
-
-    return SearchState{
-        T,L,with_type_parameters(options.node_type, T),WorkerOutputType,ChannelType
-    }(;
-        procs=procs,
-        we_created_procs=we_created_procs,
-        worker_output=worker_output,
-        tasks=tasks,
-        channels=channels,
-        worker_assignment=worker_assignment,
-        task_order=task_order,
-        halls_of_fame=halls_of_fame,
-        last_pops=last_pops,
-        best_sub_pops=best_sub_pops,
-        all_running_search_statistics=all_running_search_statistics,
-        num_evals=num_evals,
-        cycles_remaining=cycles_remaining,
-        cur_maxsizes=cur_maxsizes,
-        stdin_reader=stdin_reader,
-        record=Ref(record),
-    )
-end
-function _initialize_search!(
-    state::SearchState{T,L,N}, datasets, ropt::RuntimeOptions, options::Options, saved_state
-) where {T,L,N}
-    nout = length(datasets)
-
-    init_hall_of_fame = load_saved_hall_of_fame(saved_state)
-    if init_hall_of_fame === nothing
-        for j in 1:nout
-            state.halls_of_fame[j] = HallOfFame(options, T, L)
-        end
+    hallOfFame = load_saved_hall_of_fame(saved_state)
+    hallOfFame = if hallOfFame === nothing
+        [HallOfFame(options, T, L) for j in 1:nout]
     else
         # Recompute losses for the hall of fame, in
         # case the dataset changed:
-        for j in eachindex(init_hall_of_fame, datasets, state.halls_of_fame)
-            hof = init_hall_of_fame[j]
+        for (hof, dataset) in zip(hallOfFame, datasets)
             for member in hof.members[hof.exists]
-                score, result_loss = score_func(datasets[j], member, options)
+                score, result_loss = score_func(dataset, member, options)
                 member.score = score
                 member.loss = result_loss
             end
-            state.halls_of_fame[j] = hof
         end
+        hallOfFame
     end
+    @assert length(hallOfFame) == nout
+    hallOfFame::Vector{HallOfFame{T,L}}
 
-    for j in 1:nout, i in 1:(options.populations)
+    # zwy: Create populations
+    for j in 1:nout, i in 1:(options.populations) 
         worker_idx = assign_next_worker!(
-            state.worker_assignment; out=j, pop=i, parallelism=ropt.parallelism, state.procs
+            worker_assignment; out=j, pop=i, parallelism=PARALLELISM, procs
         )
         saved_pop = load_saved_population(saved_state; out=j, pop=i)
+
         new_pop =
             if saved_pop !== nothing && length(saved_pop.members) == options.population_size
-                saved_pop::Population{T,L,N}
+                saved_pop::Population{T,L}
                 ## Update losses:
                 for member in saved_pop.members
                     score, result_loss = score_func(datasets[j], member, options)
@@ -762,11 +698,11 @@ function _initialize_search!(
                     begin
                         (copy_pop, HallOfFame(options, T, L), RecordType(), 0.0)
                     end,
-                    parallelism = ropt.parallelism,
+                    parallelism = PARALLELISM,
                     worker_idx = worker_idx
                 )
             else
-                if saved_pop !== nothing && ropt.verbosity > 0
+                if saved_pop !== nothing
                     @warn "Recreating population (output=$(j), population=$(i)), as the saved one doesn't have the correct number of members."
                 end
                 @sr_spawner(
@@ -784,83 +720,87 @@ function _initialize_search!(
                             Float64(options.population_size),
                         )
                     end,
-                    parallelism = ropt.parallelism,
+                    parallelism = PARALLELISM,
                     worker_idx = worker_idx
                 )
                 # This involves population_size evaluations, on the full dataset:
             end
-        push!(state.worker_output[j], new_pop)
+        push!(worker_output[j], new_pop)
     end
-    return nothing
-end
-function _warmup_search!(
-    state::SearchState{T,L,N}, datasets, ropt::RuntimeOptions, options::Options
-) where {T,L,N}
-    nout = length(datasets)
+    total_cycles = options.populations * niterations
+    cycles_remaining = [total_cycles for j in 1:nout]
+    curmaxsizes = [
+        get_cur_maxsize(; options, total_cycles, cycles_remaining=cycles_remaining[j]) for
+        j in 1:nout
+    ]
+    # 2. Start the cycle on every process:
     for j in 1:nout, i in 1:(options.populations)
         dataset = datasets[j]
-        running_search_statistics = state.all_running_search_statistics[j]
-        cur_maxsize = state.cur_maxsizes[j]
-        @recorder state.record[]["out$(j)_pop$(i)"] = RecordType()
+        running_search_statistics = all_running_search_statistics[j]
+        curmaxsize = curmaxsizes[j]
+        @recorder record["out$(j)_pop$(i)"] = RecordType()
         worker_idx = assign_next_worker!(
-            state.worker_assignment; out=j, pop=i, parallelism=ropt.parallelism, state.procs
+            worker_assignment; out=j, pop=i, parallelism=PARALLELISM, procs
         )
 
         # TODO - why is this needed??
         # Multi-threaded doesn't like to fetch within a new task:
         c_rss = deepcopy(running_search_statistics)
-        last_pop = state.worker_output[j][i]
+        last_pop = worker_output[j][i]
         updated_pop = @sr_spawner(
             begin
-                in_pop = first(
-                    extract_from_worker(last_pop, Population{T,L,N}, HallOfFame{T,L,N})
-                )
-                _dispatch_s_r_cycle(
-                    in_pop,
-                    dataset,
-                    options;
+                in_pop = if PARALLELISM in (:multiprocessing, :multithreading)
+                    fetch(last_pop)[1]
+                else
+                    last_pop[1]
+                end
+                _dispatch_s_r_cycle(;
                     pop=i,
                     out=j,
                     iteration=0,
-                    ropt.verbosity,
-                    cur_maxsize,
+                    dataset,
+                    options,
+                    verbosity,
+                    in_pop,
+                    curmaxsize,
                     running_search_statistics=c_rss,
-                )::DefaultWorkerOutputType{Population{T,L,N},HallOfFame{T,L,N}}
+                )
             end,
-            parallelism = ropt.parallelism,
+            parallelism = PARALLELISM,
             worker_idx = worker_idx
         )
-        state.worker_output[j][i] = updated_pop
+        worker_output[j][i] = updated_pop
     end
-    return nothing
-end
-function _main_search_loop!(
-    state::SearchState{T,L,N}, datasets, ropt::RuntimeOptions, options::Options
-) where {T,L,N}
-    ropt.verbosity > 0 && @info "Started!"
-    nout = length(datasets)
+
+    verbosity > 0 && @info "Started!"
     start_time = time()
-    if ropt.progress
+    if progress
         #TODO: need to iterate this on the max cycles remaining!
-        sum_cycle_remaining = sum(state.cycles_remaining)
+        sum_cycle_remaining = sum(cycles_remaining)
         progress_bar = WrappedProgressBar(
             1:sum_cycle_remaining; width=options.terminal_width
         )
     end
+
     last_print_time = time()
     last_speed_recording_time = time()
-    num_evals_last = sum(sum, state.num_evals)
-    num_evals_since_last = sum(sum, state.num_evals) - num_evals_last  # i.e., start at 0
+    num_evals_last = sum(sum, num_evals)
+    num_evals_since_last = sum(sum, num_evals) - num_evals_last
     print_every_n_seconds = 5
     equation_speed = Float32[]
 
-    if ropt.parallelism in (:multiprocessing, :multithreading)
+    if PARALLELISM in (:multiprocessing, :multithreading)
         for j in 1:nout, i in 1:(options.populations)
             # Start listening for each population to finish:
-            t = @async put!(state.channels[j][i], fetch(state.worker_output[j][i]))
-            push!(state.tasks[j], t)
+            t = @async put!(channels[j][i], fetch(worker_output[j][i]))
+            push!(tasks[j], t)
         end
     end
+
+    # Randomly order which order to check populations:
+    # This is done so that we do work on all nout equally.
+    all_idx = [(j, i) for j in 1:nout for i in 1:(options.populations)]
+    shuffle!(all_idx)
     kappa = 0
     resource_monitor = ResourceMonitor(;
         absolute_start_time=time(),
@@ -868,71 +808,100 @@ function _main_search_loop!(
         # help get accurate resource estimates:
         num_intervals_to_store=options.populations * 100 * nout,
     )
-    while sum(state.cycles_remaining) > 0
+    while sum(cycles_remaining) > 0
         kappa += 1
         if kappa > options.populations * nout
             kappa = 1
         end
         # nout, populations:
-        j, i = state.task_order[kappa]
+        j, i = all_idx[kappa]
 
         # Check if error on population:
-        if ropt.parallelism in (:multiprocessing, :multithreading)
-            if istaskfailed(state.tasks[j][i])
-                fetch(state.tasks[j][i])
+        if PARALLELISM in (:multiprocessing, :multithreading)
+            if istaskfailed(tasks[j][i])
+                fetch(tasks[j][i])
                 error("Task failed for population")
             end
         end
         # Non-blocking check if a population is ready:
-        population_ready = if ropt.parallelism in (:multiprocessing, :multithreading)
+        population_ready = if PARALLELISM in (:multiprocessing, :multithreading)
             # TODO: Implement type assertions based on parallelism.
-            isready(state.channels[j][i])
+            isready(channels[j][i])
         else
             true
         end
         # Don't start more if this output has finished its cycles:
         # TODO - this might skip extra cycles?
-        population_ready &= (state.cycles_remaining[j] > 0)
+        population_ready &= (cycles_remaining[j] > 0)
         if population_ready
             start_work_monitor!(resource_monitor)
             # Take the fetch operation from the channel since its ready
-            (cur_pop, best_seen, cur_record, cur_num_evals) = if ropt.parallelism in
-                (
-                :multiprocessing, :multithreading
-            )
-                take!(
-                    state.channels[j][i]
-                )
-            else
-                state.worker_output[j][i]
-            end::DefaultWorkerOutputType{Population{T,L,N},HallOfFame{T,L,N}}
-            state.last_pops[j][i] = copy(cur_pop)
-            state.best_sub_pops[j][i] = best_sub_pop(cur_pop; topn=options.topn)
-            @recorder state.record[] = recursive_merge(state.record[], cur_record)
-            state.num_evals[j][i] += cur_num_evals
+            (cur_pop, best_seen, cur_record, cur_num_evals) =
+                if PARALLELISM in (:multiprocessing, :multithreading)
+                    take!(channels[j][i])
+                else
+                    worker_output[j][i]
+                end
+            cur_pop::Population{T,L}
+            best_seen::HallOfFame{T,L}
+            cur_record::RecordType
+            cur_num_evals::Float64
+            returnPops[j][i] = copy(cur_pop)
+            bestSubPops[j][i] = best_sub_pop(cur_pop; topn=options.topn)
+            @recorder record = recursive_merge(record, cur_record)
+            num_evals[j][i] += cur_num_evals
             dataset = datasets[j]
-            cur_maxsize = state.cur_maxsizes[j]
+            curmaxsize = curmaxsizes[j]
 
             for member in cur_pop.members
                 size = compute_complexity(member, options)
-                update_frequencies!(state.all_running_search_statistics[j]; size)
+                update_frequencies!(all_running_search_statistics[j]; size)
             end
             #! format: off
-            update_hall_of_fame!(state.halls_of_fame[j], cur_pop.members, options)
-            update_hall_of_fame!(state.halls_of_fame[j], best_seen.members[best_seen.exists], options)
+            update_hall_of_fame!(hallOfFame[j], cur_pop.members, options)
+            update_hall_of_fame!(hallOfFame[j], best_seen.members[best_seen.exists], options)
             #! format: on
+            
+            if options.optimize_hof && cycles_remaining[j]==1
+                for size in 1:(options.maxsize + MAX_DEGREE)
+                    if hallOfFame[j].exists[size]
+                        println("$size before opt: $(hallOfFame[j].members[size].loss) $(string_tree(hallOfFame[j].members[size].tree, options, variable_names=dataset.variable_names))")
+
+                        hallOfFame[j].members[size], evals_opt_hof = dispatch_optimize_constants(dataset, hallOfFame[j].members[size], options, nothing)
+                        num_evals[j][i] += evals_opt_hof
+
+                        println("$size after opt: $(hallOfFame[j].members[size].loss) $(string_tree(hallOfFame[j].members[size].tree, options, variable_names=dataset.variable_names))")
+                    end
+                end
+            end
 
             # Dominating pareto curve - must be better than all simpler equations
-            dominating = calculate_pareto_frontier(state.halls_of_fame[j])
+            dominating = calculate_pareto_frontier(hallOfFame[j])
 
             if options.save_to_file
-                save_to_file(dominating, nout, j, dataset, options)
+                output_file = options.output_file
+                if nout > 1
+                    output_file = output_file * ".out$j"
+                end
+                # Write file twice in case exit in middle of filewrite
+                for out_file in (output_file, output_file * ".bkup")
+                    open(out_file, "w") do io
+                        println(io, "Complexity,Loss,Equation")
+                        for member in dominating
+                            println(
+                                io,
+                                "$(compute_complexity(member, options)),$(member.loss),\"" *
+                                "$(string_tree(member.tree, options, variable_names=dataset.variable_names))\"",
+                            )
+                        end
+                    end
+                end
             end
             ###################################################################
             # Migration #######################################################
             if options.migration
                 best_of_each = Population([
-                    member for pop in state.best_sub_pops[j] for member in pop.members
+                    member for pop in bestSubPops[j] for member in pop.members
                 ])
                 migrate!(
                     best_of_each.members => cur_pop, options; frac=options.fraction_replaced
@@ -943,74 +912,68 @@ function _main_search_loop!(
             end
             ###################################################################
 
-            state.cycles_remaining[j] -= 1
-            if state.cycles_remaining[j] == 0
+            cycles_remaining[j] -= 1
+            if cycles_remaining[j] == 0
                 break
             end
             worker_idx = assign_next_worker!(
-                state.worker_assignment;
-                out=j,
-                pop=i,
-                parallelism=ropt.parallelism,
-                state.procs,
+                worker_assignment; out=j, pop=i, parallelism=PARALLELISM, procs
             )
-            iteration = if options.use_recorder
+            iteration = if is_recording(options)
                 key = "out$(j)_pop$(i)"
-                find_iteration_from_record(key, state.record[]) + 1
+                find_iteration_from_record(key, record) + 1
             else
                 0
             end
 
-            c_rss = deepcopy(state.all_running_search_statistics[j])
-            in_pop = copy(cur_pop::Population{T,L,N})
-            state.worker_output[j][i] = @sr_spawner(
+            c_rss = deepcopy(all_running_search_statistics[j])
+            in_pop = copy(cur_pop)
+            worker_output[j][i] = @sr_spawner(
                 begin
-                    _dispatch_s_r_cycle(
-                        in_pop,
-                        dataset,
-                        options;
+                    _dispatch_s_r_cycle(;
                         pop=i,
                         out=j,
                         iteration,
-                        ropt.verbosity,
-                        cur_maxsize,
+                        dataset,
+                        options,
+                        verbosity,
+                        in_pop,
+                        curmaxsize,
                         running_search_statistics=c_rss,
                     )
                 end,
-                parallelism = ropt.parallelism,
+                parallelism = PARALLELISM,
                 worker_idx = worker_idx
             )
-            if ropt.parallelism in (:multiprocessing, :multithreading)
-                state.tasks[j][i] = @async put!(
-                    state.channels[j][i], fetch(state.worker_output[j][i])
-                )
+            if PARALLELISM in (:multiprocessing, :multithreading)
+                tasks[j][i] = @async put!(channels[j][i], fetch(worker_output[j][i]))
             end
 
-            state.cur_maxsizes[j] = get_cur_maxsize(;
-                options, ropt.total_cycles, cycles_remaining=state.cycles_remaining[j]
+            curmaxsizes[j] = get_cur_maxsize(;
+                options, total_cycles, cycles_remaining=cycles_remaining[j]
             )
             stop_work_monitor!(resource_monitor)
-            move_window!(state.all_running_search_statistics[j])
-            if ropt.progress
+            move_window!(all_running_search_statistics[j])
+            if progress
                 head_node_occupation = estimate_work_fraction(resource_monitor)
                 update_progress_bar!(
                     progress_bar,
-                    only(state.halls_of_fame),
+                    only(hallOfFame),
                     only(datasets),
                     options,
                     equation_speed,
                     head_node_occupation,
-                    ropt.parallelism,
+                    PARALLELISM,
                 )
             end
         end
-        yield()
+        sleep(1e-6)
 
         ################################################################
         ## Search statistics
         elapsed_since_speed_recording = time() - last_speed_recording_time
         if elapsed_since_speed_recording > 1.0
-            num_evals_since_last, num_evals_last = let s = sum(sum, state.num_evals)
+            num_evals_since_last, num_evals_last = let s = sum(sum, num_evals)
                 s - num_evals_last, s
             end
             current_speed = num_evals_since_last / elapsed_since_speed_recording
@@ -1028,19 +991,19 @@ function _main_search_loop!(
         elapsed = time() - last_print_time
         # Update if time has passed
         if elapsed > print_every_n_seconds
-            if ropt.verbosity > 0 && !ropt.progress && length(equation_speed) > 0
+            if verbosity > 0 && !progress && length(equation_speed) > 0
 
                 # Dominating pareto curve - must be better than all simpler equations
                 head_node_occupation = estimate_work_fraction(resource_monitor)
                 print_search_state(
-                    state.halls_of_fame,
+                    hallOfFame,
                     datasets;
                     options,
                     equation_speed,
-                    ropt.total_cycles,
-                    state.cycles_remaining,
+                    total_cycles,
+                    cycles_remaining,
                     head_node_occupation,
-                    parallelism=ropt.parallelism,
+                    parallelism=PARALLELISM,
                     width=options.terminal_width,
                 )
             end
@@ -1051,51 +1014,51 @@ function _main_search_loop!(
         ################################################################
         ## Early stopping code
         if any((
-            check_for_loss_threshold(state.halls_of_fame, options),
-            check_for_user_quit(state.stdin_reader),
+            check_for_loss_threshold(hallOfFame, options),
+            check_for_user_quit(stdin_reader),
             check_for_timeout(start_time, options),
-            check_max_evals(state.num_evals, options),
+            check_max_evals(num_evals, options),
         ))
             break
         end
         ################################################################
     end
-    return nothing
-end
-function _tear_down!(state::SearchState, ropt::RuntimeOptions, options::Options)
-    close_reader!(state.stdin_reader)
+
+    close_reader!(stdin_reader)
+
     # Safely close all processes or threads
-    if ropt.parallelism == :multiprocessing
-        state.we_created_procs && rmprocs(state.procs)
-    elseif ropt.parallelism == :multithreading
-        nout = length(state.worker_output)
-        for j in 1:nout, i in eachindex(state.worker_output[j])
-            wait(state.worker_output[j][i])
+    if PARALLELISM == :multiprocessing
+        we_created_procs && rmprocs(procs)
+    elseif PARALLELISM == :multithreading
+        for j in 1:nout, i in 1:(options.populations)
+            wait(worker_output[j][i])
         end
     end
-    @recorder json3_write(state.record[], options.recorder_file)
-    return nothing
-end
-function _format_output(state::SearchState, ropt::RuntimeOptions)
-    out_hof = (ropt.dim_out == 1 ? only(state.halls_of_fame) : state.halls_of_fame)
-    if ropt.return_state
-        return (state.last_pops, out_hof)
+
+    ##########################################################################
+    ### Distributed code^
+    ##########################################################################
+
+    @recorder json3_write(record, options.recorder_file)
+
+    if RETURN_STATE
+        return (returnPops, (DIM_OUT == 1 ? only(hallOfFame) : hallOfFame))
     else
-        return out_hof
+        return (DIM_OUT == 1 ? only(hallOfFame) : hallOfFame)
     end
 end
 
-@stable default_mode = "disable" function _dispatch_s_r_cycle(
-    in_pop::Population{T,L,N},
-    dataset::Dataset,
-    options::Options;
+function _dispatch_s_r_cycle(;
     pop::Int,
     out::Int,
     iteration::Int,
+    dataset::Dataset,
+    options::Options,
     verbosity,
-    cur_maxsize::Int,
+    in_pop::Population,
+    curmaxsize::Int,
     running_search_statistics,
-) where {T,L,N}
+)
     record = RecordType()
     @recorder record["out$(out)_pop$(pop)"] = RecordType(
         "iteration$(iteration)" => record_population(in_pop, options)
@@ -1106,7 +1069,7 @@ end
         dataset,
         in_pop,
         options.ncycles_per_iteration,
-        cur_maxsize,
+        curmaxsize,
         running_search_statistics;
         verbosity=verbosity,
         options=options,
@@ -1114,9 +1077,10 @@ end
     )
     num_evals += evals_from_cycle
     out_pop, evals_from_optimize = optimize_and_simplify_population(
-        dataset, out_pop, options, cur_maxsize, record
+        dataset, out_pop, options, curmaxsize, record
     )
     num_evals += evals_from_optimize
+
     if options.batching
         for i_member in 1:(options.maxsize + MAX_DEGREE)
             score, result_loss = score_func(dataset, best_seen.members[i_member], options)


### PR DESCRIPTION
OptionsModule
-- Options :  Attributes allocation, eval_probability, ori_sep, num_places, optimize_hof are added.

-- In allocation mode, ori_sep is required as n-dim vector, where n is the number of places; dataset entry ori_sep[i-1]+1:ori_sep[i] corresponds to flows with origin i. Alternatively, you may input n*n adjmatrix, which is transformed into ori_sep. num_places will be calculated automatically.

LossFunctionsModule
-- eval_loss: Generate partition if allocation.
-- _eval_loss: Perform probability normalization if allocation. If eval_probability, do not multiply total outflow.
-- batch_sample: Sample from 1:num_places instead of 1:dataset.n if allocation.

SymbolicRegressionModule
-- _equation_search: if optimize_hof, Hall-of-Fame equations will be optimized with entire dataset (even if batching=true) after the last s_r_cycle.