### PR TITLE
fix: make `:class` col more generic to `X` type

### DIFF
--- a/src/InterfaceDynamicExpressions.jl
+++ b/src/InterfaceDynamicExpressions.jl
@@ -359,4 +359,7 @@ function DE.EvaluationHelpersModule._grad_evaluator(
     )
 end
 
+# Allows special handling of class columns in MLJInterface.jl
+handles_class_column(::Type{<:AbstractExpression}) = false
+
 end

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -213,10 +213,12 @@ function _update(
     options,
     class,
 )
-    if IDE.handles_class_column(m.expression_type) &&
+    if (
+        IDE.handles_class_column(m.expression_type) &&
         isnothing(class) &&
         MMI.istable(X) &&
         :class in MMI.schema(X).names
+    )
         names_without_class = filter(!=(:class), MMI.schema(X).names)
         new_X = MMI.selectcols(X, collect(names_without_class))
         new_class = MMI.selectcols(X, :class)
@@ -490,10 +492,12 @@ function _predict(m::M, fitresult, Xnew, idx, class) where {M<:AbstractSRRegress
         )
         return _predict(m, fitresult, Xnew.data, Xnew.idx, class)
     end
-    if IDE.handles_class_column(m.expression_type) &&
+    if (
+        IDE.handles_class_column(m.expression_type) &&
         isnothing(class) &&
         MMI.istable(Xnew) &&
         :class in MMI.schema(Xnew).names
+    )
         names_without_class = filter(!=(:class), MMI.schema(Xnew).names)
         Xnew2 = MMI.selectcols(Xnew, collect(names_without_class))
         class = MMI.selectcols(Xnew, :class)

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -212,12 +212,10 @@ function _update(
     options,
     class,
 )
-    if isnothing(class) && MMI.istable(X) && haskey(X, :class)
-        if !(X isa NamedTuple)
-            error("Classes can only be specified with named tuples.")
-        end
-        new_X = Base.structdiff(X, (; X.class))
-        new_class = X.class
+    if isnothing(class) && MMI.istable(X) && :class in MMI.schema(X).names
+        names_without_class = filter(!=(:class), MMI.schema(X).names)
+        new_X = MMI.selectcols(X, collect(names_without_class))
+        new_class = MMI.selectcols(X, :class)
         return _update(
             m, verbosity, old_fitresult, old_cache, new_X, y, w, options, new_class
         )

--- a/src/ParametricExpression.jl
+++ b/src/ParametricExpression.jl
@@ -17,7 +17,7 @@ using Random: default_rng, AbstractRNG
 
 using ..CoreModule: AbstractOptions, Dataset, DATA_TYPE, AbstractMutationWeights
 using ..PopMemberModule: PopMember
-using ..InterfaceDynamicExpressionsModule: expected_array_type
+using ..InterfaceDynamicExpressionsModule: InterfaceDynamicExpressionsModule as IDE
 using ..LossFunctionsModule: LossFunctionsModule as LF
 using ..ExpressionBuilderModule: ExpressionBuilderModule as EB
 using ..MutateModule: MutateModule as MM
@@ -65,7 +65,7 @@ function DE.eval_tree_array(
     options::AbstractOptions;
     kws...,
 )
-    A = expected_array_type(X, typeof(tree))
+    A = IDE.expected_array_type(X, typeof(tree))
     out, complete = DE.eval_tree_array(
         tree,
         X,
@@ -80,7 +80,7 @@ end
 function LF.eval_tree_dispatch(
     tree::ParametricExpression, dataset::Dataset, options::AbstractOptions, idx
 )
-    A = expected_array_type(dataset.X, typeof(tree))
+    A = IDE.expected_array_type(dataset.X, typeof(tree))
     out, complete = DE.eval_tree_array(
         tree,
         LF.maybe_getindex(dataset.X, :, idx),
@@ -180,5 +180,8 @@ function MF.mutate_constant(
         return ex
     end
 end
+
+# ParametricExpression handles class columns
+IDE.handles_class_column(::Type{<:ParametricExpression}) = true
 
 end


### PR DESCRIPTION
@ablaom this should fix the issue you noticed with `rowtable(X)` types.

However this will currently result in type instability for NamedTuple input since I have to `collect` the columns due to this issue: https://github.com/JuliaAI/MLJModelInterface.jl/issues/214. But it does fix the issue for other types.