### PR TITLE
refactor: rename to `.cost`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ import SymbolicRegression: calculate_pareto_frontier
 dominating = calculate_pareto_frontier(hall_of_fame)
 ```
 
-This is a vector of `PopMember` type - which contains the expression along with the score.
+This is a vector of `PopMember` type - which contains the expression along with the cost.
 We can get the expressions with:
 
 ```julia

--- a/benchmark/family_tree.py
+++ b/benchmark/family_tree.py
@@ -12,7 +12,7 @@ def load_pysr_graph(json_path, progress=True):
 
     Returns:
         NetworkX DiGraph with:
-        - Node attributes: tree, score, loss, parent
+        - Node attributes: tree, cost, loss, parent
         - Edge attributes: type, time, mutation_details
     """
     # Load JSON data
@@ -176,7 +176,7 @@ def simplify_graph(G):
 
         simple_G.add_node(
             node,
-            score=data.get("score"),
+            cost=data.get("cost"),
             loss=data.get("loss"),
             tree=tree,
             display_tree=display_tree,

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -91,7 +91,7 @@ These types allow you to define expressions with parameters that can be tuned to
 ## Population
 
 Groups of equations are given as a population, which is
-an array of trees tagged with score, loss, and birthdate---these
+an array of trees tagged with cost, loss, and birthdate---these
 values are given in the `PopMember`.
 
 ```@docs

--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -14,7 +14,7 @@ using DynamicExpressions:
 using ..CoreModule:
     AbstractOptions, Dataset, DATA_TYPE, LOSS_TYPE, specialized_options, dataset_fraction
 using ..UtilsModule: get_birth_order
-using ..LossFunctionsModule: eval_loss, loss_to_score
+using ..LossFunctionsModule: eval_loss, loss_to_cost
 using ..PopMemberModule: PopMember
 
 function optimize_constants(
@@ -79,7 +79,7 @@ function _optimize_constants(
     if result.minimum < baseline
         member.tree = tree
         member.loss = f(result.minimizer; regularization=true)
-        member.score = loss_to_score(
+        member.cost = loss_to_cost(
             member.loss, dataset.use_baseline, dataset.baseline_loss, member, options
         )
         member.birth = get_birth_order(; deterministic=options.deterministic)

--- a/src/ExpressionBuilder.jl
+++ b/src/ExpressionBuilder.jl
@@ -111,7 +111,7 @@ end
     ) where {T,L}
         return PopMember(
             embed_metadata(member.tree, options, dataset),
-            member.score,
+            member.cost,
             member.loss,
             nothing;
             member.ref,
@@ -157,7 +157,7 @@ function strip_metadata(
 ) where {T,L}
     return PopMember(
         strip_metadata(member.tree, options, dataset),
-        member.score,
+        member.cost,
         member.loss,
         nothing;
         member.ref,

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -165,8 +165,8 @@ get_tree_from_member(m) = m.tree
 # losses to use the PopMember's cached complexity for trees.
 # TODO!
 
-# Compute a score which includes a complexity penalty in the loss
-function loss_to_score(
+# Compute a cost which includes a complexity penalty in the loss
+function loss_to_cost(
     loss::L,
     use_baseline::Bool,
     baseline::L,
@@ -189,14 +189,14 @@ function loss_to_score(
 end
 
 # Score an equation
-function score_func(
+function eval_cost(
     dataset::Dataset{T,L},
     member,
     options::AbstractOptions;
     complexity::Union{Int,Nothing}=nothing,
 )::Tuple{L,L} where {T<:DATA_TYPE,L<:LOSS_TYPE}
     result_loss = eval_loss(get_tree_from_member(member), dataset, options)
-    score = loss_to_score(
+    cost = loss_to_cost(
         result_loss,
         dataset.use_baseline,
         dataset.baseline_loss,
@@ -204,8 +204,11 @@ function score_func(
         options,
         complexity,
     )
-    return score, result_loss
+    return cost, result_loss
 end
+
+# Deprecated form
+function score_func end
 
 """
     update_baseline_loss!(dataset::Dataset{T,L}, options::AbstractOptions) where {T<:DATA_TYPE,L<:LOSS_TYPE}

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -27,7 +27,9 @@ end
     elseif field == :tree
         setfield!(member, :complexity, -1)
     elseif field == :score
-        Base.depwarn("Use `cost` instead of `score`.", Symbol(:setproperty!, :PopMember))
+        Base.depwarn(
+            "deprecated: use `cost` instead of `score`.", Symbol(:setproperty!, :PopMember)
+        )
         return setfield!(member, :cost, value)
     end
     return setfield!(member, field, value)
