### PR TITLE
Unused `TemplateExpression` in template_expression_complex.jl

### DIFF
--- a/examples/template_expression_complex.jl
+++ b/examples/template_expression_complex.jl
@@ -250,14 +250,16 @@ ex = TemplateExpression(
 So we can see that it prints the expression as we've defined it.
 
 Now, we can create a regressor that builds template expressions
-which follow this structure!
+which follow this structure, by defining a `TemplateExpressionSpec`
+which wraps the `structure` object. This will result in generating
+expressions like the above `ex` object.
 =#
 model = SRRegressor(;
     binary_operators=(+, -, *, /),
     unary_operators=(sin, cos, sqrt, exp),
     niterations=500,
     maxsize=35,
-    expression_spec=ex,
+    expression_spec=TemplateExpressionSpec(; structure),
     ## Note that the elementwise loss needs to operate directly on each row of `y`:
     elementwise_loss=(F1, F2) -> (F1.x - F2.x)^2 + (F1.y - F2.y)^2 + (F1.z - F2.z)^2,
     batching=true,

--- a/examples/template_expression_complex.jl
+++ b/examples/template_expression_complex.jl
@@ -257,7 +257,7 @@ model = SRRegressor(;
     unary_operators=(sin, cos, sqrt, exp),
     niterations=500,
     maxsize=35,
-    expression_spec=TemplateExpressionSpec(; structure),
+    expression_spec=ex,
     ## Note that the elementwise loss needs to operate directly on each row of `y`:
     elementwise_loss=(F1, F2) -> (F1.x - F2.x)^2 + (F1.y - F2.y)^2 + (F1.z - F2.z)^2,
     batching=true,


### PR DESCRIPTION
```julia
ex = TemplateExpression(
    (; B_x, B_y, B_z, F_d_scale);
    structure, operators, variable_names
)
```

is un-used, should it be used?