### PR TITLE
fix: issue where minimizer is not loaded to tree

### DIFF
--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -85,7 +85,7 @@ function _optimize_constants(
     end
 
     if result.minimum < baseline
-        member.tree = tree
+        set_scalar_constants!(member.tree, result.minimizer, refs)
         member.loss = f(result.minimizer; regularization=true)
         member.cost = loss_to_cost(
             member.loss, dataset.use_baseline, dataset.baseline_loss, member, options


### PR DESCRIPTION
I'm not sure I entirely understand this bug... If it's "real" then it is a _huge_ problem. I suppose I am not entirely sure if Optim would have set the result back to the tree or not.