### PR TITLE
Show real variable names in template expression printing

### DIFF
--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -603,7 +603,13 @@ function DE.string_tree(
     expressions = get_contents(ex)
     num_features = get_metadata(ex).structure.num_features
     total_num_features = max(values(num_features)...)
-    variable_names = ['#' * string(i) for i in 1:total_num_features]
+    real_variable_names = get_metadata(ex).variable_names
+    variable_names = if real_variable_names !== nothing &&
+        length(real_variable_names) >= total_num_features
+        real_variable_names[1:total_num_features]
+    else
+        ['#' * string(i) for i in 1:total_num_features]
+    end
     parameters = has_params(ex) ? get_metadata(ex).parameters : NamedTuple()
     all_keys = (keys(num_features)..., keys(parameters)...)
     colors = _colors(Val(length(all_keys)))


### PR DESCRIPTION
## Summary
`TemplateExpression`'s `string_tree` always printed features as generic `#1`, `#2`, ... placeholders, even though the real dataset variable names are already stored in the expression's metadata (`get_metadata(ex).variable_names`).

This uses the real names when their count matches the total number of features referenced by the template's sub-expressions, and falls back to the generic `#i` labels otherwise (e.g. when variable names aren't available).

Fixes #456

## Test plan
- [x] Existing `test/unit/templates/test_template_expression_string.jl` passes (7/7)
- [x] Verified manually: a template expression built with `variable_names=["x"]` now prints `f = x` instead of `f = #1`