### PR TITLE
Restore accidentally dropped Enzyme mention in docs

### DIFF
--- a/src/Options.jl
+++ b/src/Options.jl
@@ -436,7 +436,7 @@ const OPTION_DESCRIPTIONS = """- `defaults`: What set of defaults to use for `Op
     an instance of `AbstractADType` (see `ADTypes.jl`).
     Default is `nothing`, which means `Optim.jl` will estimate gradients (likely
     with finite differences). You can also pass a symbolic version of the backend
-    type, such as `:Enzyme` for Enzyme.jl,  `:Mooncake` for Mooncake.jl, or 
+    type, such as `:Enzyme` for Enzyme.jl,  `:Mooncake` for Mooncake.jl, or
     `:Zygote` for Zygote.jl. Most backends will not work, and many will never work
     due to incompatibilities, though support for some is gradually being added.
 - `perturbation_factor`: When mutating a constant, either


### PR DESCRIPTION
was seemingly accidentally removed in https://github.com/MilesCranmer/SymbolicRegression.jl/pull/468