### PR TITLE
Create `loss_function_expression` for custom loss functions on template expressions

### DIFF
--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -144,10 +144,12 @@ function eval_loss(
 )::L where {T<:DATA_TYPE,L<:LOSS_TYPE}
     loss_val = if !isnothing(options.loss_function)
         f = options.loss_function::Function
-        evaluator(f, get_tree(tree)::AbstractExpressionNode, dataset, options, idx)
+        inner_tree = tree isa AbstractExpression ? get_tree(tree) : tree
+        evaluator(f, inner_tree, dataset, options, idx)
     elseif !isnothing(options.loss_function_expression)
         f = options.loss_function_expression::Function
-        evaluator(f, tree::AbstractExpression, dataset, options, idx)
+        @assert tree isa AbstractExpression
+        evaluator(f, tree, dataset, options, idx)
     else
         _eval_loss(tree, dataset, options, regularization, idx)
     end

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -114,7 +114,7 @@ end
 # This evaluates function F:
 function evaluator(
     f::F,
-    tree::AbstractExpressionNode{T},
+    tree::Union{AbstractExpressionNode{T},AbstractExpression{T}},
     dataset::Dataset{T,L},
     options::AbstractOptions,
     idx,
@@ -142,11 +142,14 @@ function eval_loss(
     regularization::Bool=true,
     idx=nothing,
 )::L where {T<:DATA_TYPE,L<:LOSS_TYPE}
-    loss_val = if options.loss_function === nothing
-        _eval_loss(tree, dataset, options, regularization, idx)
-    else
+    loss_val = if !isnothing(options.loss_function)
         f = options.loss_function::Function
-        evaluator(f, get_tree(tree), dataset, options, idx)
+        evaluator(f, get_tree(tree)::AbstractExpressionNode, dataset, options, idx)
+    elseif !isnothing(options.loss_function_expression)
+        f = options.loss_function_expression::Function
+        evaluator(f, tree::AbstractExpression, dataset, options, idx)
+    else
+        _eval_loss(tree, dataset, options, regularization, idx)
     end
 
     return loss_val

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -235,6 +235,8 @@ function inverse_unaopmap(@nospecialize(op))
     return op
 end
 
+recommend_loss_function_expression(expression_type) = false
+
 create_mutation_weights(w::AbstractMutationWeights) = w
 create_mutation_weights(w::NamedTuple) = MutationWeights(; w...)
 
@@ -732,6 +734,13 @@ $(OPTION_DESCRIPTIONS)
         count(!isnothing, [elementwise_loss, loss_function, loss_function_expression]) <= 1,
         "You cannot specify more than one of `elementwise_loss`, `loss_function`, and `loss_function_expression`."
     )
