### PR TITLE
Get template expressions working in distributed settings

### DIFF
--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -142,19 +142,19 @@ function move_functions_to_workers(
     for function_set in function_sets
         if function_set == :unaops
             ops = options.operators.unaops
-            example_inputs = (zero(T),)
+            example_inputs = (init_value(T),)
         elseif function_set == :binops
             ops = options.operators.binops
-            example_inputs = (zero(T), zero(T))
+            example_inputs = (init_value(T), init_value(T))
         elseif function_set == :elementwise_loss
             if typeof(options.elementwise_loss) <: SupervisedLoss
                 continue
             end
             ops = (options.elementwise_loss,)
             example_inputs = if is_weighted(dataset)
-                (zero(T), zero(T), zero(T))
+                (init_value(T), init_value(T), init_value(T))
             else
-                (zero(T), zero(T))
+                (init_value(T), init_value(T))
             end
         elseif function_set == :early_stop_condition
             if !(typeof(options.early_stop_condition) <: Function)
@@ -167,20 +167,20 @@ function move_functions_to_workers(
                 continue
             end
             ops = (options.loss_function,)
-            example_inputs = (Node(T; val=zero(T)), dataset, options)
+            example_inputs = ((options.node_type)(T; val=init_value(T)), dataset, options)
         elseif function_set == :loss_function_expression
             if options.loss_function_expression === nothing
                 continue
             end
             ops = (options.loss_function_expression,)
-            ex = create_expression(zero(T), options, dataset)
+            ex = create_expression(init_value(T), options, dataset)
             example_inputs = (ex, dataset, options)
         elseif function_set == :complexity_mapping
             if !(options.complexity_mapping isa Function)
                 continue
             end
             ops = (options.complexity_mapping,)
-            example_inputs = (create_expression(zero(T), options, dataset),)
+            example_inputs = (create_expression(init_value(T), options, dataset),)
         else
             error("Invalid function set: $function_set")
         end

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -163,6 +163,18 @@ function move_functions_to_workers(
             end
             ops = (options.early_stop_condition,)
             example_inputs = (zero(T), 0)
+        elseif function_set == :expression_type
+            # Needs to run _before_ using TemplateExpression anywhere, such
+            # as in `loss_function_expression`!
+            if isnothing(options.expression_type)
+                continue
+            end
+            if !require_copy_to_workers(options.expression_type)
+                continue
+            end
+            (; ops, example_inputs) = make_example_inputs(
+                options.expression_type, T, options, dataset
+            )
         elseif function_set == :loss_function
             if isnothing(options.loss_function)
                 continue

--- a/src/Configure.jl
+++ b/src/Configure.jl
@@ -134,6 +134,7 @@ function move_functions_to_workers(
         :binops,
         :elementwise_loss,
         :early_stop_condition,
+        :expression_type,
         :loss_function,
         :loss_function_expression,
         :complexity_mapping,
@@ -163,13 +164,13 @@ function move_functions_to_workers(
             ops = (options.early_stop_condition,)
             example_inputs = (zero(T), 0)
         elseif function_set == :loss_function
-            if options.loss_function === nothing
+            if isnothing(options.loss_function)
                 continue
             end
             ops = (options.loss_function,)
             example_inputs = ((options.node_type)(T; val=init_value(T)), dataset, options)
         elseif function_set == :loss_function_expression
-            if options.loss_function_expression === nothing
+            if isnothing(options.loss_function_expression)
                 continue
             end
             ops = (options.loss_function_expression,)

--- a/src/InterfaceDynamicExpressions.jl
+++ b/src/InterfaceDynamicExpressions.jl
@@ -375,4 +375,18 @@ end
 # Allows special handling of class columns in MLJInterface.jl
 handles_class_column(::Type{<:AbstractExpression}) = false
 
+# These functions allow you to declare functions that must be
+# passed to worker nodes explicitly. See TemplateExpressions.jl for
+# an example. This is used inside Configure.jl.
+# COV_EXCL_START
+require_copy_to_workers(::Type{<:AbstractExpression}) = false
+function make_example_inputs(
+    ::Type{<:AbstractExpression}, ::Type{T}, options, dataset
+) where {T}
+    return error(
+        "`make_example_inputs` is not implemented for `$(typeof(options.expression_type))`."
+    )
+end
+# COV_EXCL_STOP
+
 end

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -297,7 +297,8 @@ using .MutationFunctionsModule:
     random_node,
     random_node_and_parent,
     crossover_trees
-using .InterfaceDynamicExpressionsModule: @extend_operators
+using .InterfaceDynamicExpressionsModule:
+    @extend_operators, require_copy_to_workers, make_example_inputs
 using .LossFunctionsModule: eval_loss, eval_cost, update_baseline_loss!, score_func
 using .PopMemberModule: PopMember, reset_birth!
 using .PopulationModule: Population, best_sub_pop, record_population, best_of_sample

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -907,4 +907,21 @@ ES.get_expression_options(spec::TemplateExpressionSpec) = (; structure=spec.stru
 ES.get_node_type(::TemplateExpressionSpec) = Node
 # COV_EXCL_STOP
 
+IDE.require_copy_to_workers(::Type{<:TemplateExpression}) = true  # COV_EXCL_LINE
+function IDE.make_example_inputs(
+    ::Type{<:TemplateExpression}, ::Type{T}, options, dataset
+) where {T}
+    ex = EB.create_expression(CM.init_value(T), options, dataset)
+    raw_contents = get_contents(ex)
+    extra_args = has_params(ex) ? (get_metadata(ex).parameters,) : ()
+    return (;
+        ops=(get_metadata(ex).structure.combine,),
+        example_inputs=(
+            raw_contents,
+            extra_args...,
+            map(x -> ValidVector(copy(x), true), eachrow(dataset.X)),
+        ),
+    )
+end
+
 end


### PR DESCRIPTION
This took some extra work because the closure function inside the template needs to be explicitly defined on worker nodes, otherwise they can't deserialize the type.