### PR TITLE
chore: update repository links after org migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 SymbolicRegression.jl searches for symbolic expressions which optimize a particular objective.
 
-https://github.com/MilesCranmer/SymbolicRegression.jl/assets/7593028/f5b68f1f-9830-497f-a197-6ae332c94ee0
+https://github.com/astroautomata/SymbolicRegression.jl/assets/7593028/f5b68f1f-9830-497f-a197-6ae332c94ee0
 
 <table>
 <thead>
@@ -18,7 +18,7 @@ https://github.com/MilesCranmer/SymbolicRegression.jl/assets/7593028/f5b68f1f-98
 <tr>
 <td align="center"><a href="https://juliahub.com/ui/Packages/SymbolicRegression/X2eIS"><img src="https://juliahub.com/docs/SymbolicRegression/version.svg" alt="version"></a></td>
 <td align="center"><a href="https://ai.damtp.cam.ac.uk/symbolicregression/dev/"><img src="https://img.shields.io/badge/docs-dev-blue.svg" alt="Dev"></a></td>
-<td align="center"><a href="https://github.com/MilesCranmer/PySR/discussions"><img src="https://img.shields.io/badge/discussions-github-informational" alt="Discussions"></a></td>
+<td align="center"><a href="https://github.com/astroautomata/PySR/discussions"><img src="https://img.shields.io/badge/discussions-github-informational" alt="Discussions"></a></td>
 <td align="center"><a href="https://arxiv.org/abs/2305.01582"><img src="https://img.shields.io/badge/arXiv-2305.01582-b31b1b" alt="Paper"></a></td>
 </tr>
 <tr>
@@ -28,15 +28,15 @@ https://github.com/MilesCranmer/SymbolicRegression.jl/assets/7593028/f5b68f1f-98
 <td align="center"></td>
 </tr>
 <tr>
-<td align="center"><a href=".github/workflows/CI.yml"><img src="https://github.com/MilesCranmer/SymbolicRegression.jl/workflows/CI/badge.svg" alt="CI"></a></td>
-<td align="center"><a href="https://coveralls.io/github/MilesCranmer/SymbolicRegression.jl?branch=master"><img src="https://coveralls.io/repos/github/MilesCranmer/SymbolicRegression.jl/badge.svg?branch=master" alt="Coverage Status"></a></td>
+<td align="center"><a href=".github/workflows/CI.yml"><img src="https://github.com/astroautomata/SymbolicRegression.jl/workflows/CI/badge.svg" alt="CI"></a></td>
+<td align="center"><a href="https://coveralls.io/github/astroautomata/SymbolicRegression.jl?branch=master"><img src="https://coveralls.io/repos/github/astroautomata/SymbolicRegression.jl/badge.svg?branch=master" alt="Coverage Status"></a></td>
 <td align="center"></td>
 <td align="center"></td>
 </tr>
 </tbody>
 </table>
 
