### PR TITLE
docs: add language picker

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -20,6 +20,13 @@ const navTemp = {
 const nav = [
   ...navTemp.nav,
   {
+    text: 'Julia',
+    items: [
+      { text: 'Julia', link: '/' },
+      { text: 'Python', link: 'https://ai.damtp.cam.ac.uk/pysr/dev/' }
+    ]
+  },
+  {
     component: 'VersionPicker'
   }
 ]

--- a/docs/src/.vitepress/theme/style.css
+++ b/docs/src/.vitepress/theme/style.css
@@ -90,3 +90,11 @@ html.dark {
   border-top: 1px solid var(--vp-c-divider);
   padding-top: 48px;
 }
+
+/* Make language picker match version picker styling (black text, not colored) */
+.VPNavBarMenuGroup button .text {
+  color: var(--vp-c-text-1) !important;
+}
+.VPNavBarMenuGroup:hover button .text {
+  color: var(--vp-c-text-2) !important;
+}


### PR DESCRIPTION
Paired with https://github.com/MilesCranmer/PySR/pull/1056, this gives us a uniform style across PySR and SymbolicRegression.jl docs, and makes it easier to switch between them.