### PR TITLE
Create `mutate_feature` for mutating a feature node exclusively

### DIFF
--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -133,8 +133,8 @@ function condition_mutation_weights!(
 
     condition_mutate_constant!(typeof(member.tree), weights, member, options, curmaxsize)
 
-    # Disable feature mutation if no feature nodes or only one feature available
-    if !any(node -> node.degree == 0 && !node.constant, tree) || nfeatures <= 1
+    # Disable feature mutation if only one feature available
+    if nfeatures <= 1
         weights.mutate_feature = 0.0
     end
 

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -26,6 +26,7 @@ using ..PopMemberModule: PopMember
 using ..MutationFunctionsModule:
     mutate_constant,
     mutate_operator,
+    mutate_feature,
     swap_operands,
     append_random_op,
     prepend_random_op,
@@ -82,7 +83,7 @@ struct MutationResult{N<:AbstractExpression,P<:PopMember} <: AbstractMutationRes
 end
 
 """
-    condition_mutation_weights!(weights::AbstractMutationWeights, member::PopMember, options::AbstractOptions, curmaxsize::Int)
+    condition_mutation_weights!(weights::AbstractMutationWeights, member::PopMember, options::AbstractOptions, curmaxsize::Int, nfeatures::Int)
 
 Adjusts the mutation weights based on the properties of the current member and options.
 
@@ -95,9 +96,14 @@ Note that the weights were already copied, so you don't need to worry about muta
 - `member::PopMember`: The current population member being mutated.
 - `options::AbstractOptions`: The options that guide the mutation process.
 - `curmaxsize::Int`: The current maximum size constraint for the member's expression tree.
+- `nfeatures::Int`: The number of features available in the dataset.
 """
 function condition_mutation_weights!(
-    weights::AbstractMutationWeights, member::P, options::AbstractOptions, curmaxsize::Int
+    weights::AbstractMutationWeights,
+    member::P,
+    options::AbstractOptions,
+    curmaxsize::Int,
+    nfeatures::Int,
 ) where {T,L,N<:AbstractExpression,P<:PopMember{T,L,N}}
     tree = get_tree(member.tree)
     if !preserve_sharing(typeof(member.tree))
@@ -114,6 +120,8 @@ function condition_mutation_weights!(
         if !tree.constant
             weights.optimize = 0.0
             weights.mutate_constant = 0.0
+        else
+            weights.mutate_feature = 0.0
         end
         return nothing
     end
@@ -124,6 +132,11 @@ function condition_mutation_weights!(
     end
 
     condition_mutate_constant!(typeof(member.tree), weights, member, options, curmaxsize)
+
+    # Disable feature mutation if no feature nodes or only one feature available
+    if !any(node -> node.degree == 0 && !node.constant, tree) || nfeatures <= 1
+        weights.mutate_feature = 0.0
+    end
 
     complexity = compute_complexity(member, options)
 
@@ -179,7 +192,7 @@ end
 
     weights = copy(options.mutation_weights)
 
-    condition_mutation_weights!(weights, member, options, curmaxsize)
+    condition_mutation_weights!(weights, member, options, curmaxsize, nfeatures)
 
     mutation_choice = sample_mutation(weights)
 
@@ -431,6 +444,21 @@ function mutate!(
 ) where {N<:AbstractExpression,P<:PopMember}
     tree = mutate_operator(tree, options)
     @recorder recorder["type"] = "mutate_operator"
+    return MutationResult{N,P}(; tree=tree)
+end
+
+function mutate!(
+    tree::N,
+    member::P,
+    ::Val{:mutate_feature},
+    ::AbstractMutationWeights,
+    options::AbstractOptions;
+    recorder::RecordType,
+    nfeatures,
+    kws...,
+) where {N<:AbstractExpression,P<:PopMember}
+    tree = mutate_feature(tree, nfeatures)
+    @recorder recorder["type"] = "mutate_feature"
     return MutationResult{N,P}(; tree=tree)
 end
 

--- a/src/MutationWeights.jl
+++ b/src/MutationWeights.jl
@@ -77,6 +77,7 @@ will be normalized to sum to 1.0 after initialization.
 
 - `mutate_constant::Float64`: How often to mutate a constant.
 - `mutate_operator::Float64`: How often to mutate an operator.
+- `mutate_feature::Float64`: How often to mutate which feature a variable node references.
 - `swap_operands::Float64`: How often to swap the operands of a binary operator.
 - `rotate_tree::Float64`: How often to perform a tree rotation at a random node.
 - `add_node::Float64`: How often to append a node to the tree.
@@ -102,6 +103,7 @@ will be normalized to sum to 1.0 after initialization.
 Base.@kwdef mutable struct MutationWeights <: AbstractMutationWeights
     mutate_constant::Float64 = 0.0353
     mutate_operator::Float64 = 3.63
+    mutate_feature::Float64 = 0.1
     swap_operands::Float64 = 0.00608
     rotate_tree::Float64 = 1.42
     add_node::Float64 = 0.0771

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -692,6 +692,7 @@ function MM.condition_mutation_weights!(
     @nospecialize(member::P),
     @nospecialize(options::AbstractOptions),
     curmaxsize::Int,
+    nfeatures::Int,
 ) where {T,L,N<:TemplateExpression,P<:PopMember{T,L,N}}
     if !preserve_sharing(typeof(member.tree))
         weights.form_connection = 0.0
@@ -699,6 +700,11 @@ function MM.condition_mutation_weights!(
     end
 
     MM.condition_mutate_constant!(typeof(member.tree), weights, member, options, curmaxsize)
+
+    # Disable feature mutation if only one feature available
+    if nfeatures <= 1
+        weights.mutate_feature = 0.0
+    end
 
     complexity = ComplexityModule.compute_complexity(member, options)
 

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -761,6 +761,12 @@ function MF.with_contents_for_mutation(
     )
     return with_contents(ex, new_contents)
 end
+
+"""We only want to mutate to a valid number of features."""
+function MF.get_nfeatures_for_mutation(ex::TemplateExpression, ctx::Symbol, _::Int)
+    return get_metadata(ex).structure.num_features[ctx]
+end
+
 function MM.condition_mutate_constant!(
     ::Type{<:TemplateExpression},
     weights::AbstractMutationWeights,

--- a/test/test_feature_mutation.jl
+++ b/test/test_feature_mutation.jl
@@ -1,0 +1,35 @@
+@testitem "Test feature mutation" tags = [:part1] begin
+    using SymbolicRegression
+    using DynamicExpressions: Node
+    using StableRNGs: StableRNG
+
+    rng = StableRNG(0)
+
+    @testset "Basic feature mutation" begin
+        # Single feature node
+        tree = Node(Float64; feature=1)
+        mutated = SymbolicRegression.MutationFunctionsModule.mutate_feature(tree, 3, rng)
+        @test mutated.feature != 1  # Should change
+        @test 1 <= mutated.feature <= 3  # In valid range
+    end
+
+    @testset "Edge cases" begin
+        # Single feature - should not change when nfeatures=1
+        tree = Node(Float64; feature=1)
+        mutated = SymbolicRegression.MutationFunctionsModule.mutate_feature(tree, 1, rng)
+        @test mutated.feature == 1
+
+        # Constant node - should be unchanged
+        tree = Node(Float64; val=1.0)
+        original_val = tree.val
+        mutated = SymbolicRegression.MutationFunctionsModule.mutate_feature(tree, 3, rng)
+        @test mutated.val == original_val  # Should be unchanged
+    end
+
+    @testset "Mutation weights" begin
+        # Test that mutate_feature is included in MutationWeights
+        weights = MutationWeights()
+        @test hasfield(typeof(weights), :mutate_feature)
+        @test weights.mutate_feature == 0.1
+    end
+end


### PR DESCRIPTION
This also make template expressions have smarter mutations wrt features. They will only generate feature nodes that are valid. This is much better than the current approach which is basically generate mutations until we find a valid expression.