### PR TITLE
Generalize row/column collation in HallOfFame.jl.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,12 +36,14 @@ Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [extensions]
 SymbolicRegressionEnzymeExt = "Enzyme"
 SymbolicRegressionJSON3Ext = "JSON3"
 SymbolicRegressionMooncakeExt = "Mooncake"
 SymbolicRegressionSymbolicUtilsExt = "SymbolicUtils"
+SymbolicRegressionTablesExt = "Tables"
 
 [compat]
 ADTypes = "^1.4.0"
@@ -74,4 +76,5 @@ StatsBase = "0.33, 0.34"
 StyledStrings = "1"
 SymbolicUtils = "0.19, ^1.0.5, 2, 3"
 TOML = "<0.0.1, 1"
+Tables = "1"
 julia = "1.10"

--- a/ext/SymbolicRegressionTablesExt.jl
+++ b/ext/SymbolicRegressionTablesExt.jl
@@ -1,12 +1,46 @@
 module SymbolicRegressionTablesExt
 
 using Tables: Tables
-import SymbolicRegression.HallOfFameModule: HOFRows
+import SymbolicRegression.HallOfFameModule: HOFRows, member_to_row
 
 # Make HOFRows compatible with the Tables.jl interface
 # HOFRows is already iterable via Base.iterate, so we just need to declare compatibility
 Tables.istable(::Type{<:HOFRows}) = true
 Tables.rowaccess(::Type{<:HOFRows}) = true
 Tables.rows(view::HOFRows) = view  # Return itself since it's already iterable
+
+# Provide schema information for better Tables.jl integration
+function Tables.schema(rows::HOFRows)
+    if isempty(rows.members)
+        # Empty table - can't infer schema
+        return nothing
+    end
+
+    # Get column names from either column specs or first row
+    if rows.columns !== nothing
+        # Use explicit column specs
+        names = Tuple(col.name for col in rows.columns)
+        # We can't reliably infer types without evaluating, so return nothing for types
+        return Tables.Schema(names, nothing)
+    else
+        # Infer from first row
+        first_row = member_to_row(
+            rows.members[1], rows.dataset, rows.options; pretty=rows.pretty
+        )
+        if rows.include_score
+            # Will add score in iteration
+            names = (keys(first_row)..., :score)
+        else
+            names = keys(first_row)
+        end
+        # Get types from first row
+        types = if rows.include_score
+            (typeof.(values(first_row))..., Float64)  # Assume Float64 for score
+        else
+            typeof.(values(first_row))
+        end
+        return Tables.Schema(names, types)
+    end
+end
 
 end

--- a/ext/SymbolicRegressionTablesExt.jl
+++ b/ext/SymbolicRegressionTablesExt.jl
@@ -1,0 +1,12 @@
+module SymbolicRegressionTablesExt
+
+using Tables: Tables
+import SymbolicRegression.HallOfFameModule: HOFRows
+
+# Make HOFRows compatible with the Tables.jl interface
+# HOFRows is already iterable via Base.iterate, so we just need to declare compatibility
+Tables.istable(::Type{<:HOFRows}) = true
+Tables.rowaccess(::Type{<:HOFRows}) = true
+Tables.rows(view::HOFRows) = view  # Return itself since it's already iterable
+
+end

--- a/src/ExpressionBuilder.jl
+++ b/src/ExpressionBuilder.jl
@@ -11,7 +11,8 @@ using DynamicExpressions:
 using ..CoreModule: AbstractOptions, Dataset
 using ..HallOfFameModule: HallOfFame
 using ..PopulationModule: Population
-using ..PopMemberModule: PopMember
+using ..PopMemberModule: PopMember, AbstractPopMember, create_child
+using ..ComplexityModule: compute_complexity
 
 import DynamicExpressions: get_operators
 import ..CoreModule: create_expression
@@ -107,15 +108,16 @@ end
         return with_metadata(ex; init_params(options, dataset, ex, Val(true))...)
     end
     function embed_metadata(
-        member::PopMember, options::AbstractOptions, dataset::Dataset{T,L}
-    ) where {T,L}
-        return PopMember(
+        member::PM, options::AbstractOptions, dataset::Dataset{T,L}
+    ) where {T,L,N,PM<:AbstractPopMember{T,L,N}}
+        return create_child(
+            member,
             embed_metadata(member.tree, options, dataset),
             member.cost,
             member.loss,
-            nothing;
-            member.ref,
-            member.parent,
+            options;
+            complexity=compute_complexity(member, options),
+            parent_ref=member.ref,
             deterministic=options.deterministic,
         )
     end
@@ -135,7 +137,7 @@ end
     end
     function embed_metadata(
         vec::Vector{H}, options::AbstractOptions, dataset::Dataset{T,L}
-    ) where {T,L,H<:Union{HallOfFame,Population,PopMember}}
+    ) where {T,L,H<:Union{HallOfFame,Population,AbstractPopMember}}
         return map(Fix{2}(Fix{3}(embed_metadata, dataset), options), vec)
     end
 end

--- a/src/ExpressionBuilder.jl
+++ b/src/ExpressionBuilder.jl
@@ -118,7 +118,6 @@ end
             options;
             complexity=compute_complexity(member, options),
             parent_ref=member.ref,
