### PR TITLE
fix `@template_spec` doc string

### DIFF
--- a/src/TemplateExpressionMacro.jl
+++ b/src/TemplateExpressionMacro.jl
@@ -5,7 +5,7 @@ module TemplateExpressionMacroModule
         parameters=(p1=10, p2=10, p3=1),
         expressions=(f, g),
     ) do x1, x2, class
-        return p1[class] * g(x1^2) + f(x1, x2, p2[class]) - p3[1],
+        return p1[class] * g(x1^2) + f(x1, x2, p2[class]) - p3[1]
     end
 
 (Experimental) Creates a TemplateExpressionSpec with the given parameters and expressions.


### PR DESCRIPTION
the original doc string results in parse error:
```julia
ParseError:
# Error @ ]8;;file:///home/jiling/.julia/environments/BjetTLA/notebooks/In[26]#6:1\In[26]:6:1]8;;\
    return p1[class] * g(x1^2) + f(x1, x2, p2[class]) - p3[1],
end
└─┘ ── invalid identifier
```