+
+    if !isnothing(loss_function) && recommend_loss_function_expression(expression_type)
+        @warn(
+            "You are using `loss_function` with `$(expression_type)`. " *
+                "You should use `loss_function_expression` instead, as it is designed to work with expressions directly."
+        )
+    end
 
     elementwise_loss = something(elementwise_loss, L2DistLoss())
 

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -339,6 +339,7 @@ const OPTION_DESCRIPTIONS = """- `defaults`: What set of defaults to use for `Op
             return sum((prediction .- dataset.y) .^ 2) / dataset.n
         end
 
+- `loss_function_expression`: Similar to `loss_function`, but takes `AbstractExpression` instead of `AbstractExpressionNode` as its first argument. Useful for `TemplateExpressionSpec`.
 - `expression_spec::AbstractExpressionSpec`: A specification of what types of expressions to use in the
     search. For example, `ExpressionSpec()` (default). You can also see `TemplateExpressionSpec` and
     `ParametricExpressionSpec` for specialized cases.
@@ -501,6 +502,7 @@ $(OPTION_DESCRIPTIONS)
     ## 3. The Objective:
     @nospecialize(elementwise_loss::Union{Function,SupervisedLoss,Nothing} = nothing),
     @nospecialize(loss_function::Union{Function,Nothing} = nothing),
+    @nospecialize(loss_function_expression::Union{Function,Nothing} = nothing),
     ###           [model_selection - only used in MLJ interface]
     @nospecialize(dimensional_constraint_penalty::Union{Nothing,Real} = nothing),
     ###           dimensionless_constants_only
@@ -726,17 +728,18 @@ $(OPTION_DESCRIPTIONS)
         error("`output_file` is deprecated. Use `output_directory` instead.")
     end
 
-    if elementwise_loss === nothing
-        elementwise_loss = L2DistLoss()
-    else
-        if loss_function !== nothing
-            error("You cannot specify both `elementwise_loss` and `loss_function`.")
-        end
-    end
+    @assert(
+        count(!isnothing, [elementwise_loss, loss_function, loss_function_expression]) <= 1,
+        "You cannot specify more than one of `elementwise_loss`, `loss_function`, and `loss_function_expression`."
+    )
+
+    elementwise_loss = something(elementwise_loss, L2DistLoss())
+
     if complexity_mapping !== nothing
-        @assert complexity_of_operators === nothing &&
-            complexity_of_constants === nothing &&
-            complexity_of_variables === nothing
+        @assert all(
+            isnothing,
+            [complexity_of_operators, complexity_of_constants, complexity_of_variables],
+        )
     end
 
     #################################
@@ -973,6 +976,7 @@ $(OPTION_DESCRIPTIONS)
         seed,
         elementwise_loss,
         loss_function,
+        loss_function_expression,
         node_type,
         expression_type,
         expression_options,

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -234,6 +234,7 @@ struct Options{
     seed::Union{Int,Nothing}
     elementwise_loss::Union{SupervisedLoss,Function}
     loss_function::Union{Nothing,Function}
+    loss_function_expression::Union{Nothing,Function}
     node_type::Type{N}
     expression_type::Type{E}
     expression_options::EO

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -720,6 +720,8 @@ function CM.operator_specialization(
     return O
 end
 
+CM.OptionsModule.recommend_loss_function_expression(::Type{<:TemplateExpression}) = true
+
 function CM.max_features(
     dataset::Dataset, options::Options{<:Any,<:Any,<:Any,<:TemplateExpression}
 )

--- a/test/test_params.jl
+++ b/test/test_params.jl
@@ -8,7 +8,7 @@ ENV["SYMBOLIC_REGRESSION_IS_TESTING"] = "true"
 
 empty_all_globals!()
 
-const maximum_residual = 1e-2
+const maximum_residual = 2e-2
 
 if !@isdefined(custom_cos) || !hasmethod(custom_cos, (String,))
     @eval custom_cos(x) = cos(x)

--- a/test/test_template_expression.jl
+++ b/test/test_template_expression.jl
@@ -447,3 +447,117 @@ end
     # n.b., we can't actually test whether turbo is used here,
     # this is basically just a smoke test
 end
+
+@testitem "loss_function_expression with expressions and templates" tags = [:part3] begin
+    using SymbolicRegression
+    using SymbolicRegression: AbstractOptions
+    using SymbolicRegression.LossFunctionsModule: eval_loss
+
+    # Define realistic loss functions for testing
+    function tree_loss(
+        tree::AbstractExpressionNode, dataset::Dataset, options::AbstractOptions
+    )
+        output, completed = eval_tree_array(tree, dataset.X, options)
+        !completed && return Inf
+        return sum(abs2, output .- dataset.y) / length(dataset.y)
+    end
+
+    function expr_loss(ex::AbstractExpression, dataset::Dataset, options::AbstractOptions)
+        output, completed = eval_tree_array(ex, dataset.X, options)
+        !completed && return Inf
+        return sum(abs2, output .- dataset.y) / length(dataset.y)
+    end
+
+    function expr_loss_batched(
+        ex::AbstractExpression, dataset::Dataset, options::AbstractOptions, idx
+    )
+        if idx === nothing
+            return expr_loss(ex, dataset, options)
+        end
+        output, completed = eval_tree_array(ex, dataset.X[:, idx], options)
+        !completed && return Inf
+        return sum(abs2, output .- dataset.y[idx]) / length(idx)
+    end
+
+    # Test they can't be used together
+    @test_throws "You cannot specify more than one" Options(;
+        binary_operators=[+, *], loss_function=tree_loss, loss_function_expression=expr_loss
+    )
+
+    # Test regular expression loss
+    options = Options(; binary_operators=[+, *], loss_function_expression=expr_loss)
+
+    # Create a simple dataset where y = 2x₁ + x₂²
+    X = Float32[1.0 2.0 3.0; 2.0 3.0 4.0; 0.0 0.0 0.0]  # 3x3 array
+    y = Float32[2.0 * X[1, i] + X[2, i]^2 for i in 1:3]  # y = 2x₁ + x₂²
+    d = Dataset(X, y)
+
+    # Create an expression that should give a constant 1.0
+    ex = Expression(Node(Float32; val=1.0); operators=options.operators)
+    expected_loss = sum(abs2, ones(Float32, 3) .- y) / 3  # MSE for constant 1.0
+    @test expr_loss(ex, d, options) ≈ expected_loss
+
+    # Create an expression that matches the true function: 2x₁ + x₂²
+    ex = Expression(
+        2.0f0 * Node(Float32; feature=1) +
+        Node(Float32; feature=2) * Node(Float32; feature=2);
+        operators=options.operators,
+    )
+    @test expr_loss(ex, d, options) < 1e-10
+
+    # Test that it errors with a tree instead of expression
+    @test_throws ErrorException eval_loss(Node(Float32; val=1.0), d, options)
+
+    # Test batched version
+    options = Options(;
+        binary_operators=[+, *],
+        loss_function_expression=expr_loss_batched,
+        batching=true,
+        batch_size=5,
+    )
+    # Test with full dataset (idx=nothing):
+    @test expr_loss_batched(ex, d, options, nothing) < 1e-10
+    # Test with subset of data:
+    idx = [1, 2]
+    @test expr_loss_batched(ex, d, options, idx) < 1e-10
+
+    # Test with template expressions
+    template = @template(expressions = (f,), parameters = (p=2,)) do x
+        f(x) + sum(p)
+    end
+
+    # Create template expression with parameters
+    options = Options(;
+        binary_operators=[+, *],
+        expression_spec=template,
+        loss_function_expression=expr_loss,
+    )
+    x = ComposableExpression(Node{Float32}(; feature=1); operators=options.operators)
+    template_ex = TemplateExpression(
+        (; f=x);
+        structure=template.structure,
+        operators=options.operators,
+        parameters=(; p=[1.0f0, 2.0f0]),
+    )
+
+    # Test template expression works with loss_function_expression
+    # Template evaluates to: x₁ + (1.0 + 2.0)
+    # Expected output: [4.0, 5.0, 6.0]
+    expected_template_loss = sum(abs2, [4.0f0, 5.0f0, 6.0f0] .- y) / 3
+    loss = expr_loss(template_ex, d, options)
+    @test loss ≈ expected_template_loss
+
+    # Test batched version with template expression
+    options = Options(;
+        binary_operators=[+, *],
+        expression_spec=template,
+        loss_function_expression=expr_loss_batched,
+        batching=true,
+        batch_size=5,
+    )
+    # Test with subset of data:
+    idx = [1, 2]
+    expected_batch_loss = sum(abs2, [4.0f0, 5.0f0] .- y[idx]) / 2
+    loss_batch = expr_loss_batched(template_ex, d, options, idx)
+    @test loss_batch ≈ expected_batch_loss
+end

--- a/test/test_template_expression.jl
+++ b/test/test_template_expression.jl
@@ -561,3 +561,16 @@ end
     loss_batch = expr_loss_batched(template_ex, d, options, idx)
     @test loss_batch ≈ expected_batch_loss
 end
+
+@testitem "warning for loss_function with TemplateExpression" begin
+    using SymbolicRegression
+
+    @test_warn(
+        "You are using `loss_function` with",
+        Options(;
+            binary_operators=[+, *],
+            loss_function=Returns(1.0),
+            expression_type=TemplateExpression,
+        )
+    )
+end

--- a/test/test_template_expression.jl
+++ b/test/test_template_expression.jl
@@ -506,7 +506,7 @@ end
     @test expr_loss(ex, d, options) < 1e-10
 
     # Test that it errors with a tree instead of expression
-    @test_throws TypeError eval_loss(Node{Float32}(; val=1.0), d, options)
+    @test_throws AssertionError eval_loss(Node{Float32}(; val=1.0), d, options)
 
     # Test batched version
     options = Options(;


### PR DESCRIPTION
Creates `loss_function_expression` so you can use custom losses on template expressions.

@moelf @gm89uk @fcogneaux


Fixes https://github.com/MilesCranmer/SymbolicRegression.jl/issues/380