### PR TITLE
Add TemplateExpression shared-state optimization hooks

### DIFF
--- a/ext/SymbolicRegressionMooncakeExt.jl
+++ b/ext/SymbolicRegressionMooncakeExt.jl
@@ -2,13 +2,46 @@ module SymbolicRegressionMooncakeExt
 
 using DynamicExpressions: DynamicExpressions as DE
 using SymbolicRegression: SymbolicRegression as SR
-using SymbolicRegression.ConstantOptimizationModule: count_constants_for_optimization
 using Mooncake: Mooncake
+
+function SR.ComposableExpressionModule._composable_gradient_tree(
+    gradient::Mooncake.Tangent
+)
+    return gradient.fields.tree
+end
+
+function SR.ComposableExpressionModule._extract_composable_gradient_for_optimization(
+    gradient::Mooncake.Tangent, ex::SR.ComposableExpression
+)
+    return DE.extract_gradient(gradient, ex)
+end
+
+function SR.TemplateExpressionModule._template_inner_gradient(
+    gradient::Mooncake.Tangent, ::SR.TemplateExpression, key::Symbol
+)
+    tree_gradient = getproperty(gradient.fields.trees, key)
+    @assert(
+        !(tree_gradient isa Mooncake.NoTangent),
+        "Unexpected input type: $(tree_gradient)::$(typeof(tree_gradient))"
+    )
+    return tree_gradient
+end
+
+function SR.TemplateExpressionModule._template_parameter_gradient_data(
+    gradient::Mooncake.Tangent, ::SR.TemplateExpression, key::Symbol
+)
+    param_gradient = getproperty(gradient.fields.metadata.fields._data.parameters, key)
+    @assert(
+        !(param_gradient isa Mooncake.NoTangent),
+        "Unexpected input type: $(param_gradient)::$(typeof(param_gradient))"
+    )
+    return param_gradient.fields._data
+end
 
 function DE.extract_gradient(
     gradient::Mooncake.Tangent, ex::SR.TemplateExpression{T}
 ) where {T}
-    n_const = count_constants_for_optimization(ex)
+    n_const = DE.count_scalar_constants(ex)
     out = Array{T}(undef, n_const)
     i = firstindex(out)
     for (tree_gradient, tree) in zip(values(gradient.fields.trees), values(ex.trees))

--- a/ext/SymbolicRegressionMooncakeExt.jl
+++ b/ext/SymbolicRegressionMooncakeExt.jl
@@ -4,9 +4,7 @@ using DynamicExpressions: DynamicExpressions as DE
 using SymbolicRegression: SymbolicRegression as SR
 using Mooncake: Mooncake
 
-function SR.ComposableExpressionModule._composable_gradient_tree(
-    gradient::Mooncake.Tangent
-)
+function SR.ComposableExpressionModule._composable_gradient_tree(gradient::Mooncake.Tangent)
     return gradient.fields.tree
 end
 

--- a/src/ComposableExpression.jl
+++ b/src/ComposableExpression.jl
@@ -124,7 +124,9 @@ function _composable_gradient_tree(grad)
 end
 function _extract_composable_gradient_for_optimization(grad, ex::ComposableExpression)
     tree_grad = _composable_gradient_tree(grad)
-    return DE.extract_gradient((; tree=tree_grad, metadata=nothing), convert(Expression, ex))
+    return DE.extract_gradient(
+        (; tree=tree_grad, metadata=nothing), convert(Expression, ex)
+    )
 end
 function CO.extract_gradient_for_optimization(grad, ex::ComposableExpression)
     return _extract_composable_gradient_for_optimization(grad, ex)

--- a/src/ComposableExpression.jl
+++ b/src/ComposableExpression.jl
@@ -119,6 +119,16 @@ end
 function CO.count_constants_for_optimization(ex::AbstractComposableExpression)
     return CO.count_constants_for_optimization(convert(Expression, ex))
 end
+function _composable_gradient_tree(grad)
+    return hasproperty(grad, :tree) ? getproperty(grad, :tree) : get_contents(grad)
+end
+function _extract_composable_gradient_for_optimization(grad, ex::ComposableExpression)
+    tree_grad = _composable_gradient_tree(grad)
+    return DE.extract_gradient((; tree=tree_grad, metadata=nothing), convert(Expression, ex))
+end
+function CO.extract_gradient_for_optimization(grad, ex::ComposableExpression)
+    return _extract_composable_gradient_for_optimization(grad, ex)
+end
 
 struct PreallocatedComposableExpression{N}
     tree::N

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -214,6 +214,10 @@ using Compat: @compat, Fix
         on_cycle_start!,
         prepare_mutation_context,
         condition_mutation!,
+        NoTemplateSharedState, template_shared_state, get_template_shared_state,
+        copy_template_shared_state, attach_template_shared_state,
+        get_template_constants_for_optimization, set_template_constants_for_optimization!,
+        extract_template_gradient_for_optimization,
     )
 )
 #! format: on
@@ -425,7 +429,19 @@ using .SearchUtilsModule:
     infer_popmember_type
 using .LoggingModule: AbstractSRLogger, SRLogger, get_logger
 using .TemplateExpressionModule:
-    TemplateExpression, TemplateStructure, TemplateExpressionSpec, ParamVector, has_params
+    TemplateExpression,
+    TemplateStructure,
+    TemplateExpressionSpec,
+    ParamVector,
+    has_params,
+    NoTemplateSharedState,
+    template_shared_state,
+    get_template_shared_state,
+    copy_template_shared_state,
+    attach_template_shared_state,
+    get_template_constants_for_optimization,
+    set_template_constants_for_optimization!,
+    extract_template_gradient_for_optimization
 using .TemplateExpressionModule: ValidVector, TemplateReturnError
 using .ComposableExpressionModule:
     AbstractComposableExpression,

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -1420,7 +1420,7 @@ using ConstructionBase: ConstructionBase as _
 include("precompile.jl")
 redirect_stdout(devnull) do
     redirect_stderr(devnull) do