-            deterministic=options.deterministic,
         )
     end
     function embed_metadata(

--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -73,17 +73,36 @@ function HallOfFame(
     options::AbstractOptions, dataset::Dataset{T,L}
 ) where {T<:DATA_TYPE,L<:LOSS_TYPE}
     base_tree = create_expression(init_value(T), options, dataset)
+    PM = options.popmember_type
 
-    return HallOfFame{T,L,typeof(base_tree),PopMember{T,L,typeof(base_tree)}}(
+    # Create a prototype member to get the concrete type
+    prototype = PM(
+        copy(base_tree),
+        L(0),
+        L(Inf),
+        options,
+        1;  # complexity
+        parent=-1,
+        deterministic=options.deterministic,
+    )
+
+    PMtype = typeof(prototype)
+
+    return HallOfFame{T,L,typeof(base_tree),PMtype}(
         [
-            PopMember(
-                copy(base_tree),
-                L(0),
-                L(Inf),
-                options;
-                parent=-1,
-                deterministic=options.deterministic,
-            ) for i in 1:(options.maxsize)
+            if i == 1
+                prototype
+            else
+                PM(
+                    copy(base_tree),
+                    L(0),
+                    L(Inf),
+                    options,
+                    1;  # complexity
+                    parent=-1,
+                    deterministic=options.deterministic,
+                )
+            end for i in 1:(options.maxsize)
         ],
         [false for i in 1:(options.maxsize)],
     )

--- a/src/HallOfFame.jl
+++ b/src/HallOfFame.jl
@@ -6,12 +6,13 @@ using ..UtilsModule: split_string, AnnotatedIOBuffer, dump_buffer
 using ..CoreModule:
     AbstractOptions, Dataset, DATA_TYPE, LOSS_TYPE, relu, create_expression, init_value
 using ..ComplexityModule: compute_complexity
-using ..PopMemberModule: PopMember
+using ..PopMemberModule: AbstractPopMember, PopMember
+import ..PopMemberModule: popmember_type
 using ..InterfaceDynamicExpressionsModule: format_dimensions, WILDCARD_UNIT_STRING
 using Printf: @sprintf
 
 """
-    HallOfFame{T<:DATA_TYPE,L<:LOSS_TYPE,N<:AbstractExpression{T}}
+    HallOfFame{T<:DATA_TYPE,L<:LOSS_TYPE,N<:AbstractExpression{T},PM<:AbstractPopMember{T,L,N}}
 
 List of the best members seen all time in `.members`, with `.members[c]` being
 the best member seen at complexity c. Including only the members which actually
@@ -19,15 +20,19 @@ have been set, you can run `.members[exists]`.
 
 # Fields
 
-- `members::Array{PopMember{T,L,N},1}`: List of the best members seen all time.
+- `members::Array{PM,1}`: List of the best members seen all time.
     These are ordered by complexity, with `.members[1]` the member with complexity 1.
 - `exists::Array{Bool,1}`: Whether the member at the given complexity has been set.
 """
-struct HallOfFame{T<:DATA_TYPE,L<:LOSS_TYPE,N<:AbstractExpression{T}}
-    members::Array{PopMember{T,L,N},1}
+struct HallOfFame{
+    T<:DATA_TYPE,L<:LOSS_TYPE,N<:AbstractExpression{T},PM<:AbstractPopMember{T,L,N}
+}
+    members::Array{PM,1}
     exists::Array{Bool,1} #Whether it has been set
 end
-function Base.show(io::IO, mime::MIME"text/plain", hof::HallOfFame{T,L,N}) where {T,L,N}
+function Base.show(
+    io::IO, mime::MIME"text/plain", hof::HallOfFame{T,L,N,PM}
+) where {T,L,N,PM}
     println(io, "HallOfFame{...}:")
     for i in eachindex(hof.members, hof.exists)
         s_member, s_exists = if hof.exists[i]
@@ -47,8 +52,8 @@ function Base.show(io::IO, mime::MIME"text/plain", hof::HallOfFame{T,L,N}) where
     end
     return nothing
 end
-function Base.eltype(::Union{HOF,Type{HOF}}) where {T,L,N,HOF<:HallOfFame{T,L,N}}
-    return PopMember{T,L,N}
+function Base.eltype(::Union{HOF,Type{HOF}}) where {T,L,N,PM,HOF<:HallOfFame{T,L,N,PM}}
+    return PM
 end
 
 """
@@ -69,7 +74,7 @@ function HallOfFame(
 ) where {T<:DATA_TYPE,L<:LOSS_TYPE}
     base_tree = create_expression(init_value(T), options, dataset)
 
-    return HallOfFame{T,L,typeof(base_tree)}(
+    return HallOfFame{T,L,typeof(base_tree),PopMember{T,L,typeof(base_tree)}}(
         [
             PopMember(
                 copy(base_tree),
@@ -93,11 +98,10 @@ end
 """
     calculate_pareto_frontier(hallOfFame::HallOfFame{T,L,P}) where {T<:DATA_TYPE,L<:LOSS_TYPE}
 """
-function calculate_pareto_frontier(hallOfFame::HallOfFame{T,L,N}) where {T,L,N}
+function calculate_pareto_frontier(hallOfFame::HallOfFame{T,L,N,PM}) where {T,L,N,PM}
     # TODO - remove dataset from args.
-    P = PopMember{T,L,N}
     # Dominating pareto curve - must be better than all simpler equations
-    dominating = P[]
+    dominating = PM[]
     for size in eachindex(hallOfFame.members)
         if !hallOfFame.exists[size]
             continue
@@ -275,5 +279,8 @@ function format_hall_of_fame(hof::AbstractVector{<:HallOfFame}, options)
     )
 end
 # TODO: Re-use this in `string_dominating_pareto_curve`
+
+# Type accessor for HallOfFame
+popmember_type(::Type{<:HallOfFame{T,L,N,PM}}) where {T,L,N,PM} = PM
 
 end

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -39,8 +39,8 @@ using ..CoreModule:
     ExpressionSpec,
     get_expression_type,
     check_warm_start_compatibility
-using ..CoreModule.OptionsModule:
-    DEFAULT_OPTIONS, OPTION_DESCRIPTIONS, default_popmember_type
+using ..CoreModule.OptionsModule: DEFAULT_OPTIONS, OPTION_DESCRIPTIONS
+using ..PopMemberModule: default_popmember_type
 using ..ComplexityModule: compute_complexity
 using ..HallOfFameModule: HallOfFame, format_hall_of_fame
 using ..UtilsModule: subscriptify, @ignore

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -39,7 +39,8 @@ using ..CoreModule:
     ExpressionSpec,
     get_expression_type,
     check_warm_start_compatibility
-using ..CoreModule.OptionsModule: DEFAULT_OPTIONS, OPTION_DESCRIPTIONS
+using ..CoreModule.OptionsModule:
+    DEFAULT_OPTIONS, OPTION_DESCRIPTIONS, default_popmember_type
 using ..ComplexityModule: compute_complexity
 using ..HallOfFameModule: HallOfFame, format_hall_of_fame
 using ..UtilsModule: subscriptify, @ignore

--- a/src/Migration.jl
+++ b/src/Migration.jl
@@ -2,7 +2,7 @@ module MigrationModule
 
 using ..CoreModule: AbstractOptions
 using ..PopulationModule: Population
-using ..PopMemberModule: PopMember, reset_birth!
+using ..PopMemberModule: AbstractPopMember, PopMember, reset_birth!
 using ..UtilsModule: poisson_sample
 
 """
@@ -14,7 +14,7 @@ to do so. The original migrant population is not modified. Pass with, e.g.,
 """
 function migrate!(
     migration::Pair{Vector{PM},P}, options::AbstractOptions; frac::AbstractFloat
-) where {T,L,N,PM<:PopMember{T,L,N},P<:Population{T,L,N}}
+) where {T,L,N,PM<:AbstractPopMember{T,L,N},P<:Population{T,L,N,PM}}
     base_pop = migration.second
     population_size = length(base_pop.members)
     mean_number_replaced = population_size * frac

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -22,7 +22,7 @@ using ..ComplexityModule: compute_complexity
 using ..LossFunctionsModule: eval_cost
 using ..CheckConstraintsModule: check_constraints
 using ..AdaptiveParsimonyModule: RunningSearchStatistics
-using ..PopMemberModule: PopMember
+using ..PopMemberModule: AbstractPopMember, PopMember
 using ..MutationFunctionsModule:
     mutate_constant,
     mutate_operator,
@@ -61,7 +61,8 @@ This struct encapsulates the result of a mutation operation. Either a new expres
 Return the `member` if you want to return immediately, and have
 computed the loss value as part of the mutation.
 """
-struct MutationResult{N<:AbstractExpression,P<:PopMember} <: AbstractMutationResult{N,P}
+struct MutationResult{N<:AbstractExpression,P<:AbstractPopMember} <:
+       AbstractMutationResult{N,P}
     tree::Union{N,Nothing}
     member::Union{P,Nothing}
     num_evals::Float64
@@ -73,7 +74,7 @@ struct MutationResult{N<:AbstractExpression,P<:PopMember} <: AbstractMutationRes
         member::Union{_P,Nothing}=nothing,
         num_evals::Float64=0.0,
         return_immediately::Bool=false,
-    ) where {_N<:AbstractExpression,_P<:PopMember}
+    ) where {_N<:AbstractExpression,_P<:AbstractPopMember}
         @assert(
             (tree === nothing) ⊻ (member === nothing),
             "Mutation result must return either a tree or a pop member, not both"
@@ -83,7 +84,7 @@ struct MutationResult{N<:AbstractExpression,P<:PopMember} <: AbstractMutationRes
 end
 
 """
-    condition_mutation_weights!(weights::AbstractMutationWeights, member::PopMember, options::AbstractOptions, curmaxsize::Int, nfeatures::Int)
+    condition_mutation_weights!(weights::AbstractMutationWeights, member::AbstractPopMember, options::AbstractOptions, curmaxsize::Int, nfeatures::Int)
 
 Adjusts the mutation weights based on the properties of the current member and options.
 
@@ -93,7 +94,7 @@ Note that the weights were already copied, so you don't need to worry about muta
 
 # Arguments
 - `weights::AbstractMutationWeights`: The mutation weights to be adjusted.
-- `member::PopMember`: The current population member being mutated.
+- `member::AbstractPopMember`: The current population member being mutated.
 - `options::AbstractOptions`: The options that guide the mutation process.
 - `curmaxsize::Int`: The current maximum size constraint for the member's expression tree.
 - `nfeatures::Int`: The number of features available in the dataset.
@@ -104,7 +105,7 @@ function condition_mutation_weights!(
     options::AbstractOptions,
     curmaxsize::Int,
     nfeatures::Int,
-) where {T,L,N<:AbstractExpression,P<:PopMember{T,L,N}}
+) where {T,L,N<:AbstractExpression,P<:AbstractPopMember{T,L,N}}
     tree = get_tree(member.tree)
     if !preserve_sharing(typeof(member.tree))
         weights.form_connection = 0.0
@@ -181,7 +182,7 @@ end
     tmp_recorder::RecordType,
 )::Tuple{
     P,Bool,Float64
-} where {T,L,D<:Dataset{T,L},N<:AbstractExpression{T},P<:PopMember{T,L,N}}
+} where {T,L,D<:Dataset{T,L},N<:AbstractExpression{T},P<:AbstractPopMember{T,L,N}}
     parent_ref = member.ref
     num_evals = 0.0
 
@@ -665,7 +666,7 @@ function crossover_generation(
     curmaxsize::Int,
     options::AbstractOptions;
     recorder::RecordType=RecordType(),
-)::Tuple{P,P,Bool,Float64} where {T,L,D<:Dataset{T,L},N,P<:PopMember{T,L,N}}
+)::Tuple{P,P,Bool,Float64} where {T,L,D<:Dataset{T,L},N,P<:AbstractPopMember{T,L,N}}
     tree1 = member1.tree
     tree2 = member2.tree
     crossover_accepted = false

--- a/src/Mutate.jl
+++ b/src/Mutate.jl
@@ -40,10 +40,10 @@ using ..MutationFunctionsModule:
 using ..ConstantOptimizationModule: optimize_constants
 using ..RecorderModule: @recorder
 
-abstract type AbstractMutationResult{N<:AbstractExpression,P<:PopMember} end
+abstract type AbstractMutationResult{N<:AbstractExpression,P<:AbstractPopMember} end
 
 """
-    MutationResult{N<:AbstractExpression,P<:PopMember}
+    MutationResult{N<:AbstractExpression,P<:AbstractPopMember}
 
 Represents the result of a mutation operation in the genetic programming algorithm. This struct is used to return values from `mutate!` functions.
 
@@ -160,7 +160,7 @@ Use this to modify how `mutate_constant` changes for an expression type.
 function condition_mutate_constant!(
     ::Type{<:AbstractExpression},
     weights::AbstractMutationWeights,
-    member::PopMember,
+    member::AbstractPopMember,
     options::AbstractOptions,
     curmaxsize::Int,
 )
@@ -352,7 +352,7 @@ end
 
 @generated function _dispatch_mutations!(
     tree::AbstractExpression,
-    member::PopMember,
+    member::AbstractPopMember,
     mutation_choice::Symbol,
     weights::W,
     options::AbstractOptions;
@@ -381,7 +381,7 @@ end
         mutation_weights::AbstractMutationWeights,
         options::AbstractOptions;
         kws...,
-    ) where {N<:AbstractExpression,P<:PopMember,S}
+    ) where {N<:AbstractExpression,P<:AbstractPopMember,S}
 
 Perform a mutation on the given `tree` and `member` using the specified mutation type `S`.
 Various `kws` are provided to access other data needed for some mutations.
