### PR TITLE
feat: allow negative losses

### DIFF
--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -136,8 +136,7 @@ function string_dominating_pareto_curve(
     hallOfFame, dataset, options; width::Union{Integer,Nothing}=nothing, pretty::Bool=true
 )
     terminal_width = (width === nothing) ? 100 : max(100, width::Integer)
-    _buffer = IOBuffer()
-    buffer = AnnotatedIOBuffer(_buffer)
+    buffer = AnnotatedIOBuffer(IOBuffer())
     println(buffer, '─'^(terminal_width - 1))
     if show_score_column(options)
         println(buffer, HEADER)
@@ -188,8 +187,8 @@ end
 function wrap_equation_string(eqn_string, left_cols_width, terminal_width)
     dots = "..."
     equation_width = (terminal_width - 1) - left_cols_width - length(dots)
-    _buffer = IOBuffer()
-    buffer = AnnotatedIOBuffer(_buffer)
+
+    buffer = AnnotatedIOBuffer(IOBuffer())
 
     forced_split_eqn = split(eqn_string, '\n')
     print_pad = false

--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -130,6 +130,8 @@ let header_parts = (
     @eval const HEADER_WITHOUT_SCORE = join($(header_parts[[1, 2, 4]]), "  ")
 end
 
+show_score_column(options::AbstractOptions) = options.loss_scale == :log
+
 function string_dominating_pareto_curve(
     hallOfFame, dataset, options; width::Union{Integer,Nothing}=nothing, pretty::Bool=true
 )
@@ -137,10 +139,10 @@ function string_dominating_pareto_curve(
     _buffer = IOBuffer()
     buffer = AnnotatedIOBuffer(_buffer)
     println(buffer, '─'^(terminal_width - 1))
-    if options.loss_scale == :linear
-        println(buffer, HEADER_WITHOUT_SCORE)
-    else
+    if show_score_column(options)
         println(buffer, HEADER)
+    else
+        println(buffer, HEADER_WITHOUT_SCORE)
     end
 
     formatted = format_hall_of_fame(hallOfFame, options)
@@ -156,10 +158,10 @@ function string_dominating_pareto_curve(
         )
         prefix = make_prefix(tree, options, dataset)
         eqn_string = prefix * eqn_string
-        stats_columns_string = if options.loss_scale == :linear
-            @sprintf("%-10d  %-8.3e  ", complexity, loss)
-        else
+        stats_columns_string = if show_score_column(options)
             @sprintf("%-10d  %-8.3e  %-8.3e  ", complexity, loss, score)
+        else
+            @sprintf("%-10d  %-8.3e  ", complexity, loss)
         end
         left_cols_width = length(stats_columns_string)
         print(buffer, stats_columns_string)

--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -208,12 +208,12 @@ function format_hall_of_fame(hof::HallOfFame{T,L}, options) where {T,L}
     dominating = calculate_pareto_frontier(hof)
 
     # Only check for negative losses if allow_negative_losses is false
-    if !options.allow_negative_losses
-        if any(member -> member.loss < 0.0, dominating)
+    !options.allow_negative_losses && for member in dominating
+        if member.loss < 0.0
             throw(
                 DomainError(
                     member.loss,
-                    "To use a loss function that has negative values, you must set `allow_negative_losses` to true.",
+                    "Your loss function must be non-negative. To do this, consider wrapping your loss inside an exponential, which will not affect the search (unless you are using annealing).",
                 ),
             )
         end

--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -135,7 +135,7 @@ function _log_scalars(;
     out["summaries"] = Dict([
         "min_loss" => length(dominating) > 0 ? dominating[end].loss : L(Inf),
         "pareto_volume" => pareto_volume(
-            losses, complexities, options.maxsize, options.allow_negative_losses
+            losses, complexities, options.maxsize, options.loss_scale == :linear
         ),
     ])
 
@@ -155,13 +155,13 @@ function _log_scalars(;
 end
 
 function pareto_volume(
-    losses::AbstractVector{L}, complexities, maxsize::Int, allow_negative_losses::Bool
+    losses::AbstractVector{L}, complexities, maxsize::Int, use_linear_scaling::Bool
 ) where {L}
     if length(losses) == 0
         return 0.0
     end
 
-    y = allow_negative_losses ? copy(losses) : @.(log10(losses + eps(L)))
+    y = use_linear_scaling ? copy(losses) : @.(log10(losses + eps(L)))
     x = @. log10(complexities)
 
     # Add a point equal to the best loss and largest possible complexity, + 1

--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -134,7 +134,9 @@ function _log_scalars(;
 
     out["summaries"] = Dict([
         "min_loss" => length(dominating) > 0 ? dominating[end].loss : L(Inf),
-        "pareto_volume" => pareto_volume(losses, complexities, options.maxsize),
+        "pareto_volume" => pareto_volume(
+            losses, complexities, options.maxsize, options.allow_negative_losses
+        ),
     ])
 
     #### Full Pareto front
@@ -152,22 +154,25 @@ function _log_scalars(;
     return out
 end
 
-function pareto_volume(losses::AbstractVector{L}, complexities, maxsize::Int) where {L}
+function pareto_volume(
+    losses::AbstractVector{L}, complexities, maxsize::Int, allow_negative_losses::Bool
+) where {L}
     if length(losses) == 0
         return 0.0
     end
-    log_losses = @. log10(losses + eps(L))
-    log_complexities = @. log10(complexities)
+
+    y = allow_negative_losses ? copy(losses) : @.(log10(losses + eps(L)))
+    x = @. log10(complexities)
 
     # Add a point equal to the best loss and largest possible complexity, + 1
-    push!(log_losses, minimum(log_losses))
-    push!(log_complexities, log10(maxsize + 1))
+    push!(y, minimum(y))
+    push!(x, log10(maxsize + 1))
 
     # Add a point to connect things:
-    push!(log_losses, maximum(log_losses))
-    push!(log_complexities, maximum(log_complexities))
+    push!(y, maximum(y))
+    push!(x, maximum(x))
 
-    xy = cat(log_complexities, log_losses; dims=2)
+    xy = cat(x, y; dims=2)
     hull = convex_hull(xy)
     return Float64(convex_hull_area(hull))
 end

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -605,7 +605,7 @@ function choose_best(;
     # https://github.com/MilesCranmer/PySR/blob/e74b8ad46b163c799908b3aa4d851cf8457c79ef/pysr/sr.py#L2318-L2332
     # threshold = 1.5 * minimum_loss
     # Then, we get max score of those below the threshold.
-    if !isnothing(options) && options.allow_negative_losses
+    if !isnothing(options) && options.loss_scale == :linear
         return argmin(losses)
     end
 

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -280,6 +280,7 @@ end
 
     probChange = 1.0
     if options.annealing
+        # TODO: Try using log(after_cost) - log(before_cost) here
         delta = after_cost - before_cost
         probChange *= exp(-delta / (temperature * options.alpha))
     end

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -350,6 +350,9 @@ const OPTION_DESCRIPTIONS = """- `defaults`: What set of defaults to use for `Op
         end
 
 - `loss_function_expression`: Similar to `loss_function`, but takes `AbstractExpression` instead of `AbstractExpressionNode` as its first argument. Useful for `TemplateExpressionSpec`.
+- `allow_negative_losses`: Whether to allow negative losses in the search. By default, negative losses
+    throw an error when encountered in the hall of fame. When set to true, negative losses are properly
+    handled in the search, which may be useful for custom loss functions.
 - `expression_spec::AbstractExpressionSpec`: A specification of what types of expressions to use in the
     search. For example, `ExpressionSpec()` (default). You can also see `TemplateExpressionSpec` and
     `ParametricExpressionSpec` for specialized cases.
@@ -594,6 +597,7 @@ $(OPTION_DESCRIPTIONS)
     ## 2. Setting the Search Size:
     ## 3. The Objective:
     dimensionless_constants_only::Bool=false,
+    allow_negative_losses::Bool=false,
     ## 4. Working with Complexities:
     complexity_mapping::Union{Function,ComplexityMapping,Nothing}=nothing,
     use_frequency::Bool=true,
@@ -1004,6 +1008,7 @@ $(OPTION_DESCRIPTIONS)
         elementwise_loss,
         loss_function,
         loss_function_expression,
+        allow_negative_losses,
         node_type,
         expression_type,
         expression_options,

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -235,6 +235,7 @@ struct Options{
     elementwise_loss::Union{SupervisedLoss,Function}
     loss_function::Union{Nothing,Function}
     loss_function_expression::Union{Nothing,Function}
+    allow_negative_losses::Bool
     node_type::Type{N}
     expression_type::Type{E}
     expression_options::EO

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -235,7 +235,7 @@ struct Options{
     elementwise_loss::Union{SupervisedLoss,Function}
     loss_function::Union{Nothing,Function}
     loss_function_expression::Union{Nothing,Function}
-    allow_negative_losses::Bool
+    loss_scale::Symbol
     node_type::Type{N}
     expression_type::Type{E}
     expression_options::EO

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -1185,7 +1185,11 @@ end
 
 include("MLJInterface.jl")
 using .MLJInterfaceModule:
-    SRRegressor, MultitargetSRRegressor, SRTestRegressor, MultitargetSRTestRegressor
+    get_options,
+    SRRegressor,
+    MultitargetSRRegressor,
+    SRTestRegressor,
+    MultitargetSRTestRegressor
 
 # Hack to get static analysis to work from within tests:
 @ignore include("../test/runtests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,10 +76,7 @@ end
 end
 
 include("test_complexity.jl")
-
-@testitem "Test options" tags = [:part1] begin
-    include("test_options.jl")
-end
+include("test_options.jl")
 
 @testitem "Test hash of tree" tags = [:part2] begin
     include("test_hash.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,6 +174,7 @@ include("test_parametric_template_expressions.jl")
 include("test_template_macro.jl")
 include("test_template_expression_mutation.jl")
 include("test_template_expression_string.jl")
+include("test_loss_scale.jl")
 
 @testitem "Aqua tests" tags = [:part2, :aqua] begin
     include("test_aqua.jl")

--- a/test/test_loss_scale.jl
+++ b/test/test_loss_scale.jl
@@ -1,0 +1,132 @@
+@testitem "loss_scale parameter validation" tags = [:part2] begin
+    using SymbolicRegression
+
+    # Test Options constructor assertion
+    @test_throws AssertionError Options(loss_scale=:invalid)
+
+    # Test we can create options with valid values
+    options_log = Options(; loss_scale=:log)
+    options_linear = Options(; loss_scale=:linear)
+
+    @test options_log.loss_scale == :log
+    @test options_linear.loss_scale == :linear
+end
+
+@testitem "loss_scale score computation" tags = [:part2] begin
+    using SymbolicRegression.HallOfFameModule:
+        compute_direct_score, compute_zero_centered_score
+
+    @test compute_direct_score(0.5, 1.0, 1.0) ≈ 0.5
+    @test compute_direct_score(1.2, 1.0, 1.0) ≈ 0.0
+
+    @test compute_zero_centered_score(0.5, 1.0, 1.0) ≈ log(2) atol = 1e-5
+    @test compute_zero_centered_score(0.1, 1.0, 1.0) ≈ log(10) atol = 1e-5
+    @test compute_zero_centered_score(2.0, 1.0, 1.0) ≈ 0.0
+end
+
+@testitem "loss_scale in choose_best" tags = [:part2] begin
+    using SymbolicRegression
+    using SymbolicRegression.MLJInterfaceModule: choose_best
+
+    # Test data
+    trees = [1, 2, 3, 4]  # Placeholder, not used in function
+    losses = [0.5, 0.3, 0.4, 0.2]
+    scores = [0.1, 0.8, 0.5, 0.3]
+    complexities = [1, 2, 3, 4]
+
+    # With loss_scale=:log (default behavior)
+    options_log = Options(; loss_scale=:log)
+    best_idx_log = choose_best(;
+        trees=trees,
+        losses=losses,
+        scores=scores,
+        complexities=complexities,
+        options=options_log,
+    )
+    @test best_idx_log == 2  # Best score (0.8) among those with loss <= 1.5*min_loss
+
+    # With loss_scale=:linear
+    options_linear = Options(; loss_scale=:linear)
+    best_idx_linear = choose_best(;
+        trees=trees,
+        losses=losses,
+        scores=scores,
+        complexities=complexities,
+        options=options_linear,
+    )
+    @test best_idx_linear == 4  # Simply picks minimum loss (0.2)
+end
+
+@testitem "loss_scale in pareto_volume" tags = [:part2] begin
+    using SymbolicRegression.LoggingModule: pareto_volume
+
+    # Test data
+    test_losses = [0.5, 0.3, 0.2]
+    test_complexities = [1, 3, 5]
+
+    # Both should produce valid volumes
+    @test pareto_volume(test_losses, test_complexities, 10, false) > 0  # log mode
+    @test pareto_volume(test_losses, test_complexities, 10, true) > 0   # linear mode
+
+    # Test negative losses work with linear mode but not log mode
+    neg_losses = [0.1, -0.1, -0.5]
+    @test pareto_volume(neg_losses, test_complexities, 10, true) > 0    # works with linear
+end
+
+@testitem "loss_scale in MLJ interface" tags = [:part2] begin
+    using SymbolicRegression
+    using SymbolicRegression: get_options
+
+    # Test MLJ interface supports loss_scale parameter
+    model_log = SRRegressor(; loss_scale=:log)
+    model_linear = SRRegressor(; loss_scale=:linear)
+    @test get_options(model_log).loss_scale == :log
+    @test get_options(model_linear).loss_scale == :linear
+
+    # Test with multitarget regressor too
+    model_mt_log = MultitargetSRRegressor(; loss_scale=:log)
+    model_mt_linear = MultitargetSRRegressor(; loss_scale=:linear)
+    @test get_options(model_mt_log).loss_scale == :log
+    @test get_options(model_mt_linear).loss_scale == :linear
+end
+
+@testitem "loss_scale error handling" tags = [:part2] begin
+    using SymbolicRegression
+    using SymbolicRegression.CoreModule: Dataset
+    using SymbolicRegression.HallOfFameModule: format_hall_of_fame
+    using SymbolicRegression.PopMemberModule: PopMember
+    using DynamicExpressions: Node
+
+    # Create test dataset
+    X = [1.0 2.0]
+    y = [3.0]
+    dataset = Dataset(X, y; variable_names=["x1", "x2"])
+
+    # Create options with different loss scales
+    options_log = Options(; loss_scale=:log, binary_operators=[+, -, *], unary_operators=[])
+    options_linear = Options(; loss_scale=:linear)
+
+    # Create a simple test case with negative loss
+    hof = HallOfFame(options_log, dataset)
+    hof.members[1].tree = Expression(
+        Node{Float64}(; feature=1); operators=nothing, variable_names=nothing
+    )
+    hof.members[1].loss = -1.0
+    hof.exists[1] = true
+
+    # With :log scale, should throw a DomainError with a helpful message
+    err = try
+        format_hall_of_fame(hof, options_log)
+        nothing
+    catch e
+        e
+    end
+    @test err isa DomainError
+    @test occursin("must be non-negative", err.msg)
+    @test occursin("set the `loss_scale` to linear", err.msg)
+
+    # With :linear scale, should work fine with negative losses
+    result = format_hall_of_fame(hof, options_linear)
+    @test result.losses[1] == -1.0f0
+    @test result.scores[1] >= 0.0
+end

--- a/test/test_loss_scale.jl
+++ b/test/test_loss_scale.jl
@@ -108,7 +108,9 @@ end
 
     # Create a simple test case with negative loss
     hof = HallOfFame(options_log, dataset)
-    hof.members[1].tree = Expression(Node{Float64}(; feature=1); operators=nothing)
+    hof.members[1].tree = Expression(
+        Node{Float64}(; feature=1); operators=nothing, variable_names=nothing
+    )
     hof.members[1].loss = -1.0
     hof.exists[1] = true
 

--- a/test/test_options.jl
+++ b/test/test_options.jl
@@ -1,26 +1,28 @@
-using SymbolicRegression
-using Optim: Optim
+@testitem "Test options" tags = [:part1] begin
+    using SymbolicRegression
+    using Optim: Optim
 
-# testing types
-op = Options(; optimizer_options=(iterations=16, f_calls_limit=100, x_tol=1e-16));
-@test isa(op.optimizer_options, Optim.Options)
+    # testing types
+    op = Options(; optimizer_options=(iterations=16, f_calls_limit=100, x_tol=1e-16))
+    @test isa(op.optimizer_options, Optim.Options)
 
-op = Options(;
-    optimizer_options=Dict(:iterations => 32, :g_calls_limit => 50, :f_tol => 1e-16)
-);
-@test isa(op.optimizer_options, Optim.Options)
+    op = Options(;
+        optimizer_options=Dict(:iterations => 32, :g_calls_limit => 50, :f_tol => 1e-16)
+    )
+    @test isa(op.optimizer_options, Optim.Options)
 
-optim_op = Optim.Options(; iterations=16)
-op = Options(; optimizer_options=optim_op);
-@test isa(op.optimizer_options, Optim.Options)
+    optim_op = Optim.Options(; iterations=16)
+    op = Options(; optimizer_options=optim_op)
+    @test isa(op.optimizer_options, Optim.Options)
 
-# testing loss_scale parameter
-op_log = Options(; loss_scale=:log);
-@test op_log.loss_scale == :log
+    # testing loss_scale parameter
+    op_log = Options(; loss_scale=:log)
+    @test op_log.loss_scale == :log
 
-op_linear = Options(; loss_scale=:linear);
-@test op_linear.loss_scale == :linear
+    op_linear = Options(; loss_scale=:linear)
+    @test op_linear.loss_scale == :linear
 
-# test that invalid loss_scale values are caught
-@test_throws AssertionError Options(; loss_scale=:invalid)
-@test_throws AssertionError Options(; loss_scale=:cubic)
+    # test that invalid loss_scale values are caught
+    @test_throws AssertionError Options(; loss_scale=:invalid)
+    @test_throws AssertionError Options(; loss_scale=:cubic)
+end

--- a/test/test_options.jl
+++ b/test/test_options.jl
@@ -13,3 +13,14 @@ op = Options(;
 optim_op = Optim.Options(; iterations=16)
 op = Options(; optimizer_options=optim_op);
 @test isa(op.optimizer_options, Optim.Options)
+
+# testing loss_scale parameter
+op_log = Options(; loss_scale=:log);
+@test op_log.loss_scale == :log
+
+op_linear = Options(; loss_scale=:linear);
+@test op_linear.loss_scale == :linear
+
+# test that invalid loss_scale values are caught
+@test_throws AssertionError Options(; loss_scale=:invalid)
+@test_throws AssertionError Options(; loss_scale=:cubic)


### PR DESCRIPTION
Requested a few times by @Moelf; finally added it.

This changes the scoring equation so needs to be accessed with the `loss_scaling` parameter

TODO:
- [x] Rename parameter to `loss_scaling`
- [x] Add a unittest