### PR TITLE
Implement tree rotation operator

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     name: Julia ${{ matrix.julia-version }}-${{ matrix.os }}-${{ matrix.test }}-${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,7 @@ SymbolicRegressionSymbolicUtilsExt = "SymbolicUtils"
 
 [compat]
 ADTypes = "^1.4.0"
-Compat = "^4.2"
+Compat = "^4.16"
 ConstructionBase = "<1.5.7"
 Dates = "1"
 DifferentiationInterface = "0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,7 @@ SymbolicRegressionSymbolicUtilsExt = "SymbolicUtils"
 
 [compat]
 ADTypes = "^1.4.0"
-Compat = "^4.16"
+Compat = "^4.2"
 ConstructionBase = "<1.5.7"
 Dates = "1"
 DifferentiationInterface = "0.5"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -138,6 +138,19 @@ function create_utils_benchmark()
         s
     end
 
+    suite["randomly_rotate_tree_x10"] = @benchmarkable(
+        foreach(trees) do tree
+            randomly_rotate_tree!(tree, $options)
+        end,
+        setup = (
+            T = Float64;
+            nfeatures = 3;
+            trees = [
+                gen_random_tree_fixed_size(20, $options, nfeatures, T) for i in 1:($ntrees)
+            ]
+        )
+    )
+
     ntrees = 10
     options = Options(;
         unary_operators=[sin, cos],

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -151,6 +151,19 @@ function create_utils_benchmark()
         )
     )
 