@@ -409,7 +409,7 @@ so it can always return immediately.
 """
 function mutate!(
     ::N, ::P, ::Val{S}, ::AbstractMutationWeights, ::AbstractOptions; kws...
-) where {N<:AbstractExpression,P<:PopMember,S}
+) where {N<:AbstractExpression,P<:AbstractPopMember,S}
     return error("Unknown mutation choice: $S")
 end
 
@@ -422,7 +422,7 @@ function mutate!(
     recorder::RecordType,
     temperature,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     tree = mutate_constant(tree, temperature, options)
     @recorder recorder["type"] = "mutate_constant"
     return MutationResult{N,P}(; tree=tree)
@@ -436,7 +436,7 @@ function mutate!(
     options::AbstractOptions;
     recorder::RecordType,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     tree = mutate_operator(tree, options)
     @recorder recorder["type"] = "mutate_operator"
     return MutationResult{N,P}(; tree=tree)
@@ -451,7 +451,7 @@ function mutate!(
     recorder::RecordType,
     nfeatures,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     tree = mutate_feature(tree, nfeatures)
     @recorder recorder["type"] = "mutate_feature"
     return MutationResult{N,P}(; tree=tree)
@@ -465,7 +465,7 @@ function mutate!(
     options::AbstractOptions;
     recorder::RecordType,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     tree = swap_operands(tree)
     @recorder recorder["type"] = "swap_operands"
     return MutationResult{N,P}(; tree=tree)
@@ -480,7 +480,7 @@ function mutate!(
     recorder::RecordType,
     nfeatures,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     if rand() < 0.5
         tree = append_random_op(tree, options, nfeatures)
         @recorder recorder["type"] = "add_node:append"
@@ -500,7 +500,7 @@ function mutate!(
     recorder::RecordType,
     nfeatures,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     tree = insert_random_op(tree, options, nfeatures)
     @recorder recorder["type"] = "insert_node"
     return MutationResult{N,P}(; tree=tree)
@@ -514,7 +514,7 @@ function mutate!(
     options::AbstractOptions;
     recorder::RecordType,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     tree = delete_random_op!(tree)
     @recorder recorder["type"] = "delete_node"
     return MutationResult{N,P}(; tree=tree)
@@ -528,7 +528,7 @@ function mutate!(
     options::AbstractOptions;
     recorder::RecordType,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     tree = form_random_connection!(tree)
     @recorder recorder["type"] = "form_connection"
     return MutationResult{N,P}(; tree=tree)
@@ -542,7 +542,7 @@ function mutate!(
     options::AbstractOptions;
     recorder::RecordType,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     tree = break_random_connection!(tree)
     @recorder recorder["type"] = "break_connection"
     return MutationResult{N,P}(; tree=tree)
@@ -556,7 +556,7 @@ function mutate!(
     options::AbstractOptions;
     recorder::RecordType,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     tree = randomly_rotate_tree!(tree)
     @recorder recorder["type"] = "rotate_tree"
     return MutationResult{N,P}(; tree=tree)
@@ -572,7 +572,7 @@ function mutate!(
     recorder::RecordType,
     parent_ref,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     @assert options.should_simplify
     simplify_tree!(tree, options.operators)
     tree = combine_operators(tree, options.operators)
@@ -593,7 +593,7 @@ function mutate!(
     curmaxsize,
     nfeatures,
     kws...,
-) where {T,N<:AbstractExpression{T},P<:PopMember}
+) where {T,N<:AbstractExpression{T},P<:AbstractPopMember}
     tree = randomize_tree(tree, curmaxsize, options, nfeatures)
     @recorder recorder["type"] = "randomize"
     return MutationResult{N,P}(; tree=tree)
@@ -608,7 +608,7 @@ function mutate!(
     recorder::RecordType,
     dataset::Dataset,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     cur_member, new_num_evals = optimize_constants(dataset, member, options)
     @recorder recorder["type"] = "optimize"
     return MutationResult{N,P}(;
@@ -625,7 +625,7 @@ function mutate!(
     recorder::RecordType,
     parent_ref,
     kws...,
-) where {N<:AbstractExpression,P<:PopMember}
+) where {N<:AbstractExpression,P<:AbstractPopMember}
     @recorder begin
         recorder["type"] = "identity"
         recorder["result"] = "accept"

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -40,9 +40,6 @@ using ..MutationWeightsModule: AbstractMutationWeights, MutationWeights, mutatio
 import ..OptionsStructModule: Options
 using ..OptionsStructModule: ComplexityMapping, operator_specialization
 using ..UtilsModule: @save_kwargs, @ignore
-
-# Forward declaration - will be defined in PopMemberModule
-function default_popmember_type end
 using ..ExpressionSpecModule:
     AbstractExpressionSpec,
     ExpressionSpec,
@@ -226,6 +223,8 @@ recommend_loss_function_expression(expression_type) = false
 
 create_mutation_weights(w::AbstractMutationWeights) = w
 create_mutation_weights(w::NamedTuple) = MutationWeights(; w...)
+
+function default_popmember_type end
 
 @unstable function with_max_degree_from_context(
     node_type, user_provided_operators, operators

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -40,6 +40,9 @@ using ..MutationWeightsModule: AbstractMutationWeights, MutationWeights, mutatio
 import ..OptionsStructModule: Options
 using ..OptionsStructModule: ComplexityMapping, operator_specialization
 using ..UtilsModule: @save_kwargs, @ignore
+
+# Forward declaration - will be defined in PopMemberModule
+function default_popmember_type end
 using ..ExpressionSpecModule:
     AbstractExpressionSpec,
     ExpressionSpec,
@@ -651,6 +654,7 @@ $(OPTION_DESCRIPTIONS)
     terminal_width::Union{Nothing,Integer}=nothing,
     use_recorder::Bool=false,
     recorder_file::AbstractString="pysr_recorder.json",
+    popmember_type::Type=default_popmember_type(),
     ### Not search options; just construction options:
     define_helper_functions::Bool=true,
     #########################################
@@ -1030,6 +1034,7 @@ $(OPTION_DESCRIPTIONS)
         expression_type,
         typeof(expression_options),
         typeof(set_mutation_weights),
+        popmember_type,
         turbo,
         bumper,
         deprecated_return_state::Union{Bool,Nothing},
@@ -1103,6 +1108,7 @@ $(OPTION_DESCRIPTIONS)
         deterministic,
         define_helper_functions,
         use_recorder,
+        popmember_type,
     )
 
     return options

--- a/src/OptionsStruct.jl
+++ b/src/OptionsStruct.jl
@@ -181,6 +181,7 @@ struct Options{
     E<:AbstractExpression,
     EO<:NamedTuple,
     MW<:AbstractMutationWeights,
+    PM,
     _turbo,
     _bumper,
     _return_state,
@@ -254,6 +255,7 @@ struct Options{
     deterministic::Bool
     define_helper_functions::Bool
     use_recorder::Bool
+    popmember_type::Type{PM}
 end
 
 function Base.print(io::IO, @nospecialize(options::Options))

--- a/src/ParametricExpression.jl
+++ b/src/ParametricExpression.jl
@@ -24,7 +24,7 @@ using ..CoreModule:
     AbstractExpressionSpec,
     get_indices,
     ExpressionSpecModule as ES
-using ..PopMemberModule: PopMember
+using ..PopMemberModule: PopMember, AbstractPopMember
 using ..InterfaceDynamicExpressionsModule: InterfaceDynamicExpressionsModule as IDE
 using ..LossFunctionsModule: LossFunctionsModule as LF
 using ..ExpressionBuilderModule: ExpressionBuilderModule as EB
@@ -102,7 +102,7 @@ end
 function MM.condition_mutate_constant!(
     ::Type{<:ParametricExpression},
     weights::AbstractMutationWeights,
-    member::PopMember,
+    member::AbstractPopMember,
     options::AbstractOptions,
     curmaxsize::Int,
 )

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -198,35 +198,25 @@ function recompute_complexity!(
     return complexity
 end
 
-# Interface for creating child members with custom field preservation
 """
