### PR TITLE
feat: allow user-specified `stdin`

### DIFF
--- a/src/Options.jl
+++ b/src/Options.jl
@@ -868,7 +868,6 @@ $(OPTION_DESCRIPTIONS)
         deprecated_return_state::Union{Bool,Nothing},
         typeof(_autodiff_backend),
         print_precision,
-        typeof(input_stream),
     }(
         operators,
         _bin_constraints,

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -419,6 +419,8 @@ const OPTION_DESCRIPTIONS = """- `defaults`: What set of defaults to use for `Op
     Function - a function taking (loss, complexity) as arguments and returning true or false.
 - `timeout_in_seconds`: Float64 - the time in seconds after which to exit (as an alternative to the number of iterations).
 - `max_evals`: Int (or Nothing) - the maximum number of evaluations of expressions to perform.
+- `input_stream`: the stream to read user input from. By default, this is `stdin`. If you encounter issues
+    with reading from `stdin`, like a hang, you can simply pass `devnull` to this argument.
 - `skip_mutation_failures`: Whether to simply skip over mutations that fail or are rejected, rather than to replace the mutated
     expression with the original expression and proceed normally.
 - `nested_constraints`: Specifies how many times a combination of operators can be nested. For example,
@@ -574,6 +576,7 @@ $(OPTION_DESCRIPTIONS)
     ## 10. Stopping Criteria:
     timeout_in_seconds::Union{Nothing,Real}=nothing,
     max_evals::Union{Nothing,Integer}=nothing,
+    input_stream::IO=stdin,
     ## 11. Performance and Parallelization:
     turbo::Bool=false,
     bumper::Bool=false,
@@ -865,6 +868,7 @@ $(OPTION_DESCRIPTIONS)
         deprecated_return_state::Union{Bool,Nothing},
         typeof(_autodiff_backend),
         print_precision,
+        typeof(input_stream),
     }(
         operators,
         _bin_constraints,
@@ -926,6 +930,7 @@ $(OPTION_DESCRIPTIONS)
         Val(deprecated_return_state),
         timeout_in_seconds,
         max_evals,
+        input_stream,
         skip_mutation_failures,
         _nested_constraints,
         deterministic,

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -189,7 +189,6 @@ struct Options{
     _return_state,
     AD,
     print_precision,
-    ST,
 } <: AbstractOptions
     operators::OP
     bin_constraints::Vector{Tuple{Int,Int}}
@@ -251,7 +250,7 @@ struct Options{
     return_state::Val{_return_state}
     timeout_in_seconds::Union{Float64,Nothing}
     max_evals::Union{Int,Nothing}
-    input_stream::ST
+    input_stream::IO
     skip_mutation_failures::Bool
     nested_constraints::Union{Vector{Tuple{Int,Int,Vector{Tuple{Int,Int,Int}}}},Nothing}
     deterministic::Bool

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -189,6 +189,7 @@ struct Options{
     _return_state,
     AD,
     print_precision,
+    ST,
 } <: AbstractOptions
     operators::OP
     bin_constraints::Vector{Tuple{Int,Int}}
@@ -250,6 +251,7 @@ struct Options{
     return_state::Val{_return_state}
     timeout_in_seconds::Union{Float64,Nothing}
     max_evals::Union{Int,Nothing}
+    input_stream::ST
     skip_mutation_failures::Bool
     nested_constraints::Union{Vector{Tuple{Int,Int,Vector{Tuple{Int,Int,Int}}}},Nothing}
     deterministic::Bool

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -578,7 +578,7 @@ end
 @stable default_mode = "disable" function _create_workers(
     datasets::Vector{D}, ropt::AbstractRuntimeOptions, options::AbstractOptions
 ) where {T,L,D<:Dataset{T,L}}
-    stdin_reader = watch_stream(stdin)
+    stdin_reader = watch_stream(options.input_stream)
 
     record = RecordType()
     @recorder record["options"] = "$(options)"


### PR DESCRIPTION
This lets the user specify a specific `IO` object to read user input from, which by default is `stdin`, but could also be some other stream.

This fixes #370.

@rafaelcuperman sorry you haven't received a response from the VSCode extension team, I think they are just pretty busy. In the meantime I hope this helps with your issue! You would just specify `input_stream=devnull` when running on your system and it should avoid the hang.