-        do_precompilation(Val(:precompile))
+        return do_precompilation(Val(:precompile))
     end
 end
 

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -523,7 +523,7 @@ function DE.set_scalar_constants!(e::TemplateExpression, constants, refs)
         i = cursor[]
         c = constants[i:(i + n - 1)]
         DE.set_scalar_constants!(tree, c, r.ref)
-        cursor[] = i + n
+        return cursor[] = i + n
     end
     if has_params(e)
         num_parameters = get_metadata(e).structure.num_parameters
@@ -613,8 +613,11 @@ function _template_gradient_metadata(grad)
     return hasproperty(grad, :metadata) ? getproperty(grad, :metadata) : get_metadata(grad)
 end
 function _template_gradient_parameters(metadata)
-    return hasproperty(metadata, :parameters) ? getproperty(metadata, :parameters) :
-           getproperty(getproperty(metadata, :_data), :parameters)
+    return if hasproperty(metadata, :parameters)
+        getproperty(metadata, :parameters)
+    else
+        getproperty(getproperty(metadata, :_data), :parameters)
+    end
 end
 function _template_inner_gradient(grad, ::TemplateExpression, key::Symbol)
     return getproperty(_template_gradient_trees(grad), key)
@@ -1098,7 +1101,7 @@ function DE.simplify_tree!(
 end
 function has_constants(tree::AbstractExpression)
     any(get_tree(tree)) do node
-        node.degree == 0 && node.constant
+        return node.degree == 0 && node.constant
     end
 end
 has_constants(ex::TemplateExpression) = any(has_constants, values(get_contents(ex)))
@@ -1143,9 +1146,7 @@ function DE.count_scalar_constants(ex::TemplateExpression)
     else
         0
     end
-    return (
-        sum(DE.count_scalar_constants, values(get_contents(ex))) + parameter_count
-    )
+    return (sum(DE.count_scalar_constants, values(get_contents(ex))) + parameter_count)
 end
 function CO.count_constants_for_optimization(ex::TemplateExpression)
     return length(first(CO.get_constants_for_optimization(ex)))
@@ -1189,7 +1190,7 @@ function has_invalid_variables(ex::TemplateExpression)
     any(keys(raw_contents)) do key
         tree = raw_contents[key]
         max_feature = num_features[key]
-        contains_features_greater_than(tree, max_feature)
+        return contains_features_greater_than(tree, max_feature)
     end
 end
 function contains_features_greater_than(tree::AbstractExpression, max_feature)
@@ -1197,7 +1198,7 @@ function contains_features_greater_than(tree::AbstractExpression, max_feature)
 end
 function contains_features_greater_than(tree::AbstractExpressionNode, max_feature)
     any(tree) do node
-        node.degree == 0 && !node.constant && node.feature > max_feature
+        return node.degree == 0 && !node.constant && node.feature > max_feature
     end
 end
 
@@ -1368,7 +1369,7 @@ parse_expression((; f="cos(#1) - 1.5", g="exp(#2) - #1"); expression_type=Templa
                 kws...,
             )
 
-            DE.constructorof(inner_expression_type)(
+            return DE.constructorof(inner_expression_type)(
                 parsed_expr.tree;
                 operators,
                 variable_names=nothing,

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -323,6 +323,85 @@ struct TemplateExpression{
     end
 end
 
+"""
+    NoTemplateSharedState
+
+Sentinel used by the default template hooks when an inner expression type does
+not need candidate-local state shared across the subexpressions of a
+`TemplateExpression`.
+"""
+struct NoTemplateSharedState end
+
+"""
+    template_shared_state(::Type{E}, contents, metadata)
+
+Return candidate-local state that should be shared by every inner expression of
+a `TemplateExpression` whose inner expression type is `E`.
+
+The default returns `NoTemplateSharedState()`. Plugins that use this hook should
+also implement `attach_template_shared_state`, `get_template_shared_state`, and
+`copy_template_shared_state`.
+"""
+template_shared_state(::Type, ::NamedTuple, ::Metadata) = NoTemplateSharedState()
+
+"""
+    get_template_shared_state(::Type{E}, ex::TemplateExpression)
+
+Return the candidate-local state currently attached to `ex`.
+"""
+get_template_shared_state(::Type, ::TemplateExpression) = NoTemplateSharedState()
+
+"""
+    copy_template_shared_state(::Type{E}, state)
+
+Return the copied candidate-local template state used when a
+`TemplateExpression` candidate is copied or copied into a preallocated
+container. The default supports `NoTemplateSharedState`.
+"""
+copy_template_shared_state(::Type, ::NoTemplateSharedState) = NoTemplateSharedState()
+function copy_template_shared_state(::Type{E}, state) where {E}
+    return throw(
+        ArgumentError(
+            "`copy_template_shared_state` must be implemented for template inner expression type $E and shared state $(typeof(state)).",
+        ),
+    )
+end
+
+"""
+    attach_template_shared_state(::Type{E}, inner, state, key::Symbol)
+
+Return `inner` with `state` attached for the template slot named by `key`.
+Methods should return the same concrete inner expression type as `inner`.
+"""
+attach_template_shared_state(::Type, inner, ::NoTemplateSharedState, ::Symbol) = inner
+function attach_template_shared_state(::Type{E}, inner, state, key::Symbol) where {E}
+    return throw(
+        ArgumentError(
+            "`attach_template_shared_state` must be implemented for template inner expression type $E and shared state $(typeof(state)) at key `$key`.",
+        ),
+    )
+end
+
+function _attach_template_shared_state(::Type{E}, contents::NamedTuple, state) where {E}
+    state isa NoTemplateSharedState && return contents
+    content_keys = keys(contents)
+    return NamedTuple{content_keys}(
+        ntuple(Val(length(content_keys))) do i
+            key = content_keys[i]
+            inner = contents[key]
+            attached = attach_template_shared_state(E, inner, state, key)
+            if !(attached isa E)
+                throw(
+                    ArgumentError(
+                        "`attach_template_shared_state` for key `$key` returned $(typeof(attached)); expected an instance of $E.",
+                    ),
+                )
+            end
+            return attached
+        end,
+    )
+end
+
 function TemplateExpression(
     trees::NamedTuple{<:Any,<:NTuple{<:Any,<:AbstractExpression{T}}};
     structure::TemplateStructure,
@@ -358,7 +437,11 @@ function TemplateExpression(
         NamedTuple()
     end
     metadata = (; structure, operators, variable_names, parameters=final_parameters)
-    return TemplateExpression(trees, Metadata(metadata))
+    typed_metadata = Metadata(metadata)
+    E = typeof(first(values(trees)))
+    shared_state = template_shared_state(E, trees, typed_metadata)
+    trees_with_shared_state = _attach_template_shared_state(E, trees, shared_state)
+    return TemplateExpression(trees_with_shared_state, typed_metadata)
 end
 
 @unstable DE.constructorof(::Type{<:TemplateExpression}) = TemplateExpression  # COV_EXCL_LINE
@@ -377,7 +460,10 @@ function Base.copy(e::TemplateExpression)
     ts = get_contents(e)
     meta = get_metadata(e)
     meta_inner = DE.ExpressionModule.unpack_metadata(meta)
+    E = typeof(first(values(ts)))
+    shared_state = copy_template_shared_state(E, get_template_shared_state(E, e))
     copy_ts = NamedTuple{keys(ts)}(map(copy, values(ts)))
+    copy_ts = _attach_template_shared_state(E, copy_ts, shared_state)
     keys_except_structure = filter(!=(:structure), keys(meta_inner))
     copy_metadata = (;
         meta_inner.structure,
@@ -393,6 +479,13 @@ function DE.get_contents(e::TemplateExpression)
 end
 function DE.get_metadata(e::TemplateExpression)
     return e.metadata
+end
+function DE.with_contents(
+    ex::TemplateExpression{<:Any,<:Any,<:Any,E}, new_contents::NamedTuple
+) where {E}
+    shared_state = copy_template_shared_state(E, get_template_shared_state(E, ex))
+    new_contents = _attach_template_shared_state(E, new_contents, shared_state)
+    return DE.constructorof(typeof(ex))(new_contents, get_metadata(ex))
 end
 function DE.get_operators(
     e::TemplateExpression, operators::Union{AbstractOperatorEnum,Nothing}=nothing
@@ -446,9 +539,21 @@ function DE.set_scalar_constants!(e::TemplateExpression, constants, refs)
 end
 
 _parameter_data(x::ParamVector) = x._data
-_parameter_data(x) = x
+_parameter_data(x) = hasproperty(x, :_data) ? getproperty(x, :_data) : x
 
 function CO.get_constants_for_optimization(e::TemplateExpression{T}) where {T}
+    E = typeof(first(values(get_contents(e))))
+    return get_template_constants_for_optimization(E, e)
+end
+"""
+    get_template_constants_for_optimization(::Type{E}, ex::TemplateExpression)
+
+Template-level analogue of [`get_constants_for_optimization`](@ref). Override
+this when a template inner expression type `E` stores candidate-local
+optimizable state that should appear once per `TemplateExpression` candidate
+rather than once per inner subexpression.
+"""
+function get_template_constants_for_optimization(::Type, e::TemplateExpression{T}) where {T}
     inner_params_and_refs = map(CO.get_constants_for_optimization, values(get_contents(e)))
     inner_chunks = first.(inner_params_and_refs)
     parameter_chunks = if has_params(e)
@@ -468,6 +573,17 @@ function CO.get_constants_for_optimization(e::TemplateExpression{T}) where {T}
     return flat, refs
 end
 function CO.set_constants_for_optimization!(e::TemplateExpression, constants, refs)
+    E = typeof(first(values(get_contents(e))))
+    return set_template_constants_for_optimization!(E, e, constants, refs)
+end
+"""
+    set_template_constants_for_optimization!(::Type{E}, ex::TemplateExpression, x, refs)
+
+Template-level analogue of [`set_constants_for_optimization!`](@ref).
+"""
+function set_template_constants_for_optimization!(
+    ::Type, e::TemplateExpression, constants, refs
+)
     cursor = Ref(1)
     foreach(values(get_contents(e)), refs.inner) do tree, r
         let n = r.n, i = cursor[]
@@ -485,6 +601,55 @@ function CO.set_constants_for_optimization!(e::TemplateExpression, constants, re
         end
     end
     return e
+end
+function CO.extract_gradient_for_optimization(grad, ex::TemplateExpression{T}) where {T}
+    E = typeof(first(values(get_contents(ex))))
+    return extract_template_gradient_for_optimization(E, grad, ex)
+end
+function _template_gradient_trees(grad)
+    return hasproperty(grad, :trees) ? getproperty(grad, :trees) : get_contents(grad)
+end
+function _template_gradient_metadata(grad)
+    return hasproperty(grad, :metadata) ? getproperty(grad, :metadata) : get_metadata(grad)
+end
+function _template_gradient_parameters(metadata)
+    return hasproperty(metadata, :parameters) ? getproperty(metadata, :parameters) :
+           getproperty(getproperty(metadata, :_data), :parameters)
+end
+function _template_inner_gradient(grad, ::TemplateExpression, key::Symbol)
+    return getproperty(_template_gradient_trees(grad), key)
+end
+function _template_parameter_gradient_data(grad, ::TemplateExpression, key::Symbol)
+    parameters = _template_gradient_parameters(_template_gradient_metadata(grad))
+    return _parameter_data(getproperty(parameters, key))
+end
+"""
+    extract_template_gradient_for_optimization(::Type{E}, grad, ex::TemplateExpression)
+
+Template-level analogue of [`extract_gradient_for_optimization`](@ref).
+"""
+function extract_template_gradient_for_optimization(
+    ::Type, grad, ex::TemplateExpression{T}
+) where {T}
+    contents = get_contents(ex)
+    inner_grad = map(keys(contents), values(contents)) do key, tree
+        return CO.extract_gradient_for_optimization(
+            _template_inner_gradient(grad, ex, key), tree
+        )
+    end
+    parameter_pieces = if has_params(ex)
+        map(
+            k -> _template_parameter_gradient_data(grad, ex, k),
+            keys(get_metadata(ex).parameters),
+        )
+    else
+        ()
+    end
+    return if isempty(inner_grad) && isempty(parameter_pieces)
+        T[]
+    else
+        vcat(inner_grad..., parameter_pieces...)
+    end
 end
 Base.@kwdef struct PreallocatedTemplateExpression{A,B}
     trees::A
@@ -972,13 +1137,20 @@ function MF.mutate_constant(
 end
 # TODO: Look at other ParametricExpression behavior
 
-for f in (:(DE.count_scalar_constants), :(CO.count_constants_for_optimization))
-    @eval function $f(ex::TemplateExpression)
-        return (
-            sum($f, values(get_contents(ex))) +
-            (has_params(ex) ? sum($f, values(get_metadata(ex).parameters)) : 0)
-        )
+function DE.count_scalar_constants(ex::TemplateExpression)
+    parameter_count = if has_params(ex)
+        sum(DE.count_scalar_constants, values(get_metadata(ex).parameters))
+    else
+        0
     end
+    return (
+        sum(DE.count_scalar_constants, values(get_contents(ex))) + parameter_count
+    )
+end
+function CO.count_constants_for_optimization(ex::TemplateExpression)
+    return length(first(CO.get_constants_for_optimization(ex)))
+end
+for f in (:(DE.count_scalar_constants), :(CO.count_constants_for_optimization))
     @eval function $f(p::ParamVector)
         # TODO: This is not general enough; we should be using `get_scalar_constants`
         # on the parameters themselves.

--- a/test/integration/ad/mooncake/test_mooncake_autodiff.jl
+++ b/test/integration/ad/mooncake/test_mooncake_autodiff.jl
@@ -1,6 +1,7 @@
 @testitem "Expression constant optimization with Mooncake" begin
     using SymbolicRegression
-    using SymbolicRegression.ConstantOptimizationModule: EvaluatorContext, optimize_constants
+    using SymbolicRegression.ConstantOptimizationModule:
+        EvaluatorContext, optimize_constants
     using DynamicExpressions:
         DynamicExpressions,
         AbstractExpressionNode,
@@ -86,7 +87,7 @@
 
     @testset "TemplateExpression" begin
         spec = @template_spec(expressions = (f, g)) do x, y, z
-            f(x, y) + 2.0 * g(3.0 * z)
+            return f(x, y) + 2.0 * g(3.0 * z)
         end
         options = Options(; default_args..., expression_spec=spec)
 
@@ -129,7 +130,7 @@
 
     @testset "TemplateExpression with parameters" begin
         spec = @template_spec(expressions = (f, g), parameters = (p=1,),) do x, y, z, w
-            f(x, y) + g(3.0 * z) + p[1] * w
+            return f(x, y) + g(3.0 * z) + p[1] * w
         end
         options = Options(; default_args..., expression_spec=spec)
 
@@ -185,12 +186,11 @@
 
     @testset "TemplateExpression with custom inner fallback" begin
         spec = @template_spec(expressions = (f,), parameters = (p=1,),) do x
-            f(x) + p[1]
+            return f(x) + p[1]
         end
         options = Options(; default_args..., expression_spec=spec)
         wrapped_node = Node{Float64}(;
-            op=3,
-            children=(Node{Float64}(; val=1.2), Node{Float64}(; feature=1)),
+            op=3, children=(Node{Float64}(; val=1.2), Node{Float64}(; feature=1))
         )
         init_tree = TemplateExpression(
             (; f=MooncakeWrappedExpression(wrapped_node; operators=options.operators));

--- a/test/integration/ad/mooncake/test_mooncake_autodiff.jl
+++ b/test/integration/ad/mooncake/test_mooncake_autodiff.jl
@@ -1,10 +1,19 @@
 @testitem "Expression constant optimization with Mooncake" begin
     using SymbolicRegression
-    using SymbolicRegression.ConstantOptimizationModule: optimize_constants
-    using DynamicExpressions: get_scalar_constants
+    using SymbolicRegression.ConstantOptimizationModule: EvaluatorContext, optimize_constants
+    using DynamicExpressions:
+        DynamicExpressions,
+        AbstractExpressionNode,
+        AbstractOperatorEnum,
+        EvalOptions,
+        Metadata,
+        extract_gradient,
+        get_contents,
+        get_scalar_constants
+    using SymbolicRegression: AbstractComposableExpression
     using StableRNGs: StableRNG
     using Mooncake
-    using DifferentiationInterface: AutoMooncake
+    using DifferentiationInterface: AutoMooncake, value_and_gradient
 
     backend = AutoMooncake(; config=nothing)
     default_args = (;
@@ -16,6 +25,32 @@
         optimizer_probability=1.0,
         optimizer_iterations=1000,
     )
+
+    struct MooncakeWrappedExpression{T,N<:AbstractExpressionNode{T},D} <:
+           AbstractComposableExpression{T,N}
+        tree::N
+        metadata::Metadata{D}
+    end
+
+    function MooncakeWrappedExpression(
+        tree::AbstractExpressionNode{T};
+        operators::Union{AbstractOperatorEnum,Nothing}=nothing,
+        variable_names::Union{AbstractVector{<:AbstractString},Nothing}=nothing,
+        eval_options::Union{EvalOptions,Nothing}=nothing,
+    ) where {T}
+        return MooncakeWrappedExpression(
+            tree, Metadata((; operators, variable_names, eval_options))
+        )
+    end
+
+    DynamicExpressions.constructorof(::Type{<:MooncakeWrappedExpression}) =
+        MooncakeWrappedExpression
+
+    function DynamicExpressions.extract_gradient(
+        gradient::Mooncake.Tangent, ex::MooncakeWrappedExpression
+    )
+        return extract_gradient(gradient.fields.tree, get_contents(ex))
+    end
 
     @testset "Expression" begin
         options = Options(; default_args...)
@@ -129,6 +164,15 @@
         @test length(get_scalar_constants(true_tree)[1]) == 5
 
         member = PopMember(dataset, init_tree, options; deterministic=false)
+
+        ctx = EvaluatorContext(dataset, options)
+        _, gradient = value_and_gradient(ctx, backend, init_tree)
+        gradient_constants = SymbolicRegression.extract_gradient_for_optimization(
+            gradient, init_tree
+        )
+        @test length(gradient_constants) == 5
+        @test all(isfinite, gradient_constants)
+
         optimized_member, num_evals = optimize_constants(
             dataset, copy(member), options; rng=rng
         )
@@ -137,5 +181,35 @@
         @test num_evals > 0
 
         @test get_metadata(optimized_member.tree).parameters.p ≈ [0.9]
+    end
+
+    @testset "TemplateExpression with custom inner fallback" begin
+        spec = @template_spec(expressions = (f,), parameters = (p=1,),) do x
+            f(x) + p[1]
+        end
+        options = Options(; default_args..., expression_spec=spec)
+        wrapped_node = Node{Float64}(;
+            op=3,
+            children=(Node{Float64}(; val=1.2), Node{Float64}(; feature=1)),
+        )
+        init_tree = TemplateExpression(
+            (; f=MooncakeWrappedExpression(wrapped_node; operators=options.operators));
+            spec.structure,
+            options.operators,
+            parameters=(; p=[0.5]),
+        )
+
+        rng = StableRNG(2)
+        X = rand(rng, 1, 16)
+        y = @. 1.4 * X[1, :] + 0.7
+        dataset = Dataset(X, y)
+
+        ctx = EvaluatorContext(dataset, options)
+        _, gradient = value_and_gradient(ctx, backend, init_tree)
+        gradient_constants = SymbolicRegression.extract_gradient_for_optimization(
+            gradient, init_tree
+        )
+        @test length(gradient_constants) == 2
+        @test all(isfinite, gradient_constants)
     end
 end

--- a/test/unit/evolution-core/test_constants_for_optimization.jl
+++ b/test/unit/evolution-core/test_constants_for_optimization.jl
@@ -29,6 +29,211 @@
     @test SymbolicRegression.get_constants_for_optimization(template)[1] == [4.0, 5.0]
 end
 
+@testitem "ComposableExpression extracts optimization gradients from wrapped tree" begin
+    using DynamicExpressions: NodeTangent, get_contents
+    using SymbolicRegression
+
+    operators = OperatorEnum(; unary_operators=(), binary_operators=(+,))
+    ex = ComposableExpression(Node{Float64}(; val=1.0); operators)
+    grad = (; tree=NodeTangent(get_contents(ex), [0.5]), metadata=nothing)
+
+    @test SymbolicRegression.extract_gradient_for_optimization(grad, ex) == [0.5]
+end
+
+@testitem "TemplateExpression default inners extract optimization gradients" begin
+    using DynamicExpressions:
+        DynamicExpressions, Metadata, NodeTangent, get_contents, get_metadata
+    using SymbolicRegression
+
+    operators = OperatorEnum(; unary_operators=(), binary_operators=(+,))
+    structure = TemplateStructure{(:f,),(:p,)}(
+        ((; f), (; p), (x,)) -> f(x) + p[1]; num_parameters=(; p=1)
+    )
+    template = TemplateExpression(
+        (; f=ComposableExpression(Node{Float64}(; val=1.0); operators));
+        structure,
+        operators,
+        parameters=(; p=[2.0]),
+    )
+    inner = get_contents(template).f
+
+    struct TemplateGradient{C,M}
+        contents::C
+        metadata::M
+    end
+    DynamicExpressions.get_contents(grad::TemplateGradient) = grad.contents
+    DynamicExpressions.get_metadata(grad::TemplateGradient) = grad.metadata
+
+    grad = TemplateGradient(
+        (; f=(; tree=NodeTangent(get_contents(inner), [0.5]), metadata=nothing)),
+        Metadata((;
+            parameters=(; p=SymbolicRegression.TemplateExpressionModule.ParamVector([0.25]))
+        )),
+    )
+
+    @test SymbolicRegression.extract_gradient_for_optimization(grad, template) ==
+        [0.5, 0.25]
+
+    structural_grad = (;
+        trees=(; f=(; tree=NodeTangent(get_contents(inner), [0.5]), metadata=nothing)),
+        metadata=(;
+            _data=(;
+                parameters=(;
+                    p=SymbolicRegression.TemplateExpressionModule.ParamVector([0.25])
+                )
+            )
+        ),
+    )
+    @test SymbolicRegression.extract_gradient_for_optimization(
+        structural_grad, template
+    ) == [0.5, 0.25]
+end
+
+@testitem "Template constants hooks can expose candidate-local state" begin
+    using DynamicExpressions:
+        DynamicExpressions,
+        AbstractExpressionNode,
+        AbstractOperatorEnum,
+        EvalOptions,
+        Metadata,
+        Node,
+        OperatorEnum,
+        get_contents,
+        get_metadata,
+        with_metadata
+    using SymbolicRegression
+    using SymbolicRegression: AbstractComposableExpression
+
+    mutable struct TemplateOptState
+        value::Float64
+    end
+
+    struct TemplateOptExpression{T,N<:AbstractExpressionNode{T},D} <:
+           AbstractComposableExpression{T,N}
+        tree::N
+        metadata::Metadata{D}
+    end
+
+    function TemplateOptExpression(
+        tree::AbstractExpressionNode{T};
+        operators::Union{AbstractOperatorEnum,Nothing}=nothing,
+        variable_names::Union{AbstractVector{<:AbstractString},Nothing}=nothing,
+        eval_options::Union{EvalOptions,Nothing}=nothing,
+        state::TemplateOptState=TemplateOptState(1.0),
+    ) where {T}
+        return TemplateOptExpression(
+            tree, Metadata((; operators, variable_names, eval_options, state))
+        )
+    end
+
+    DynamicExpressions.constructorof(::Type{<:TemplateOptExpression}) =
+        TemplateOptExpression
+
+    function DynamicExpressions.with_metadata(ex::TemplateOptExpression; kws...)
+        meta = get_metadata(ex)
+        state = haskey(kws, :state) ? kws[:state] : meta.state
+        operators = haskey(kws, :operators) ? kws[:operators] : meta.operators
+        variable_names =
+            haskey(kws, :variable_names) ? kws[:variable_names] : meta.variable_names
+        eval_options = haskey(kws, :eval_options) ? kws[:eval_options] : meta.eval_options
+        return TemplateOptExpression(
+            get_contents(ex), Metadata((; operators, variable_names, eval_options, state))
+        )
+    end
+
+    SymbolicRegression.template_shared_state(
+        ::Type{<:TemplateOptExpression}, contents::NamedTuple, metadata::Metadata
+    ) = TemplateOptState(1.0)
+
+    function SymbolicRegression.get_template_shared_state(
+        ::Type{<:TemplateOptExpression}, ex::TemplateExpression
+    )
+        states = TemplateOptState[]
+        for inner in values(get_contents(ex))
+            state = get_metadata(inner).state
+            any(existing -> existing === state, states) || push!(states, state)
+        end
+        @assert length(states) == 1
+        return only(states)
+    end
+
+    SymbolicRegression.copy_template_shared_state(
+        ::Type{<:TemplateOptExpression}, state::TemplateOptState
+    ) = TemplateOptState(state.value)
+
+    function SymbolicRegression.attach_template_shared_state(
+        ::Type{<:TemplateOptExpression},
+        inner::TemplateOptExpression,
+        state::TemplateOptState,
+        key::Symbol,
+    )
+        return with_metadata(inner; state)
+    end
+
+    function SymbolicRegression.get_template_constants_for_optimization(
+        ::Type{<:TemplateOptExpression}, ex::TemplateExpression{T}
+    ) where {T}
+        state = SymbolicRegression.get_template_shared_state(TemplateOptExpression, ex)
+        params = get_metadata(ex).parameters
+        return T[state.value, params.p[1]], (; parameter_keys=[:p])
+    end
+
+    function SymbolicRegression.set_template_constants_for_optimization!(
+        ::Type{<:TemplateOptExpression}, ex::TemplateExpression, x, refs
+    )
+        state = SymbolicRegression.get_template_shared_state(TemplateOptExpression, ex)
+        state.value = x[1]
+        get_metadata(ex).parameters.p._data[1] = x[2]
+        return ex
+    end
+
+    function SymbolicRegression.extract_template_gradient_for_optimization(
+        ::Type{<:TemplateOptExpression}, grad, ex::TemplateExpression{T}
+    ) where {T}
+        state = SymbolicRegression.get_template_shared_state(TemplateOptExpression, grad)
+        return T[state.value, get_metadata(grad).parameters.p[1]]
+    end
+
+    operators = OperatorEnum(; unary_operators=(), binary_operators=(+,))
+    structure = TemplateStructure{(:f,),(:p,)}(
+        ((; f), (; p), (x,)) -> f(x) + p[1]; num_parameters=(; p=1)
+    )
+    template = TemplateExpression(
+        (; f=TemplateOptExpression(Node{Float64}(; feature=1); operators));
+        structure,
+        operators,
+        parameters=(; p=[2.0]),
+    )
+
+    params, refs = SymbolicRegression.get_constants_for_optimization(template)
+    @test params == [1.0, 2.0]
+    @test SymbolicRegression.ConstantOptimizationModule.count_constants_for_optimization(
+        template
+    ) == length(params)
+
+    SymbolicRegression.set_constants_for_optimization!(template, [3.0, 4.0], refs)
+    @test SymbolicRegression.get_constants_for_optimization(template)[1] == [3.0, 4.0]
+    @test get_metadata(first(values(get_contents(template)))).state.value == 3.0
+    @test get_metadata(template).parameters.p[1] == 4.0
+
+    grad_inner = TemplateOptExpression(
+        Node{Float64}(; feature=1); operators, state=TemplateOptState(0.5)
+    )
+    grad = TemplateExpression(
+        (; f=grad_inner),
+        Metadata((;
+            structure,
+            operators,
+            variable_names=nothing,
+            parameters=(;
+                p=SymbolicRegression.TemplateExpressionModule.ParamVector([0.25])
+            ),
+        )),
+    )
+    @test SymbolicRegression.extract_gradient_for_optimization(grad, template) ==
+        [0.5, 0.25]
+end
+
 @testitem "Default optimize_constants handles custom optimizable expression state" begin
     using DynamicExpressions:
         DynamicExpressions,

--- a/test/unit/evolution-core/test_constants_for_optimization.jl
+++ b/test/unit/evolution-core/test_constants_for_optimization.jl
@@ -84,9 +84,8 @@ end
             )
         ),
     )
-    @test SymbolicRegression.extract_gradient_for_optimization(
-        structural_grad, template
-    ) == [0.5, 0.25]
+    @test SymbolicRegression.extract_gradient_for_optimization(structural_grad, template) ==
+        [0.5, 0.25]
 end
 
 @testitem "Template constants hooks can expose candidate-local state" begin

--- a/test/unit/expressions/test_template_inner_expression_type.jl
+++ b/test/unit/expressions/test_template_inner_expression_type.jl
@@ -53,3 +53,222 @@
     @test created_inner isa WrappedExpression
     @test get_metadata(created_inner).tag == :custom_inner
 end
+
+@testitem "TemplateExpression candidate-local shared state hooks" begin
+    using DynamicExpressions:
+        DynamicExpressions,
+        AbstractExpressionNode,
+        AbstractOperatorEnum,
+        EvalOptions,
+        Metadata,
+        Node,
+        OperatorEnum,
+        get_contents,
+        get_metadata,
+        with_metadata
+    using SymbolicRegression
+    using SymbolicRegression: AbstractComposableExpression
+    using SymbolicRegression.ExpressionBuilderModule: create_expression
+    using Random: MersenneTwister
+
+    mutable struct SharedTemplateState
+        value::Float64
+    end
+
+    struct SharedExpression{T,N<:AbstractExpressionNode{T},D} <:
+           AbstractComposableExpression{T,N}
+        tree::N
+        metadata::Metadata{D}
+    end
+
+    function SharedExpression(
+        tree::AbstractExpressionNode{T};
+        operators::Union{AbstractOperatorEnum,Nothing}=nothing,
+        variable_names::Union{AbstractVector{<:AbstractString},Nothing}=nothing,
+        eval_options::Union{EvalOptions,Nothing}=nothing,
+        state::SharedTemplateState=SharedTemplateState(0.0),
+    ) where {T}
+        return SharedExpression(
+            tree, Metadata((; operators, variable_names, eval_options, state))
+        )
+    end
+
+    DynamicExpressions.constructorof(::Type{<:SharedExpression}) = SharedExpression
+
+    function Base.copy(ex::SharedExpression)
+        meta = get_metadata(ex)
+        return SharedExpression(
+            copy(get_contents(ex));
+            operators=meta.operators,
+            variable_names=meta.variable_names,
+            eval_options=meta.eval_options,
+            state=meta.state,
+        )
+    end
+
+    function DynamicExpressions.with_metadata(ex::SharedExpression; kws...)
+        meta = get_metadata(ex)
+        state = haskey(kws, :state) ? kws[:state] : meta.state
+        operators = haskey(kws, :operators) ? kws[:operators] : meta.operators
+        variable_names =
+            haskey(kws, :variable_names) ? kws[:variable_names] : meta.variable_names
+        eval_options = haskey(kws, :eval_options) ? kws[:eval_options] : meta.eval_options
+        return SharedExpression(
+            get_contents(ex), Metadata((; operators, variable_names, eval_options, state))
+        )
+    end
+
+    struct PreallocatedSharedExpression{N}
+        tree::N
+    end
+
+    DynamicExpressions.allocate_container(
+        ex::SharedExpression, n::Union{Nothing,Integer}=nothing
+    ) = PreallocatedSharedExpression(
+        DynamicExpressions.allocate_container(get_contents(ex), n)
+    )
+
+    function DynamicExpressions.copy_into!(
+        dest::PreallocatedSharedExpression, src::SharedExpression
+    )
+        meta = get_metadata(src)
+        return SharedExpression(
+            DynamicExpressions.copy_into!(dest.tree, get_contents(src));
+            operators=meta.operators,
+            variable_names=meta.variable_names,
+            eval_options=meta.eval_options,
+            state=meta.state,
+        )
+    end
+
+    SymbolicRegression.template_shared_state(
+        ::Type{<:SharedExpression}, contents::NamedTuple, metadata::Metadata
+    ) = SharedTemplateState(10.0)
+
+    function SymbolicRegression.get_template_shared_state(
+        ::Type{<:SharedExpression}, ex::TemplateExpression
+    )
+        states = SharedTemplateState[]
+        for inner in values(get_contents(ex))
+            state = get_metadata(inner).state
+            any(existing -> existing === state, states) || push!(states, state)
+        end
+        @assert length(states) == 1
+        return only(states)
+    end
+
+    SymbolicRegression.copy_template_shared_state(
+        ::Type{<:SharedExpression}, state::SharedTemplateState
+    ) = SharedTemplateState(state.value)
+
+    function SymbolicRegression.attach_template_shared_state(
+        ::Type{<:SharedExpression},
+        inner::SharedExpression,
+        state::SharedTemplateState,
+        key::Symbol,
+    )
+        return with_metadata(inner; state)
+    end
+
+    operators = OperatorEnum(; unary_operators=(cos,), binary_operators=(+,))
+    structure = TemplateStructure{(:f, :g)}(
+        ((; f, g), (x,)) -> f(x) + g(x); num_features=(; f=1, g=1)
+    )
+
+    template = TemplateExpression(
+        (;
+            f=SharedExpression(Node{Float64}(; feature=1); operators),
+            g=SharedExpression(Node{Float64}(; val=2.0); operators),
+        );
+        structure,
+        operators,
+    )
+    states = map(inner -> get_metadata(inner).state, values(get_contents(template)))
+    @test states[1] === states[2]
+    @test states[1].value == 10.0
+
+    copied = copy(template)
+    copied_states = map(inner -> get_metadata(inner).state, values(get_contents(copied)))
+    @test copied_states[1] === copied_states[2]
+    @test copied_states[1] !== states[1]
+    @test copied_states[1].value == states[1].value
+
+    copied_into = DynamicExpressions.copy_into!(
+        DynamicExpressions.allocate_container(template), template
+    )
+    copied_into_states = map(
+        inner -> get_metadata(inner).state, values(get_contents(copied_into))
+    )
+    @test copied_into_states[1] === copied_into_states[2]
+    @test copied_into_states[1] !== states[1]
+
+    fresh_inner = SharedExpression(
+        Node{Float64}(; val=4.0); operators, state=SharedTemplateState(99.0)
+    )
+    with_contents_rebuilt = DynamicExpressions.with_contents(
+        template, (; f=fresh_inner, g=get_contents(template).g)
+    )
+    with_contents_states = map(
+        inner -> get_metadata(inner).state, values(get_contents(with_contents_rebuilt))
+    )
+    @test with_contents_states[1] === with_contents_states[2]
+    @test with_contents_states[1] !== states[1]
+    @test with_contents_states[1] !== get_metadata(fresh_inner).state
+    @test with_contents_states[1].value == states[1].value
+
+    rebuilt = SymbolicRegression.MutationFunctionsModule.with_contents_for_mutation(
+        template,
+        SharedExpression(Node{Float64}(; val=4.0); operators),
+        :f,
+    )
+    rebuilt_states = map(inner -> get_metadata(inner).state, values(get_contents(rebuilt)))
+    @test rebuilt_states[1] === rebuilt_states[2]
+    @test rebuilt_states[1] !== states[1]
+    @test rebuilt_states[1].value == states[1].value
+
+    crossover_parent = TemplateExpression(
+        (;
+            f=SharedExpression(Node{Float64}(; val=5.0); operators),
+            g=SharedExpression(Node{Float64}(; feature=1); operators),
+        );
+        structure,
+        operators,
+    )
+    crossover_parent_states = map(
+        inner -> get_metadata(inner).state, values(get_contents(crossover_parent))
+    )
+    child1, child2 = SymbolicRegression.MutationFunctionsModule.crossover_trees(
+        template, crossover_parent, MersenneTwister(3)
+    )
+    child1_states = map(inner -> get_metadata(inner).state, values(get_contents(child1)))
+    child2_states = map(inner -> get_metadata(inner).state, values(get_contents(child2)))
+    @test child1_states[1] === child1_states[2]
+    @test child2_states[1] === child2_states[2]
+    @test child1_states[1] !== states[1]
+    @test child1_states[1] !== crossover_parent_states[1]
+    @test child2_states[1] !== states[1]
+    @test child2_states[1] !== crossover_parent_states[1]
+
+    raw_f = SharedExpression(
+        Node{Float64}(; feature=1); operators, state=SharedTemplateState(1.0)
+    )
+    raw_g = SharedExpression(
+        Node{Float64}(; val=3.0); operators, state=SharedTemplateState(2.0)
+    )
+    raw = TemplateExpression((; f=raw_f, g=raw_g), get_metadata(template))
+    raw_states = map(inner -> get_metadata(inner).state, values(get_contents(raw)))
+    @test raw_states[1] !== raw_states[2]
+    @test raw_states[1].value == 1.0
+    @test raw_states[2].value == 2.0
+
+    spec = TemplateExpressionSpec(; structure, inner_expression_type=SharedExpression)
+    parsed = parse_expression((; f="#1", g="#1"); expression_spec=spec, operators)
+    parsed_states = map(inner -> get_metadata(inner).state, values(get_contents(parsed)))
+    @test parsed_states[1] === parsed_states[2]
+
+    dataset = Dataset(randn(Float64, 1, 8), randn(Float64, 8))
+    options = Options(; operators, expression_spec=spec, tournament_selection_n=5)
+    created = create_expression(Node{Float64}(; val=0.0), options, dataset)
+    created_states = map(inner -> get_metadata(inner).state, values(get_contents(created)))
+    @test created_states[1] === created_states[2]
+end

--- a/test/unit/expressions/test_template_inner_expression_type.jl
+++ b/test/unit/expressions/test_template_inner_expression_type.jl
@@ -217,9 +217,7 @@ end
     @test with_contents_states[1].value == states[1].value
 
     rebuilt = SymbolicRegression.MutationFunctionsModule.with_contents_for_mutation(
-        template,
-        SharedExpression(Node{Float64}(; val=4.0); operators),
-        :f,
+        template, SharedExpression(Node{Float64}(; val=4.0); operators), :f
     )
     rebuilt_states = map(inner -> get_metadata(inner).state, values(get_contents(rebuilt)))
     @test rebuilt_states[1] === rebuilt_states[2]


### PR DESCRIPTION
Introduce a template-level plugin interface for candidate-local state that is shared across the inner expressions of a TemplateExpression. This supports plugins whose optimizable state belongs to the whole template candidate rather than to each inner expression independently.

The new shared-state hooks are:

- NoTemplateSharedState
- template_shared_state
- get_template_shared_state
- copy_template_shared_state
- attach_template_shared_state

TemplateExpression construction now creates one shared state object for the candidate and attaches it to each inner expression. The same invariant is preserved when templates are copied, copied into preallocated storage, reconstructed with with_contents, mutated through with_contents_for_mutation, or rebuilt through crossover. The default hook behavior is a no-op, preserving existing TemplateExpression behavior for normal ComposableExpression inners.

Add template-level constant optimization hooks:

- get_template_constants_for_optimization
- set_template_constants_for_optimization!
- extract_template_gradient_for_optimization

The default implementations reproduce the previous behavior by concatenating inner-expression optimization constants with template parameters. Plugins can override these hooks when candidate-local template state should appear only once in the optimizable constant vector. count_constants_for_optimization now derives from get_constants_for_optimization so custom hook-provided constants stay in sync with optimizer buffer sizing.

Update optimization-gradient extraction for TemplateExpression and ComposableExpression so wrapped expressions and structural AD tangents are handled by the optimization API. The template fallback now accepts gradients with trees/metadata fields as well as DynamicExpressions accessors, and the ComposableExpression fallback unwraps the tree gradient before delegating to the existing expression gradient machinery.

Preserve Mooncake-specific gradient behavior by adding extension methods for Mooncake tangents. ComposableExpression optimization gradients delegate back to the existing Mooncake DynamicExpressions extraction path, while TemplateExpression gradients extract inner and parameter tangents from Mooncake's fields layout. The existing Mooncake extract_gradient implementation now sizes its scalar constant buffer using count_scalar_constants rather than optimization-hook constant counts, keeping scalar-gradient extraction separate from custom template optimization constants.

Add regression coverage for:

- shared template state attachment during construction
- copy, copy_into!, with_contents, mutation reconstruction, and crossover
- parse_expression and create_expression with custom template inner types
- template-level get/set/extract optimization hooks
- optimization constant counts matching hook-provided constants
- ComposableExpression optimization-gradient extraction from wrapped trees
- TemplateExpression gradient extraction from accessor-style and structural tangents
- Mooncake optimization gradients for templates and custom inner wrappers

Tests run:

- julia --project=. -e 'using Pkg; Pkg.test(; test_args=["unit/evolution-core"])'
- julia --project=. -e 'using Pkg; Pkg.test(; test_args=["unit/expressions"])'
- julia --project=. -e 'using Pkg; Pkg.test(; test_args=["integration/ad/mooncake"])'
- git diff --check