-    create_child(parent::P, tree, cost, loss, options;
-                complexity::Union{Int,Nothing}=nothing, parent_ref, kwargs...) where P<:AbstractPopMember
+    create_child(parent::P, tree::AbstractExpression{T}, cost, loss, options;
+                complexity::Union{Int,Nothing}=nothing, parent_ref, kwargs...) where {T,L,P<:PopMember{T,L}}
 
-Create a new PopMember derived from a parent (mutation case).
-Custom types should override to preserve their additional fields.
-
-# Arguments
-- `parent`: The parent member being mutated
-- `tree`: The new expression tree
-- `cost`: The new cost
-- `loss`: The new loss
-- `options`: The options
-- `complexity`: The complexity (computed if not provided)
-- `parent_ref`: Reference to parent for tracking
+Create a new PopMember with a potentially different expression type.
+Used by embed_metadata where the expression gains metadata.
 """
 function create_child(
     parent::P,
-    tree::N,
+    tree::AbstractExpression{T},
     cost::L,
     loss::L,
     options;
     complexity::Union{Int,Nothing}=nothing,
     parent_ref,
     kwargs...,
-) where {T,L,N<:AbstractExpression{T},P<:PopMember{T,L,N}}
+) where {T,L,P<:PopMember{T,L}}
     actual_complexity = @something complexity compute_complexity(tree, options)
-    return constructorof(P)(
+    return PopMember(
         tree,
         cost,
         loss,
@@ -246,16 +236,16 @@ Custom types should override to blend their additional fields.
 """
 function create_child(
     parents::Tuple{P,P},
-    tree::N,
+    tree::AbstractExpression{T},
     cost::L,
     loss::L,
     options;
     complexity::Union{Int,Nothing}=nothing,
     parent_ref,
     kwargs...,
-) where {T,L,N<:AbstractExpression{T},P<:PopMember{T,L,N}}
+) where {T,L,P<:PopMember{T,L}}
     actual_complexity = @something complexity compute_complexity(tree, options)
