### PR TITLE
ci: pin JuliaFormatter to 2.4.0 in format workflows

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -25,7 +25,7 @@ jobs:
         uses: julia-actions/cache@v3
       - name: Install JuliaFormatter and format
         run: |
-          julia --startup-file=no -e 'using Pkg; pkg"activate --temp"; pkg"add JuliaFormatter@2"; using JuliaFormatter; format("."; verbose=true)'
+          julia --startup-file=no -e 'using Pkg; pkg"activate --temp"; pkg"add JuliaFormatter@2.4.0"; using JuliaFormatter; format("."; verbose=true)'
       - name: "Format check"
         run: |
           julia -e '

--- a/.github/workflows/fix-format.yml
+++ b/.github/workflows/fix-format.yml
@@ -20,7 +20,7 @@ jobs:
         uses: julia-actions/cache@v3
       - name: "Install JuliaFormatter and format"
         run: |
-          julia  -e 'using Pkg; pkg"add JuliaFormatter@1.0.61"'
+          julia  -e 'using Pkg; pkg"add JuliaFormatter@2.4.0"'
           julia  -e 'using JuliaFormatter; format(".")'
       - name: "Create Pull Request"
         id: cpr


### PR DESCRIPTION
`check-format` pinned JuliaFormatter to a floating `@2`, so CI used whatever 2.x patch was newest at run time. JuliaFormatter 2.5.x changed formatting (e.g. it rewraps multi-line signatures), so files across the repo now fail the check despite being unchanged from master, e.g. `src/CheckConstraints.jl`. master itself would fail `check-format` if re-triggered.

this pins `check-format` and `fix-format` to `2.4.0`, the version the repo is currently formatted against (verified `format(".")` is a no-op on master). `fix-format` was separately stuck on `1.0.61`, which formats to v1 style and would fight the v2 checker.