+    suite["insert_random_op_x10"] = @benchmarkable(
+        foreach(trees) do tree
+            insert_random_op(tree, $options, nfeatures)
+        end,
+        setup = (
+            T = Float64;
+            nfeatures = 3;
+            trees = [
+                gen_random_tree_fixed_size(20, $options, nfeatures, T) for i in 1:($ntrees)
+            ]
+        )
+    )
+
     ntrees = 10
     options = Options(;
         unary_operators=[sin, cos],

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -138,22 +138,27 @@ function create_utils_benchmark()
         s
     end
 
-    suite["randomly_rotate_tree_x10"] = @benchmarkable(
-        foreach(trees) do tree
-            randomly_rotate_tree!(tree, $options)
-        end,
-        setup = (
-            T = Float64;
-            nfeatures = 3;
-            trees = [
-                gen_random_tree_fixed_size(20, $options, nfeatures, T) for i in 1:($ntrees)
-            ]
+    if isdefined(SymbolicRegression.MutationFunctionsModule, :randomly_rotate_tree!)
+        suite["randomly_rotate_tree_x10"] = @benchmarkable(
+            foreach(trees) do tree
+                SymbolicRegression.MutationFunctionsModule.randomly_rotate_tree!(tree)
+            end,
+            setup = (
+                T = Float64;
+                nfeatures = 3;
+                trees = [
+                    gen_random_tree_fixed_size(20, $options, nfeatures, T) for
+                    i in 1:($ntrees)
+                ]
+            )
         )
-    )
+    end
 
     suite["insert_random_op_x10"] = @benchmarkable(
         foreach(trees) do tree
-            insert_random_op(tree, $options, nfeatures)
+            SymbolicRegression.MutationFunctionsModule.insert_random_op(
+                tree, $options, nfeatures
+            )
         end,
         setup = (
             T = Float64;

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -27,7 +27,8 @@ using ..MutationFunctionsModule:
     delete_random_op!,
     crossover_trees,
     form_random_connection!,
-    break_random_connection!
+    break_random_connection!,
+    randomly_rotate_tree!
 using ..ConstantOptimizationModule: optimize_constants
 using ..RecorderModule: @recorder
 
@@ -258,6 +259,10 @@ function next_generation(
         elseif mutation_choice == :break_connection
             tree = break_random_connection!(tree)
             @recorder tmp_recorder["type"] = "break_connection"
+            is_success_always_possible = true
+        elseif mutation_choice == :rotate_tree
+            tree = randomly_rotate_tree!(tree)
+            @recorder tmp_recorder["type"] = "rotate_tree"
             is_success_always_possible = true
         else
             error("Unknown mutation choice: $mutation_choice")

--- a/src/MutationFunctions.jl
+++ b/src/MutationFunctions.jl
@@ -14,7 +14,7 @@ using DynamicExpressions:
     count_nodes,
     has_constants,
     has_operators
-using Compat: Returns, @inline, Fix
+using Compat: Returns, @inline
 using ..CoreModule: Options, DATA_TYPE
 
 """

--- a/src/MutationFunctions.jl
+++ b/src/MutationFunctions.jl
@@ -514,7 +514,7 @@ after which it will exit.
 function attach_to_parents!(tree::N, oldchild::N, newchild::N) where {N<:AbstractNode}
     attached = any(Fix{2}(Fix{3}(attach_to_parents_closure, newchild), oldchild), tree)
     #! format: off
-    !attached || throw(ArgumentError("Failed to attach node to any parent in $tree. Please file a bug report if this is unexpected."))
+    attached || throw(ArgumentError("Failed to attach node to any parent in $tree. Please file a bug report if this is unexpected."))
     #! format: on
     return nothing
 end

--- a/src/MutationFunctions.jl
+++ b/src/MutationFunctions.jl
@@ -480,6 +480,11 @@ function randomly_rotate_tree!(tree::AbstractNode, rng::AbstractRNG=default_rng(
         else
             # Need to attach to any parent of `node_5`, since `node_5`
             # was not the root node
+            # TODO: This doesn't feel very robust. For us to work around this
+            # in a clean way, we would need a sampler that returns the parent,
+            # OR have a separate sampling step for root nodes and sampling the parent
+            # node. Currently I feel that the way implemented currently is probably faster,
+            # but need testing.
             attach_to_parents!(tree, node_5, node_3)
             return tree
         end

--- a/src/MutationWeights.jl
+++ b/src/MutationWeights.jl
@@ -26,6 +26,7 @@ will be normalized to sum to 1.0 after initialization.
 - `break_connection::Float64`: **Only used for `GraphNode`, not regular `Node`**.
     Otherwise, this will automatically be set to 0.0. How often to break a
     connection between two nodes.
+- `rotate_tree::Float64`: How often to rotate the tree.
 """
 Base.@kwdef mutable struct MutationWeights
     mutate_constant::Float64 = 0.048
@@ -40,6 +41,7 @@ Base.@kwdef mutable struct MutationWeights
     optimize::Float64 = 0.0
     form_connection::Float64 = 0.5
     break_connection::Float64 = 0.1
+    rotate_tree::Float64 = 0.0
 end
 
 const mutations = fieldnames(MutationWeights)

--- a/src/MutationWeights.jl
+++ b/src/MutationWeights.jl
@@ -11,6 +11,7 @@ will be normalized to sum to 1.0 after initialization.
 - `mutate_constant::Float64`: How often to mutate a constant.
 - `mutate_operator::Float64`: How often to mutate an operator.
 - `swap_operands::Float64`: How often to swap the operands of a binary operator.
+- `rotate_tree::Float64`: How often to perform a tree rotation at a random node.
 - `add_node::Float64`: How often to append a node to the tree.
 - `insert_node::Float64`: How often to insert a node into the tree.
 - `delete_node::Float64`: How often to delete a node from the tree.
@@ -26,12 +27,12 @@ will be normalized to sum to 1.0 after initialization.
 - `break_connection::Float64`: **Only used for `GraphNode`, not regular `Node`**.
     Otherwise, this will automatically be set to 0.0. How often to break a
     connection between two nodes.
-- `rotate_tree::Float64`: How often to rotate the tree.
 """
 Base.@kwdef mutable struct MutationWeights
     mutate_constant::Float64 = 0.048
     mutate_operator::Float64 = 0.47
     swap_operands::Float64 = 0.1
+    rotate_tree::Float64 = 0.3
     add_node::Float64 = 0.79
     insert_node::Float64 = 5.1
     delete_node::Float64 = 1.7
@@ -41,7 +42,6 @@ Base.@kwdef mutable struct MutationWeights
     optimize::Float64 = 0.0
     form_connection::Float64 = 0.5
     break_connection::Float64 = 0.1
-    rotate_tree::Float64 = 0.0
 end
 
 const mutations = fieldnames(MutationWeights)

--- a/test/LocalPreferences.toml
+++ b/test/LocalPreferences.toml
@@ -1,7 +1,3 @@
-[DynamicExpressions]
-instability_check = "error"
-instability_check_codegen = "min"
-
 [SymbolicRegression]
 instability_check = "error"
 instability_check_codegen = "min"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,8 @@ end
     include("test_crossover.jl")
 end
 
+include("test_rotation.jl")
+
 # TODO: This is another very slow test
 @testitem "Test NaN detection in evaluator" tags = [:part1] begin
     include("test_nan_detection.jl")

--- a/test/test_rotation.jl
+++ b/test/test_rotation.jl
@@ -1,0 +1,56 @@
+@testitem "Basic `randomly_rotate_tree!`" tags = [:part1] begin
+    using SymbolicRegression
+    using SymbolicRegression.MutationFunctionsModule: randomly_rotate_tree!
+    using SymbolicRegression: Node
+
+    # Create a simple binary tree structure directly
+    options = Options(; binary_operators=(+, *, -, /), unary_operators=(cos, exp))
+    x1, x2, x3 = (Node(; feature=1), Node(; feature=2), Node(; feature=3))
+
+    # No-op:
+    @test randomly_rotate_tree!(x1) === x1
+
+    expr = 1.5 * x1 + x2
+
+    #  (+) -> ((*) -> (1.5, x1), x2)
+    # Should get rotated to
+    #  (*) -> (1.5, (+) -> (x1, x2))
+
+    @test randomly_rotate_tree!(copy(expr)) == 1.5 * (x1 + x2)
+
+    # The only rotation option on this tree is to rotate back:
+    @test randomly_rotate_tree!(randomly_rotate_tree!(copy(expr))) == expr
+end
+
+@testitem "Complex `randomly_rotate_tree!`" tags = [:part1] begin
+    using SymbolicRegression
+    using SymbolicRegression.MutationFunctionsModule: randomly_rotate_tree!
+    using SymbolicRegression: Node
+
+    # Create a simple binary tree structure directly
+    options = Options(; binary_operators=(+, *, -, /), unary_operators=(cos, exp))
+    x1, x2, x3 = (Node(; feature=1), Node(; feature=2), Node(; feature=3))
+
+    expr = (1.5 * x1) + (2.5 / x3)
+
+    # Multiple rotations possible:
+    #  (+) -> ((*) -> (1.5, x1), (/) -> (2.5, x3))
+    # This can either get rotated to
+    #  (*) -> (1.5, (+) -> (x1, (/) -> (2.5, x3)))
+    # OR
+    #  (/) -> ((+) -> ((*) -> (1.5, x1), 2.5), x3)
+
+    outs = Set([randomly_rotate_tree!(copy(expr)) for _ in 1:100])
+
+    @test outs == Set([((1.5 * x1) + 2.5) / x3, 1.5 * (x1 + (2.5 / x3))])
+
+    # Similarly, if we have a unary operator in the mix:
+    expr = (1.5 * exp(x1)) + (2.5 / x3)
+    outs = Set([randomly_rotate_tree!(copy(expr)) for _ in 1:100])
+    @test outs == Set([((1.5 * exp(x1)) + 2.5) / x3, 1.5 * (exp(x1) + (2.5 / x3))])
+
+    # Or, if the unary operator is at the top:
+    expr = exp((1.5 * x1) + (2.5 / x3))
+    outs = Set([randomly_rotate_tree!(copy(expr)) for _ in 1:100])
+    @test outs == Set([exp(((1.5 * x1) + 2.5) / x3), exp(1.5 * (x1 + (2.5 / x3)))])
+end


### PR DESCRIPTION
This implements a tree rotation as one of the mutation operators:

<img src="https://github.com/user-attachments/assets/6e45a215-fa3a-49d3-abbd-19df57ed4024" width="50%">

Though the code implementation here also covers unary operators – both as a root and as a pivot (and as both).

As an example, the expression $$1.5 \cdot \exp(x_1) + \frac{2.5}{x_3}$$ can randomly mutate into one of: $$\frac{(1.5 \cdot \exp(x_1)) + 2.5}{x_3},$$ $$1.5 \cdot \left(\exp(x_1) + \frac{2.5}{x_3}\right),$$ or $$\exp(1.5 \cdot x_1) + \frac{2.5}{x_3},$$.

Thanks to @larsentom for the idea.

~~This current implementation is a draft.~~ From watching the learning dynamics it definitely seems to help diversify the expressions (!) but we likely want to tune the default mutation weight.

- [x] It would also be nice to have `NodeSampler` be able to return parent nodes. Otherwise we either need to skip root nodes or do what I do currently which is do a second tree search for the parent - which seems inefficient. But maybe it is the best strategy, I'm not sure.