### PR TITLE
deps: limit ProgressMeter.jl to fix downstream bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicRegression"
 uuid = "8254be44-1295-4e6a-a16d-46603ac705cb"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "1.9.0"
+version = "1.9.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -63,7 +63,7 @@ Optim = "1.8 - 1.11"
 Pkg = "<0.0.1, 1"
 PrecompileTools = "1"
 Printf = "<0.0.1, 1"
-ProgressMeter = "1.10"
+ProgressMeter = "1.10.0 - 1.10.2"
 Random = "<0.0.1, 1"
 Reexport = "1"
 SpecialFunctions = "0.10.1, 1, 2"


### PR DESCRIPTION
Fixes https://github.com/MilesCranmer/SymbolicRegression.jl/issues/435; Fixes https://github.com/MilesCranmer/PySR/issues/889

This issue was due to https://github.com/timholy/ProgressMeter.jl/issues/343

It looks like ProgressMeter.jl isn't following SemVer (https://github.com/timholy/ProgressMeter.jl/releases) so I'm also going to lock the version to specific patches to be safe. Seems like it's being actively developed with new features every patch increment.