-Check out [PySR](https://github.com/MilesCranmer/PySR) for
+Check out [PySR](https://github.com/astroautomata/PySR) for
 a Python frontend.
 [Cite this software](https://arxiv.org/abs/2305.01582)
 
@@ -276,7 +276,7 @@ end
 ## Contributors ✨
 
 We are eager to welcome new contributors!
-If you have an idea for a new feature, don't hesitate to share it on the [issues](https://github.com/MilesCranmer/SymbolicRegression.jl/issues) page or [forums](https://github.com/MilesCranmer/PySR/discussions).
+If you have an idea for a new feature, don't hesitate to share it on the [issues](https://github.com/astroautomata/SymbolicRegression.jl/issues) page or [forums](https://github.com/astroautomata/PySR/discussions).
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/docs/all_contributors/.all-contributorsrc
+++ b/docs/all_contributors/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
   "projectName": "SymbolicRegression.jl",
-  "projectOwner": "MilesCranmer",
+  "projectOwner": "astroautomata",
   "repoType": "github",
   "repoHost": "https://github.com",
   "files": [

--- a/docs/all_contributors/package.json
+++ b/docs/all_contributors/package.json
@@ -2,7 +2,7 @@
   "name": "PySR",
   "version": "1.0.0",
   "main": "index.js",
-  "repository": "git@github.com:MilesCranmer/PySR.git",
+  "repository": "git@github.com:astroautomata/SymbolicRegression.jl.git",
   "author": "MilesCranmer <miles.cranmer@gmail.com>",
   "license": "Apache-2.0",
   "devDependencies": {

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,7 +40,7 @@ hero:
       link: /api
     - theme: alt
       text: View on GitHub
-      link: https://github.com/MilesCranmer/SymbolicRegression.jl
+      link: https://github.com/astroautomata/SymbolicRegression.jl
   image:
     src: /logo.png
     alt: SymbolicRegression.jl
@@ -121,10 +121,10 @@ readme = replace(readme, r"\*\*Contents\*\*:.*?(?=## )"s => s"") # Remove Conten
 readme = replace(readme, r"## Contributors ✨.*$"s => s"") # Remove Contributors section onwards
 readme = replace( # Convert video URL to proper video tag wrapped in @raw html for VitePress
     readme,
-    r"https://github.com/MilesCranmer/SymbolicRegression.jl/assets/7593028/f5b68f1f-9830-497f-a197-6ae332c94ee0" => """```@raw html
+    r"https://github.com/astroautomata/SymbolicRegression.jl/assets/7593028/f5b68f1f-9830-497f-a197-6ae332c94ee0" => """```@raw html
 <div align="center">
 <video width="800" height="600" controls>
-<source src="https://github.com/MilesCranmer/SymbolicRegression.jl/assets/7593028/f5b68f1f-9830-497f-a197-6ae332c94ee0" type="video/mp4">
+<source src="https://github.com/astroautomata/SymbolicRegression.jl/assets/7593028/f5b68f1f-9830-497f-a197-6ae332c94ee0" type="video/mp4">
 </video>
 </div>
 ```""",
@@ -286,7 +286,7 @@ else
     # Default astroautomata deployment
     deploy_decision = Documenter.deploy_folder(
         deploy_config;
-        repo="github.com/MilesCranmer/SymbolicRegression.jl",
+        repo="github.com/astroautomata/SymbolicRegression.jl",
         devbranch="master",
         devurl="dev",
         push_preview=true,
@@ -322,7 +322,7 @@ makedocs(;
     clean=get(ENV, "DOCUMENTER_PRODUCTION", "false") == "true",
     warnonly=[:docs_block, :cross_references, :missing_docs],
     format=DocumenterVitepress.MarkdownVitepress(;
-        repo="github.com/MilesCranmer/SymbolicRegression.jl",
+        repo="github.com/astroautomata/SymbolicRegression.jl",
         devbranch="master",
         devurl="dev",
         deploy_url=nothing,
@@ -422,7 +422,7 @@ deployment_target = get(ENV, "DEPLOYMENT_TARGET", "astroautomata")
 
 if deployment_target == "astroautomata"
     DocumenterVitepress.deploydocs(;
-        repo="github.com/MilesCranmer/SymbolicRegression.jl.git",
+        repo="github.com/astroautomata/SymbolicRegression.jl.git",
         push_preview=true,
         target="build",
         devbranch="master",

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -614,7 +614,7 @@ function choose_best(;
     trees, losses::Vector{L}, scores, complexities, options=nothing
 ) where {L<:LOSS_TYPE}
     # Same as in PySR:
-    # https://github.com/MilesCranmer/PySR/blob/e74b8ad46b163c799908b3aa4d851cf8457c79ef/pysr/sr.py#L2318-L2332
+    # https://github.com/astroautomata/PySR/blob/e74b8ad46b163c799908b3aa4d851cf8457c79ef/pysr/sr.py#L2318-L2332
     # threshold = 1.5 * minimum_loss
     # Then, we get max score of those below the threshold.
     if !isnothing(options) && options.loss_scale == :linear
@@ -652,7 +652,7 @@ MMI.metadata_pkg(
     AbstractSymbolicRegressor;
     name="SymbolicRegression",
     uuid="8254be44-1295-4e6a-a16d-46603ac705cb",
-    url="https://github.com/MilesCranmer/SymbolicRegression.jl",
+    url="https://github.com/astroautomata/SymbolicRegression.jl",
     julia=true,
     license="Apache-2.0",
     is_wrapper=false,

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -497,7 +497,7 @@ const OPTION_DESCRIPTIONS = """- `defaults`: What set of defaults to use for `Op
 
 Construct options for `equation_search` and other functions.
 The current arguments have been tuned using the median values from
-https://github.com/MilesCranmer/PySR/discussions/115.
+https://github.com/astroautomata/PySR/discussions/115.
 
 # Arguments
 $(OPTION_DESCRIPTIONS)


### PR DESCRIPTION
Update active repo links and deployment metadata for the astroautomata move.