### PR TITLE
Deprecate ParametricExpression

### DIFF
--- a/examples/parameterized_function.jl
+++ b/examples/parameterized_function.jl
@@ -66,10 +66,14 @@ expression_spec = @template_spec(
 ) do x1, x2, category
     f(x1, x2, p1[category], p2[category])
 end
-test_kwargs = (;  #src
-    expression_spec=ParametricExpressionSpec(; max_parameters=2),  #src
-    autodiff_backend=:Zygote,  #src
-)  #src
+test_kwargs = if get(ENV, "SYMBOLIC_REGRESSION_IS_TESTING", "false") == "true"  #src
+    (;  #src
+        expression_spec=ParametricExpressionSpec(; max_parameters=2),  #src
+        autodiff_backend=:Zygote,  #src
+    )  #src
+else  #src
+    NamedTuple()  #src
+end  #src
 
 model = SRRegressor(;
     niterations=100,

--- a/examples/parameterized_function.jl
+++ b/examples/parameterized_function.jl
@@ -25,6 +25,7 @@ We will need to simultaneously learn the symbolic expression and per-class param
 =#
 using SymbolicRegression
 using Random: MersenneTwister
+using Zygote  #src
 using MLJBase: machine, fit!, predict, report
 using Test
 
@@ -65,6 +66,10 @@ expression_spec = @template_spec(
 ) do x1, x2, category
     f(x1, x2, p1[category], p2[category])
 end
+test_kwargs = (;  #src
+    expression_spec=ParametricExpressionSpec(; max_parameters=2),  #src
+    autodiff_backend=:Zygote,  #src
+)  #src
 
 model = SRRegressor(;
     niterations=100,
@@ -72,6 +77,7 @@ model = SRRegressor(;
     unary_operators=[cos, exp],
     populations=30,
     expression_spec=expression_spec,
+    test_kwargs...,  #src
     early_stop_condition=(loss, _) -> loss < stop_at[],  #src
 );
 

--- a/src/ParametricExpression.jl
+++ b/src/ParametricExpression.jl
@@ -197,7 +197,7 @@ IDE.handles_class_column(::Type{<:ParametricExpression}) = true
     ParametricExpressionSpec <: AbstractExpressionSpec
 
 !!! warning
-    `ParametricExpressionSpec` is no longer recommended. Please use `TemplateExpressionSpec` or `@template_spec` instead.
+    `ParametricExpressionSpec` is no longer recommended. Please use `@template_spec` (creating a `TemplateExpressionSpec`) instead.
 
 (Experimental) Specification for parametric expressions with configurable maximum parameters.
 """

--- a/src/ParametricExpression.jl
+++ b/src/ParametricExpression.jl
@@ -196,10 +196,37 @@ IDE.handles_class_column(::Type{<:ParametricExpression}) = true
 """
     ParametricExpressionSpec <: AbstractExpressionSpec
 
+!!! warning
+    `ParametricExpressionSpec` is no longer recommended. Please use `TemplateExpressionSpec` or `@template_spec` instead.
+
 (Experimental) Specification for parametric expressions with configurable maximum parameters.
 """
-Base.@kwdef struct ParametricExpressionSpec <: AbstractExpressionSpec
+struct ParametricExpressionSpec <: AbstractExpressionSpec
     max_parameters::Int
+
+    function ParametricExpressionSpec(; max_parameters::Int, warn::Bool=true)
+        # Build a generic deprecation message
+        msg = """
+        ParametricExpressionSpec is no longer recommended – it is both faster, safer, and more explicit to
+        use TemplateExpressionSpec with the `@template_spec` macro instead.
+
+        Example with @template_spec macro:
+
+            n_categories = length(unique(X.class))
+            expression_spec = @template_spec(
+                expressions=(f,),
+                parameters=($(join(["p$i=n_categories" for i in 1:max_parameters], ", "))),
+            ) do x, #= other variable names..., =# category #= additional category feature =#
+                f(x1, #= other variable names..., =#  $(join(["p$i[category]" for i in 1:max_parameters], ", ")))
+            end
+
+        Then, when passing your dataset, include another feature with the category column.
+        """
+
+        warn && @warn msg maxlog = 1
+
+        return new(max_parameters)
+    end
 end
 
 # COV_EXCL_START

--- a/test/test_parametric_template_expressions.jl
+++ b/test/test_parametric_template_expressions.jl
@@ -199,8 +199,7 @@ end
     # Parametrized Template Expressions
 
     Template expressions in SymbolicRegression.jl can include parametric forms - expressions with tunable constants
-    that are optimized during the search. This can even include learn class-specific parameters that vary by category,
-    analogous to `ParametricExpression`s.
+    that are optimized during the search. This can even include class-specific parameters that vary by category.
 
     In this tutorial, we'll demonstrate how to use parametric template expressions to learn a model where:
 


### PR DESCRIPTION
Users should just use template expressions with the parameters field. More explicit, safer, faster, better printing, and more flexible. 