@@ -38,7 +40,9 @@ end
             error("Don't access `.complexity` directly. Use `compute_complexity` instead.")
         )
     elseif field == :score
-        Base.depwarn("Use `cost` instead of `score`.", Symbol(:getproperty, :PopMember))
+        Base.depwarn(
+            "deprecated: use `cost` instead of `score`.", Symbol(:getproperty, :PopMember)
+        )
         return getfield(member, :cost)
     end
     return getfield(member, field)

--- a/src/RegularizedEvolution.jl
+++ b/src/RegularizedEvolution.jl
@@ -53,7 +53,7 @@ function reg_evol_cycle(
                         record["mutations"]["$(member.ref)"] = RecordType(
                             "events" => Vector{RecordType}(),
                             "tree" => string_tree(member.tree, options),
-                            "score" => member.score,
+                            "cost" => member.cost,
                             "loss" => member.loss,
                             "parent" => member.parent,
                         )
@@ -118,7 +118,7 @@ function reg_evol_cycle(
                         record["mutations"]["$(member.ref)"] = RecordType(
                             "events" => Vector{RecordType}(),
                             "tree" => string_tree(member.tree, options),
-                            "score" => member.score,
+                            "cost" => member.cost,
                             "loss" => member.loss,
                             "parent" => member.parent,
                         )

--- a/src/SearchUtils.jl
+++ b/src/SearchUtils.jl
@@ -686,7 +686,7 @@ function update_hall_of_fame!(
             continue
         end
         not_filled = !hall_of_fame.exists[size]
-        better_than_current = member.score < hall_of_fame.members[size].score
+        better_than_current = member.cost < hall_of_fame.members[size].cost
         if not_filled || better_than_current
             hall_of_fame.members[size] = copy(member)
             hall_of_fame.exists[size] = true

--- a/src/SingleIteration.jl
+++ b/src/SingleIteration.jl
@@ -6,11 +6,11 @@ using ..UtilsModule: @threads_if
 using ..CoreModule: AbstractOptions, Dataset, RecordType, create_expression, batch
 using ..ComplexityModule: compute_complexity
 using ..PopMemberModule: generate_reference
-using ..PopulationModule: Population, finalize_scores
+using ..PopulationModule: Population, finalize_costs
 using ..HallOfFameModule: HallOfFame
 using ..AdaptiveParsimonyModule: RunningSearchStatistics
 using ..RegularizedEvolutionModule: reg_evol_cycle
-using ..LossFunctionsModule: score_func
+using ..LossFunctionsModule: eval_cost
 using ..ConstantOptimizationModule: optimize_constants
 using ..RecorderModule: @recorder
 
@@ -54,7 +54,7 @@ function s_r_cycle(
             size = compute_complexity(member, options)
             if 0 < size <= options.maxsize && (
                 !best_examples_seen.exists[size] ||
-                member.score < best_examples_seen.members[size].score
+                member.cost < best_examples_seen.members[size].cost
             )
                 best_examples_seen.exists[size] = true
                 best_examples_seen.members[size] = copy(member)
@@ -89,7 +89,7 @@ function optimize_and_simplify_population(
         end
     end
     num_evals = sum(array_num_evals)
-    pop, tmp_num_evals = finalize_scores(dataset, pop, options)
+    pop, tmp_num_evals = finalize_costs(dataset, pop, options)
     num_evals += tmp_num_evals
 
     # Now, we create new references for every member,
@@ -109,7 +109,7 @@ function optimize_and_simplify_population(
                 record["mutations"]["$(member.ref)"] = RecordType(
                     "events" => Vector{RecordType}(),
                     "tree" => string_tree(member.tree, options),
-                    "score" => member.score,
+                    "cost" => member.cost,
                     "loss" => member.loss,
                     "parent" => member.parent,
                 )

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -1,8 +1,18 @@
 using Base: @deprecate
 
+import .LossFunctionsModule: score_func
 import .HallOfFameModule: calculate_pareto_frontier
 import .MutationFunctionsModule: gen_random_tree, gen_random_tree_fixed_size
 
+@deprecate(
+    score_func(
+        dataset::Dataset{T,L},
+        member,
+        options::AbstractOptions;
+        complexity::Union{Int,Nothing}=nothing,
+    ) where {T<:DATA_TYPE,L<:LOSS_TYPE},
+    eval_cost(dataset, member, options; complexity),
+)
 @deprecate(
     calculate_pareto_frontier(X, y, hallOfFame, options; weights=nothing),
     calculate_pareto_frontier(hallOfFame)

--- a/test/manual_distributed.jl
+++ b/test/manual_distributed.jl
@@ -27,5 +27,5 @@ rmprocs(procs)
 
 dominating = calculate_pareto_frontier(hallOfFame)
 best = dominating[end]
-# Test the score
+# Test the cost
 @test best.loss < maximum_residual / 10

--- a/test/test_deprecation.jl
+++ b/test/test_deprecation.jl
@@ -15,3 +15,30 @@ options = Options(;
 
 options = Options(; mutationWeights=[1.0 for i in 1:8])
 @test options.mutation_weights.add_node == 1.0
+
+# Test score_func deprecation
+X = randn(3, 5)
+y = randn(5)
+dataset = Dataset(X, y)
+options = Options()
+tree = Node(; val=1.0)
+
+using SymbolicRegression: score_func, eval_cost
+
+@test_deprecated score_func(dataset, tree, options) == eval_cost(dataset, tree, options)
+
+# Test PopMember score deprecation warnings
+X = randn(3, 5)
+y = randn(5)
+dataset = Dataset(X, y)
+options = Options()
+tree = Node(; val=1.0)
+member = PopMember(dataset, tree, options; deterministic=true)
+
+# Test that accessing .score triggers deprecation warning
+@test_deprecated member.score
+@test (@test_deprecated member.score) == member.cost
+
+# Test that setting .score triggers deprecation warning
+@test_deprecated member.score = 0.5
+@test member.cost == 0.5

--- a/test/test_fast_cycle.jl
+++ b/test/test_fast_cycle.jl
@@ -21,7 +21,7 @@ dominating = calculate_pareto_frontier(hall_of_fame)
 
 best = dominating[end]
 
-# Test the score
+# Test the cost
 @test best.loss < maximum_residual / 10
 
 # Do search again, but with saved state:

--- a/test/test_mixed_utils.jl
+++ b/test/test_mixed_utils.jl
@@ -126,7 +126,7 @@ function test_mixed(i, batching::Bool, weighted::Bool, parallelism)
         # Assert we created the correct type of trees:
         @test node_type(typeof(best.tree)) == Node{T}
 
-        # Test the score
+        # Test the cost
         @test best.loss < maximum_residual
         # Test the actual equation found:
         testX = randn(MersenneTwister(1), T, 5, 100)

--- a/test/test_pretty_printing.jl
+++ b/test/test_pretty_printing.jl
@@ -12,15 +12,15 @@
     y = [2.0, 3.0, 4.0]
     dataset = Dataset(X, y)
     member = PopMember(dataset, ex, options; deterministic=false)
-    member.score = 1.0
+    member.cost = 1.0
     @test member isa PopMember{Float64,Float64,<:Expression{Float64,Node{Float64}}}
     s_member = shower(member)
-    @test s_member == "PopMember(tree = ((x ^ 2.0) + 1.5), loss = 16.25, score = 1.0)"
+    @test s_member == "PopMember(tree = ((x ^ 2.0) + 1.5), loss = 16.25, cost = 1.0)"
 
     # New options shouldn't change this
     options = Options(; binary_operators=[-, /])
     s_member = shower(member)
-    @test s_member == "PopMember(tree = ((x ^ 2.0) + 1.5), loss = 16.25, score = 1.0)"
+    @test s_member == "PopMember(tree = ((x ^ 2.0) + 1.5), loss = 16.25, cost = 1.0)"
 end
 
 @testitem "pretty print hall of fame" tags = [:part1] begin
@@ -41,7 +41,7 @@ end
     y = [2.0, 3.0, 4.0]
     dataset = Dataset(X, y)
     member = PopMember(dataset, ex, options; deterministic=false)
-    member.score = 1.0
+    member.cost = 1.0
     @test member isa PopMember{Float64,Float64,<:Expression{Float64,Node{Float64}}}
 
     hof = HallOfFame(options, dataset)
@@ -59,7 +59,7 @@ end
     .exists[4] = false
     .members[4] = undef
     .exists[5] = true
-    .members[5] = PopMember(tree = ((x ^ 2.0) + 1.5), loss = 16.25, score = 1.0)
+    .members[5] = PopMember(tree = ((x ^ 2.0) + 1.5), loss = 16.25, cost = 1.0)
     .exists[6] = false
     .members[6] = undef
     .exists[7] = false

--- a/test/test_prob_pick_first.jl
+++ b/test/test_prob_pick_first.jl
@@ -23,12 +23,12 @@ for reverse in [false, true]
             ex = @parse_expression(
                 x1 * 3.2, operators = options.operators, variable_names = [:x1],
             )
-            score = Float32(i - 1) / (n - 1)
+            cost = Float32(i - 1) / (n - 1)
             if reverse
-                score = 1 - score
+                cost = 1 - cost
             end
             test_loss = 1.0f0  # (arbitrary for this test)
-            PopMember(ex, score, test_loss, options; deterministic=false)
+            PopMember(ex, cost, test_loss, options; deterministic=false)
         end for i in 1:n
     ]
 
@@ -38,13 +38,13 @@ for reverse in [false, true]
         options=options
     )
     best_pop_member = [
-        SymbolicRegression.best_of_sample(pop, dummy_running_stats, options).score for
+        SymbolicRegression.best_of_sample(pop, dummy_running_stats, options).cost for
         j in 1:100
     ]
 
     mean_value = sum(best_pop_member) / length(best_pop_member)
 
-    # Make sure average score is small
+    # Make sure average cost is small
     @test mean_value < 0.1
 end
 

--- a/test/test_recorder.jl
+++ b/test/test_recorder.jl
@@ -39,7 +39,7 @@ end
 # Check whether 10 random elements have the right properties:
 for (i, key) in enumerate(keys(data.mutations))
     @test haskey(data.mutations[key], :events)
-    @test haskey(data.mutations[key], :score)
+    @test haskey(data.mutations[key], :cost)
     @test haskey(data.mutations[key], :tree)
     @test haskey(data.mutations[key], :loss)
     @test haskey(data.mutations[key], :parent)

--- a/test/test_tree_construction.jl
+++ b/test/test_tree_construction.jl
@@ -1,7 +1,7 @@
 using SymbolicRegression
 using Random
 using Compat: Fix
-using SymbolicRegression: eval_loss, score_func, Dataset
+using SymbolicRegression: eval_loss, eval_cost, Dataset
 using ForwardDiff
 include("test_params.jl")
 
@@ -91,19 +91,19 @@ for unaop in
             # Test loss:
             @test abs(eval_loss(tree, dataset, make_options())) < zero_tolerance
             @test eval_loss(tree, dataset, make_options()) ==
-                score_func(dataset, tree, make_options())[2]
+                eval_cost(dataset, tree, make_options())[2]
 
             #Test Scoring
-            @test abs(score_func(dataset, tree, make_options(; parsimony=0.0))[1]) <
+            @test abs(eval_cost(dataset, tree, make_options(; parsimony=0.0))[1]) <
                 zero_tolerance
-            @test score_func(dataset, tree, make_options(; parsimony=1.0))[1] > 1.0
-            @test score_func(dataset, tree, make_options())[1] <
-                score_func(dataset, tree_bad, make_options())[1]
+            @test eval_cost(dataset, tree, make_options(; parsimony=1.0))[1] > 1.0
+            @test eval_cost(dataset, tree, make_options())[1] <
+                eval_cost(dataset, tree_bad, make_options())[1]
 
             dataset_with_larger_baseline = deepcopy(dataset)
             dataset_with_larger_baseline.baseline_loss = one(T) * 10
-            @test score_func(dataset_with_larger_baseline, tree_bad, make_options())[1] <
-                score_func(dataset, tree_bad, make_options())[1]
+            @test eval_cost(dataset_with_larger_baseline, tree_bad, make_options())[1] <
+                eval_cost(dataset, tree_bad, make_options())[1]
 
             # Test gradients:
             df_true = x -> ForwardDiff.derivative(f_true, x)

--- a/test/user_defined_operator.jl
+++ b/test/user_defined_operator.jl
@@ -15,5 +15,5 @@ hallOfFame = equation_search(
 dominating = calculate_pareto_frontier(X, y, hallOfFame, options)
 
 best = dominating[end]
-# Test the score
+# Test the cost
 @test best.loss < maximum_residual / 10


### PR DESCRIPTION
To be merged after #421.

Basically, `.score` is a terrible internal name for two reasons:

1. score implies it should be maximized, which is the opposite of the use
2. "score" is actually printed out when printing the hall of fame, and this has a completely different meaning.

basically, `cost` makes way more sense. Should have done this a long time ago.

Anyways, this is completely backwards compatible.