-    return constructorof(P)(
+    return PopMember(
         tree,
         cost,
         loss,

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -224,7 +224,7 @@ function create_child(
     complexity::Union{Int,Nothing}=nothing,
     parent_ref,
     kwargs...,
-) where {T,L,N<:AbstractExpression{T},P<:AbstractPopMember{T,L,N}}
+) where {T,L,N<:AbstractExpression{T},P<:PopMember{T,L,N}}
     actual_complexity = @something complexity compute_complexity(tree, options)
     return constructorof(P)(
         tree,
@@ -253,7 +253,7 @@ function create_child(
     complexity::Union{Int,Nothing}=nothing,
     parent_ref,
     kwargs...,
-) where {T,L,N<:AbstractExpression{T},P<:AbstractPopMember{T,L,N}}
+) where {T,L,N<:AbstractExpression{T},P<:PopMember{T,L,N}}
     actual_complexity = @something complexity compute_complexity(tree, options)
     return constructorof(P)(
         tree,

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -260,7 +260,7 @@ end
 # Function to extract PopMember type from Population or HallOfFame types
 function popmember_type end
 
-default_popmember_type() = PopMember
-constructorof(::Type{<:PopMember}) = PopMember
+@unstable default_popmember_type() = PopMember
+@unstable constructorof(::Type{<:PopMember}) = PopMember
 
 end

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -2,7 +2,7 @@ module PopMemberModule
 
 using DispatchDoctor: @unstable
 using DynamicExpressions: AbstractExpression, AbstractExpressionNode, string_tree
-import DynamicExpressions: constructorof
+import DynamicExpressions: constructorof, with_type_parameters
 using ..CoreModule: AbstractOptions, Dataset, DATA_TYPE, LOSS_TYPE, create_expression
 import ..CoreModule.OptionsModule: default_popmember_type
 import ..ComplexityModule: compute_complexity
@@ -265,6 +265,16 @@ function popmember_type end
     ::Type{<:PopMember{T,L}}, ::Type{N}
 ) where {T,L,N<:AbstractExpression{T}}
     return PopMember{T,L,N}
+end
+
+@inline function with_type_parameters(
+    ::Type{<:PopMember}, ::Type{T}, ::Type{L}, ::Type{N}
+) where {T,L,N}
+    return PopMember{T,L,N}
+end
+
+@inline function expression_type(::Type{<:AbstractPopMember{<:Any,<:Any,N}}) where {N}
+    return N
 end
 
 end

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -201,7 +201,7 @@ end
 
 """
     create_child(parent::P, tree::AbstractExpression{T}, cost, loss, options;
-                complexity::Union{Int,Nothing}=nothing, parent_ref, kwargs...) where {T,L,P<:PopMember{T,L}}
+                complexity::Union{Int,Nothing}=nothing, parent_ref) where {T,L,P<:PopMember{T,L}}
 
 Create a new PopMember with a potentially different expression type.
 Used by embed_metadata where the expression gains metadata.
@@ -214,7 +214,6 @@ function create_child(
     options;
     complexity::Union{Int,Nothing}=nothing,
     parent_ref,
-    kwargs...,
 ) where {T,L,P<:PopMember{T,L}}
     actual_complexity = @something complexity compute_complexity(tree, options)
     return PopMember(
@@ -230,7 +229,7 @@ end
 
 """
     create_child(parents::Tuple{P,P}, tree, cost, loss, options;
-                complexity::Union{Int,Nothing}=nothing, parent_ref, kwargs...) where P<:AbstractPopMember
+                complexity::Union{Int,Nothing}=nothing, parent_ref) where P<:AbstractPopMember
 
 Create a new PopMember from two parents (crossover case).
 Custom types should override to blend their additional fields.
@@ -243,7 +242,6 @@ function create_child(
     options;
     complexity::Union{Int,Nothing}=nothing,
     parent_ref,
-    kwargs...,
 ) where {T,L,P<:PopMember{T,L}}
     actual_complexity = @something complexity compute_complexity(tree, options)
     return PopMember(
@@ -262,5 +260,11 @@ function popmember_type end
 
 @unstable default_popmember_type() = PopMember
 @unstable constructorof(::Type{<:PopMember}) = PopMember
+
+@inline function with_expression_type(
+    ::Type{<:PopMember{T,L}}, ::Type{N}
+) where {T,L,N<:AbstractExpression{T}}
+    return PopMember{T,L,N}
+end
 
 end

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -4,6 +4,7 @@ using DispatchDoctor: @unstable
 using DynamicExpressions: AbstractExpression, AbstractExpressionNode, string_tree
 import DynamicExpressions: constructorof
 using ..CoreModule: AbstractOptions, Dataset, DATA_TYPE, LOSS_TYPE, create_expression
+import ..CoreModule.OptionsModule: default_popmember_type
 import ..ComplexityModule: compute_complexity
 using ..UtilsModule: get_birth_order
 using ..LossFunctionsModule: eval_cost
@@ -259,10 +260,7 @@ end
 # Function to extract PopMember type from Population or HallOfFame types
 function popmember_type end
 
-# Default PopMember type for Options
-import ..CoreModule.OptionsModule: default_popmember_type
 default_popmember_type() = PopMember
-
 constructorof(::Type{<:PopMember}) = PopMember
 
 end

--- a/src/PopMember.jl
+++ b/src/PopMember.jl
@@ -164,7 +164,7 @@ function PopMember(
     )
 end
 
-function Base.copy(p::P) where {P<:AbstractPopMember}
+function Base.copy(p::PopMember)
     tree = copy(p.tree)
     cost = copy(p.cost)
     loss = copy(p.loss)
@@ -172,7 +172,7 @@ function Base.copy(p::P) where {P<:AbstractPopMember}
     complexity = copy(getfield(p, :complexity))
     ref = copy(p.ref)
     parent = copy(p.parent)
-    return P(tree, cost, loss, birth, complexity, ref, parent)
+    return PopMember(tree, cost, loss, birth, complexity, ref, parent)
 end
 
 function reset_birth!(p::AbstractPopMember; deterministic::Bool)

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -171,7 +171,7 @@ function _best_of_sample(
     end
     return members[chosen_idx]
 end
-_get_cost(member::PopMember) = member.cost
+_get_cost(member::AbstractPopMember) = member.cost
 
 const CACHED_WEIGHTS =
     let init_k = collect(0:5),

--- a/src/Population.jl
+++ b/src/Population.jl
@@ -2,8 +2,7 @@ module PopulationModule
 
 using StatsBase: StatsBase
 using DispatchDoctor: @unstable
-using DynamicExpressions: AbstractExpression, string_tree
-using ConstructionBase: constructorof
+using DynamicExpressions: AbstractExpression, string_tree, constructorof
 using ..CoreModule: AbstractOptions, Options, Dataset, RecordType, DATA_TYPE, LOSS_TYPE
 using ..ComplexityModule: compute_complexity
 using ..LossFunctionsModule: eval_cost, update_baseline_loss!

--- a/src/SearchUtils.jl
+++ b/src/SearchUtils.jl
@@ -793,7 +793,7 @@ end
 
 """Parse user-provided guess expressions and convert them into optimized
 `PopMember` objects for each output dataset."""
-function parse_guesses(
+@unstable function parse_guesses(
     ::Type{P},
     guesses::Union{AbstractVector,AbstractVector{<:AbstractVector}},
     datasets::Vector{D},
@@ -828,7 +828,7 @@ function parse_guesses(
 end
 
 # Deal with non-concrete PopMember types
-function parse_guesses(
+@unstable function parse_guesses(
     ::Type{P},
     guesses::Union{AbstractVector,AbstractVector{<:AbstractVector}},
     datasets::Vector{D},

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -297,7 +297,8 @@ using .MutationFunctionsModule:
 using .InterfaceDynamicExpressionsModule:
     @extend_operators, require_copy_to_workers, make_example_inputs
 using .LossFunctionsModule: eval_loss, eval_cost, update_baseline_loss!, score_func
-using .PopMemberModule: AbstractPopMember, PopMember, reset_birth!, popmember_type
+using .PopMemberModule:
+    AbstractPopMember, PopMember, reset_birth!, popmember_type, expression_type
 using .CoreModule.UtilsModule: get_birth_order
 using .PopulationModule: Population, best_sub_pop, record_population, best_of_sample
 using .HallOfFameModule:
@@ -339,7 +340,8 @@ using .SearchUtilsModule:
     get_cur_maxsize,
     update_hall_of_fame!,
     parse_guesses,
-    logging_callback!
+    logging_callback!,
+    infer_popmember_type
 using .LoggingModule: AbstractSRLogger, SRLogger, get_logger
 using .TemplateExpressionModule:
     TemplateExpression, TemplateStructure, TemplateExpressionSpec, ParamVector, has_params
@@ -631,20 +633,8 @@ end
     @recorder record["options"] = "$(options)"
 
     nout = length(datasets)
-    example_dataset = first(datasets)
-    example_ex = create_expression(init_value(T), options, example_dataset)
-    NT = typeof(example_ex)
-    # Create a prototype member to get the concrete type
-    prototype_member = options.popmember_type(
-        copy(example_ex),
-        L(0),
-        L(Inf),
-        options,
-        1;  # complexity
-        parent=-1,
-        deterministic=options.deterministic,
-    )
-    PMType = typeof(prototype_member)
+    PMType = infer_popmember_type(T, L, D, options)
+    NT = expression_type(PMType)
     PopType = Population{T,L,NT,PMType}
     HallOfFameType = HallOfFame{T,L,NT,PMType}
     WorkerOutputType = get_worker_output_type(

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -2,7 +2,6 @@ module SymbolicRegression
 
 # Types
 export Population,
-    AbstractPopMember,
     PopMember,
     HallOfFame,
     Options,

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -52,7 +52,7 @@ using ..CheckConstraintsModule: CheckConstraintsModule as CC
 using ..ComplexityModule: ComplexityModule
 using ..LossFunctionsModule: LossFunctionsModule as LF
 using ..MutateModule: MutateModule as MM
-using ..PopMemberModule: PopMember
+using ..PopMemberModule: PopMember, AbstractPopMember
 using ..ComposableExpressionModule: ComposableExpression, ValidVector
 
 struct ParamVector{T} <: AbstractVector{T}
@@ -745,7 +745,7 @@ function MM.condition_mutation_weights!(
     @nospecialize(options::AbstractOptions),
     curmaxsize::Int,
     nfeatures::Int,
-) where {T,L,N<:TemplateExpression,P<:PopMember{T,L,N}}
+) where {T,L,N<:TemplateExpression,P<:AbstractPopMember{T,L,N}}
     if !preserve_sharing(typeof(member.tree))
         weights.form_connection = 0.0
         weights.break_connection = 0.0
@@ -828,7 +828,7 @@ end
 function MM.condition_mutate_constant!(
     ::Type{<:TemplateExpression},
     weights::AbstractMutationWeights,
-    member::PopMember,
+    member::AbstractPopMember,
     options::AbstractOptions,
     curmaxsize::Int,
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,6 +164,7 @@ end
 end
 
 include("test_abstract_numbers.jl")
+include("test_abstract_popmember.jl")
 
 include("test_logging.jl")
 include("test_pretty_printing.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,8 @@ include("test_options.jl")
     include("test_hash.jl")
 end
 
+include("test_hof_rows.jl")
+
 @testitem "Test migration" tags = [:part3] begin
     include("test_migration.jl")
 end

--- a/test/test_abstract_popmember.jl
+++ b/test/test_abstract_popmember.jl
@@ -101,7 +101,6 @@
         options;
         complexity::Union{Int,Nothing}=nothing,
         parent_ref,
-        kwargs...,
     ) where {T,L}
         actual_complexity = @something complexity SymbolicRegression.compute_complexity(
             tree, options
@@ -126,7 +125,6 @@
         options;
         complexity::Union{Int,Nothing}=nothing,
         parent_ref,
-        kwargs...,
     ) where {T,L,N<:AbstractExpression{T}}
         actual_complexity = @something complexity SymbolicRegression.compute_complexity(
             tree, options

--- a/test/test_abstract_popmember.jl
+++ b/test/test_abstract_popmember.jl
@@ -79,6 +79,13 @@
 
     @unstable DynamicExpressions.constructorof(::Type{<:CustomPopMember}) = CustomPopMember
 
+    # Define with_type_parameters for CustomPopMember
+    @unstable function DynamicExpressions.with_type_parameters(
+        ::Type{<:CustomPopMember}, ::Type{T}, ::Type{L}, ::Type{N}
+    ) where {T,L,N}
+        return CustomPopMember{T,L,N}
+    end
+
     # Define copy for CustomPopMember
     function Base.copy(p::CustomPopMember)
         return CustomPopMember(

--- a/test/test_abstract_popmember.jl
+++ b/test/test_abstract_popmember.jl
@@ -2,6 +2,7 @@
     using SymbolicRegression
     using DynamicExpressions
     using Test
+    using DispatchDoctor: @unstable
 
     import SymbolicRegression.PopMemberModule: create_child
 
@@ -76,7 +77,7 @@
         )
     end
 
-    DynamicExpressions.constructorof(::Type{<:CustomPopMember}) = CustomPopMember
+    @unstable DynamicExpressions.constructorof(::Type{<:CustomPopMember}) = CustomPopMember
 
     # Define copy for CustomPopMember
     function Base.copy(p::CustomPopMember)

--- a/test/test_abstract_popmember.jl
+++ b/test/test_abstract_popmember.jl
@@ -1,0 +1,186 @@
+@testitem "Custom AbstractPopMember implementation" tags = [:part1] begin
+    using SymbolicRegression
+    using DynamicExpressions
+    using Test
+
+    import SymbolicRegression.PopMemberModule: create_child
+
+    # Define a custom PopMember that tracks generation count
+    mutable struct CustomPopMember{T,L,N} <: SymbolicRegression.AbstractPopMember{T,L,N}
+        tree::N
+        cost::L
+        loss::L
+        birth::Int
+        complexity::Int
+        ref::Int
+        parent::Int
+        generation::Int  # Custom field to track generation
+    end
+
+    # # Direct constructor that matches field order
+    function CustomPopMember(
+        tree::N,
+        cost::L,
+        loss::L,
+        birth::Int,
+        complexity::Int,
+        ref::Int,
+        parent::Int,
+        generation::Int,
+    ) where {T,L,N<:AbstractExpression{T}}
+        return CustomPopMember{T,L,N}(
+            tree, cost, loss, birth, complexity, ref, parent, generation
+        )
+    end
+
+    function CustomPopMember(
+        tree::N,
+        cost::L,
+        loss::L,
+        options,
+        complexity::Int;
+        parent=-1,
+        deterministic=nothing,
+    ) where {T,L,N<:AbstractExpression{T}}
+        return CustomPopMember(
+            tree,
+            cost,
+            loss,
+            SymbolicRegression.get_birth_order(; deterministic=deterministic),
+            complexity,
+            abs(rand(Int)),
+            parent,
+            0,  # Initial generation
+        )
+    end
+
+    # Constructor for Population initialization (dataset, tree, options)
+    function CustomPopMember(
+        dataset::SymbolicRegression.Dataset, tree, options; parent=-1, deterministic=nothing
+    )
+        ex = SymbolicRegression.create_expression(tree, options, dataset)
+        complexity = SymbolicRegression.compute_complexity(ex, options)
+        cost, loss = SymbolicRegression.eval_cost(
+            dataset, ex, options; complexity=complexity
+        )
+
+        return CustomPopMember(
+            ex,
+            cost,
+            loss,
+            SymbolicRegression.get_birth_order(; deterministic=deterministic),
+            complexity,
+            abs(rand(Int)),
+            parent,
+            0,  # Initial generation
+        )
+    end
+
+    DynamicExpressions.constructorof(::Type{<:CustomPopMember}) = CustomPopMember
+
+    # Define copy for CustomPopMember
+    function Base.copy(p::CustomPopMember)
+        return CustomPopMember(
+            copy(p.tree),
+            copy(p.cost),
+            copy(p.loss),
+            copy(p.birth),
+            copy(getfield(p, :complexity)),
+            copy(p.ref),
+            copy(p.parent),
+            copy(p.generation),
+        )
+    end
+
+    function create_child(
+        parent::CustomPopMember{T,L},
+        tree::AbstractExpression{T},
+        cost::L,
+        loss::L,
+        options;
+        complexity::Union{Int,Nothing}=nothing,
+        parent_ref,
+        kwargs...,
+    ) where {T,L}
+        actual_complexity = @something complexity SymbolicRegression.compute_complexity(
+            tree, options
+        )
+        return CustomPopMember(
+            tree,
+            cost,
+            loss,
+            SymbolicRegression.get_birth_order(; deterministic=options.deterministic),
+            actual_complexity,
+            abs(rand(Int)),
+            parent_ref,
+            parent.generation + 1,
+        )
+    end
+
+    function create_child(
+        parents::Tuple{<:CustomPopMember,<:CustomPopMember},
+        tree::N,
+        cost::L,
+        loss::L,
+        options;
+        complexity::Union{Int,Nothing}=nothing,
+        parent_ref,
+        kwargs...,
+    ) where {T,L,N<:AbstractExpression{T}}
+        actual_complexity = @something complexity SymbolicRegression.compute_complexity(
+            tree, options
+        )
+        max_generation = max(parents[1].generation, parents[2].generation)
+        return CustomPopMember(
+            tree,
+            cost,
+            loss,
+            SymbolicRegression.CoreModule.UtilsModule.get_birth_order(;
+                deterministic=options.deterministic
+            ),
+            actual_complexity,
+            abs(rand(Int)),
+            parent_ref,
+            max_generation + 1,
+        )
+    end
+
+    # Test that we can run equation_search with CustomPopMember
+    X = randn(Float32, 2, 100)
+    y = @. X[1, :]^2 - X[2, :]
+
+    options = SymbolicRegression.Options(;
+        binary_operators=[+, -],
+        populations=1,
+        population_size=20,
+        maxsize=5,
+        popmember_type=CustomPopMember,
+        deterministic=true,
+        seed=0,
+    )
+
+    # Test that options were created with correct type
+    @test options.popmember_type == CustomPopMember
+
+    hall_of_fame = equation_search(
+        X, y; options=options, niterations=2, parallelism=:serial
+    )
+
+    # Verify that we got results
+    @test sum(hall_of_fame.exists) > 0
+
+    # Verify that the members are CustomPopMember
+    for i in eachindex(hall_of_fame.members, hall_of_fame.exists)
+        if hall_of_fame.exists[i]
+            @test hall_of_fame.members[i] isa CustomPopMember
+            # Check that generation field exists
+            @test hall_of_fame.members[i].generation >= 0
+        end
+    end
+
+    # Verify we can extract the best member
+    best_idx = findlast(hall_of_fame.exists)
+    @test !isnothing(best_idx)
+    best_member = hall_of_fame.members[best_idx]
+    @test best_member isa CustomPopMember
+end

--- a/test/test_hof_rows.jl
+++ b/test/test_hof_rows.jl
@@ -1,0 +1,369 @@
+@testitem "HOF rows functionality" tags = [:part1] begin
+    using SymbolicRegression
+    using DynamicExpressions
+    using Test
+
+    # Create test data
+    X = Float32[1.0 2.0 3.0; 4.0 5.0 6.0]
+    y = Float32[1.0, 2.0, 3.0]
+
+    options = Options(;
+        binary_operators=[+, -],
+        unary_operators=[],
+        maxsize=5,
+        populations=1,
+        population_size=10,
+        tournament_selection_n=3,
+        deterministic=true,
+        seed=0,
+    )
+
+    dataset = Dataset(X, y)
+
+    @testset "compute_scores" begin
+        # Create a simple HOF with multiple members
+        hof = SymbolicRegression.HallOfFameModule.HallOfFame(options, dataset)
+
+        # Add multiple members with different complexities
+        for i in 1:3
+            hof.exists[i] = true
+        end
+
+        members = [hof.members[i] for i in 1:3 if hof.exists[i]]
+
+        # Test score computation
+        scores = SymbolicRegression.HallOfFameModule.compute_scores(members, options)
+
+        @test length(scores) == length(members)
+        @test scores[1] == 0  # First member always has score 0
+        @test all(s >= 0 for s in scores)  # Scores should be non-negative
+
+        # Test with empty members
+        empty_scores = SymbolicRegression.HallOfFameModule.compute_scores(
+            typeof(members[1])[], options
+        )
+        @test isempty(empty_scores)
+    end
+
+    @testset "HOFRows iteration" begin
+        hof = SymbolicRegression.HallOfFameModule.HallOfFame(options, dataset)
+        hof.exists[1] = true
+        hof.exists[2] = true
+
+        rows = SymbolicRegression.HallOfFameModule.hof_rows(
+            hof, dataset, options; pareto_only=false, include_score=true
+        )
+
+        # Test Base.length
+        @test length(rows) == 2
+
+        # Test Base.eltype
+        @test eltype(rows) == NamedTuple
+
+        # Test iteration
+        collected = collect(rows)
+        @test length(collected) == 2
+        @test all(r isa NamedTuple for r in collected)
+
+        # Test that scores are included by default for pareto_only=true
+        @test all(haskey(r, :score) for r in collected)
+
+        # Test equation inclusion
+        @test all(haskey(r, :equation) for r in collected)
+    end
+
+    @testset "hof_rows options" begin
+        hof = SymbolicRegression.HallOfFameModule.HallOfFame(options, dataset)
+        for i in 1:3
+            hof.exists[i] = true
+        end
+
+        # Test pareto_only=false
+        rows_all = SymbolicRegression.HallOfFameModule.hof_rows(
+            hof, dataset, options; pareto_only=false
+        )
+        # Should include all existing members (Pareto might filter some)
+        @test length(rows_all) == 3
+
+        # Test include_score=false
+        rows_no_score = SymbolicRegression.HallOfFameModule.hof_rows(
+            hof, dataset, options; include_score=false
+        )
+        for row in rows_no_score
+            @test !haskey(row, :score)
+        end
+    end
+
+    @testset "Empty HOF" begin
+        hof = SymbolicRegression.HallOfFameModule.HallOfFame(options, dataset)
+        # Don't mark any as existing
+
+        rows = SymbolicRegression.HallOfFameModule.hof_rows(hof, dataset, options)
+
+        @test length(rows) == 0
+        @test isempty(collect(rows))
+    end
+
+    @testset "Backwards compatibility" begin
+        hof = SymbolicRegression.HallOfFameModule.HallOfFame(options, dataset)
+        hof.exists[1] = true
+        hof.exists[2] = true
+
+        # Test that format_hall_of_fame still works
+        formatted = SymbolicRegression.HallOfFameModule.format_hall_of_fame(hof, options)
+
+        @test haskey(formatted, :trees)
+        @test haskey(formatted, :scores)
+        @test haskey(formatted, :losses)
+        @test haskey(formatted, :complexities)
+        @test length(formatted.trees) == length(formatted.scores)
+        @test length(formatted.trees) == length(formatted.losses)
+        @test length(formatted.trees) == length(formatted.complexities)
+
+        # Test that string_dominating_pareto_curve still works
+        curve_string = SymbolicRegression.HallOfFameModule.string_dominating_pareto_curve(
+            hof, dataset, options
+        )
+
+        @test curve_string isa AbstractString
+        @test contains(curve_string, "Complexity")
+        @test contains(curve_string, "Loss")
+    end
+end
+
+@testitem "HOF rows with custom PopMember" tags = [:part1] begin
+    using SymbolicRegression
+    using DynamicExpressions
+    using Test
+    using DispatchDoctor: @unstable
+
+    import SymbolicRegression.PopMemberModule: create_child
+    import SymbolicRegression.HallOfFameModule: member_to_row
+
+    # Define a custom PopMember with an extra field
+    mutable struct TestCustomPopMember{T,L,N} <: SymbolicRegression.AbstractPopMember{T,L,N}
+        tree::N
+        cost::L
+        loss::L
+        birth::Int
+        complexity::Int
+        ref::Int
+        parent::Int
+        custom_field::Float64  # Extra field
+    end
+
+    # Constructor
+    function TestCustomPopMember(
+        tree::N,
+        cost::L,
+        loss::L,
+        birth::Int,
+        complexity::Int,
+        ref::Int,
+        parent::Int,
+        custom_field::Float64,
+    ) where {T,L,N<:AbstractExpression{T}}
+        return TestCustomPopMember{T,L,N}(
+            tree, cost, loss, birth, complexity, ref, parent, custom_field
+        )
+    end
+
+    function TestCustomPopMember(
+        tree::N,
+        cost::L,
+        loss::L,
+        options,
+        complexity::Int;
+        parent=-1,
+        deterministic=nothing,
+        custom_field=1.0,
+    ) where {T,L,N<:AbstractExpression{T}}
+        return TestCustomPopMember(
+            tree,
+            cost,
+            loss,
+            SymbolicRegression.get_birth_order(; deterministic=deterministic),
+            complexity,
+            abs(rand(Int)),
+            parent,
+            custom_field,
+        )
+    end
+
+    function TestCustomPopMember(
+        dataset::SymbolicRegression.Dataset,
+        tree,
+        options;
+        parent=-1,
+        deterministic=nothing,
+        custom_field=1.0,
+    )
+        ex = SymbolicRegression.create_expression(tree, options, dataset)
+        complexity = SymbolicRegression.compute_complexity(ex, options)
+        cost, loss = SymbolicRegression.eval_cost(dataset, ex, options; complexity)
+
+        return TestCustomPopMember(
+            ex,
+            cost,
+            loss,
+            SymbolicRegression.get_birth_order(; deterministic=deterministic),
+            complexity,
+            abs(rand(Int)),
+            parent,
+            custom_field,
+        )
+    end
+
+    @unstable DynamicExpressions.constructorof(::Type{<:TestCustomPopMember}) =
+        TestCustomPopMember
+
+    @unstable function DynamicExpressions.with_type_parameters(
+        ::Type{<:TestCustomPopMember}, ::Type{T}, ::Type{L}, ::Type{N}
+    ) where {T,L,N}
+        return TestCustomPopMember{T,L,N}
+    end
+
+    function Base.copy(p::TestCustomPopMember)
+        return TestCustomPopMember(
+            copy(p.tree),
+            copy(p.cost),
+            copy(p.loss),
+            copy(p.birth),
+            copy(getfield(p, :complexity)),
+            copy(p.ref),
+            copy(p.parent),
+            copy(p.custom_field),
+        )
+    end
+
+    function create_child(
+        parent::CustomPopMember{T,L},
+        tree::AbstractExpression{T},
+        cost::L,
+        loss::L,
+        options;
+        complexity::Union{Int,Nothing}=nothing,
+        parent_ref,
+    ) where {T,L}
+        actual_complexity = @something complexity SymbolicRegression.compute_complexity(
+            tree, options
+        )
+        return TestCustomPopMember(
+            tree,
+            cost,
+            loss,
+            SymbolicRegression.get_birth_order(; deterministic=options.deterministic),
+            actual_complexity,
+            abs(rand(Int)),
+            parent_ref,
+            parent.custom_field * 1.1,  # Modify custom field
+        )
+    end
+
+    # Extend member_to_row for custom PopMember
+    function member_to_row(
+        member::TestCustomPopMember,
+        dataset::SymbolicRegression.Dataset,
+        options::SymbolicRegression.AbstractOptions;
+        kwargs...,
+    )
+        base = invoke(
+            member_to_row,
+            Tuple{
+                SymbolicRegression.AbstractPopMember,
+                SymbolicRegression.Dataset,
+                SymbolicRegression.AbstractOptions,
+            },
+            member,
+            dataset,
+            options;
+            kwargs...,
+        )
+        return merge(base, (custom_field=member.custom_field,))
+    end
+
+    @testset "Custom PopMember with member_to_row extension" begin
+        X = Float32[1.0 2.0 3.0; 4.0 5.0 6.0]
+        y = Float32[1.0, 2.0, 3.0]
+
+        options = Options(;
+            binary_operators=[+, -],
+            maxsize=5,
+            popmember_type=TestCustomPopMember,
+            deterministic=true,
+            seed=0,
+        )
+
+        dataset = Dataset(X, y)
+
+        # Create a custom member
+        tree = SymbolicRegression.create_expression(1.0f0, options, dataset)
+        custom_member = TestCustomPopMember(
+            dataset, tree, options; deterministic=true, custom_field=42.0
+        )
+
+        # Test that member_to_row includes custom field
+        row = member_to_row(custom_member, dataset, options)
+
+        @test haskey(row, :custom_field)
+        @test row.custom_field == 42.0
+        @test haskey(row, :complexity)
+        @test haskey(row, :loss)
+        @test haskey(row, :equation)
+
+        # Test with HOF
+        hof = SymbolicRegression.HallOfFameModule.HallOfFame(options, dataset)
+        hof.members[1] = custom_member
+        hof.exists[1] = true
+
+        rows = SymbolicRegression.HallOfFameModule.hof_rows(hof, dataset, options)
+        collected = collect(rows)
+
+        @test length(collected) == 1
+        @test haskey(collected[1], :custom_field)
+        @test collected[1].custom_field == 42.0
+    end
+end
+
+@testitem "Tables.jl extension" tags = [:part1] begin
+    using SymbolicRegression
+    using Test
+
+    # Only run if Tables.jl is available
+    if isdefined(Base, :get_extension)
+        # Try to load Tables
+        try
+            @eval using Tables
+
+            @testset "Tables.jl integration" begin
+                X = Float32[1.0 2.0 3.0; 4.0 5.0 6.0]
+                y = Float32[1.0, 2.0, 3.0]
+
+                options = Options(;
+                    binary_operators=[+, -], maxsize=5, deterministic=true, seed=0
+                )
+
+                dataset = Dataset(X, y)
+                hof = SymbolicRegression.HallOfFameModule.HallOfFame(options, dataset)
+                hof.exists[1] = true
+
+                rows = SymbolicRegression.HallOfFameModule.hof_rows(hof, dataset, options)
+
+                # Test Tables.jl interface
+                @test Tables.istable(rows)
+                @test Tables.rowaccess(rows)
+                @test Tables.rows(rows) === rows  # Should return itself
+
+                # Test that it works with Tables.columntable
+                ct = Tables.columntable(rows)
+                @test ct isa NamedTuple
+                @test haskey(ct, :complexity)
+                @test haskey(ct, :loss)
+            end
+        catch e
+            @info "Skipping Tables.jl tests (Tables.jl not available): $e"
+        end
+    else
+        @info "Skipping Tables.jl tests (Julia version < 1.9)"
+    end
+end


### PR DESCRIPTION
Right now, `HallOfFame.jl` is overfit to only a set of  pre-existing metrics (Score / Equation / Complexity). With the introduction of `AbstractPopMember` we now have the mechanism to track a lot more metrics. This (and following) PR is an  attempt to generalize the framework by allowing users to add arbitrary metrics in rows and filter by arbitrary columns.
    
This also opens up the API to `Tables.jl` through the SymbolicRegressionTablesExt.jl file which will, amongst other things, allow us to save the hall-of-fame as a DataFrame.jl or a JuliaDB.