### PR TITLE
Fix constant-optimization restarts never escaping a zero-valued constant

### DIFF
--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -90,7 +90,7 @@ function _optimize_constants_inner(
     for _ in 1:(options.optimizer_nrestarts)
         ET = eltype(x0)
         eps = randn(rng, ET, size(x0)...)
-        xt = @. x0 * (ET(1) + ET(1 // 2) * eps)
+        xt = @. x0 + ET(1 // 2) * eps * (abs(x0) + ET(1))
         tmpresult = Optim.optimize(obj, xt, algorithm, optimizer_options)
         num_evals += tmpresult.f_calls * eval_fraction
         # TODO: Does this need to take into account h_calls?

--- a/test/unit/misc/test_guesses.jl
+++ b/test/unit/misc/test_guesses.jl
@@ -107,6 +107,57 @@ end
     @test length(get_metadata(member.tree).parameters.p._data) == 2
 end
 
+@testitem "Guess with template parameters actually optimizes them" begin
+    # Regression test for #510: template parameters are always
+    # zero-initialized when parsing a guess, and get only a single shot at
+    # `optimize_constants`. The restart mechanism used to perturb constants
+    # multiplicatively (`x0 * (1 + eps)`), which can never move a
+    # zero-valued constant away from zero, so guesses depending on nonzero
+    # parameters were effectively unoptimizable.
+    using SymbolicRegression
+    using SymbolicRegression: calculate_pareto_frontier
+    using Random: MersenneTwister
+    using Test
+
+    structure = TemplateStructure{(:f,),(:p1,)}(
+        ((; f), (; p1), (x, cat)) -> f(x, p1[cat]); num_parameters=(; p1=4)
+    )
+    options = Options(;
+        binary_operators=[+, -, *, /],
+        unary_operators=[sqrt],
+        expression_spec=TemplateExpressionSpec(; structure),
+        optimizer_nrestarts=8,
+        deterministic=true,
+        seed=0,
+        verbosity=0,
+        progress=false,
+    )
+
+    rng = MersenneTwister(0)
+    n = 200
+    x_data = rand(rng, n) * 10.0
+    cat_data = rand(rng, 1:4, n)
+    p1_true = [5.0, 10.0, 0.8, 3.1]
+    y = @. p1_true[cat_data] * x_data^3 + sqrt(x_data) / p1_true[cat_data]
+    X = vcat(x_data', cat_data')
+
+    guess = (f="(#2 * ((#1 * #1) * #1)) + (sqrt(#1) / #2)",)
+    hof = equation_search(
+        X,
+        y;
+        niterations=0,
+        options,
+        guesses=[guess],
+        variable_names=["x", "cat"],
+        parallelism=:serial,
+    )
+    dominating = calculate_pareto_frontier(hof)
+
+    # Before the fix, the parameters stay at their zero-initialized values,
+    # the `1/p1[cat]` term blows up, and loss never leaves Inf.
+    @test any(m -> isfinite(m.loss) && m.loss < 1e-6, dominating)
+end
+
 @testitem "NamedTuple guesses with different variable names" begin
     using SymbolicRegression
     using SymbolicRegression: calculate_pareto_frontier


### PR DESCRIPTION
## Summary
Root-caused the long-running #510/#509 thread (\"Cannot load guesses in Template Expression if function contains parameters\"). The community discussion converged on \"the optimizer seems to be failing somehow\" but never found the mechanism. Here it is:

`_optimize_constants_inner`'s restart loop perturbs the initial point **multiplicatively**:

```julia
xt = @. x0 * (ET(1) + ET(1 // 2) * eps)
```

If `x0[i] == 0`, then `xt[i] = 0 * (1 + 0.5*eps) = 0` for **every** restart, regardless of `eps`. So `optimizer_nrestarts` gives any zero-valued constant zero actual restarts — it's stuck exactly where it started.

This silently breaks guesses for `TemplateExpression`s with parameters specifically: a freshly-parsed guess always zero-initializes its parameters (`TemplateExpression.jl`'s constructor defaults `parameters` to `zeros(T, n)`), and `_parse_guesses_impl` gives it exactly **one** `optimize_constants` call before it enters the population. A normal population member gets many further chances via mutation across generations and can eventually escape a bad start; a guess does not. If that single shot can't move the zero-initialized parameters (e.g. because a `1/p1[cat]`-shaped term blows up to `Inf` right at `p1=0`, as in #509/#510's repros), the guess is permanently stuck.

Verified this exactly reproduces the reported failure mode and that the fix resolves it (repro modeled on #510's example: `y = p1[cat]*x^3 + sqrt(x)/p1[cat]`, `p1_true = [5.0, 10.0, 0.8, 3.1]`):

| | Loss | Recovered parameters |
|---|---|---|
| Before fix | `Inf` (stuck) | `[0.0, 0.0, 0.0, 0.0]` |
| After fix | `4.8e-21` | `[4.9999978, 10.0, 0.79999996, 3.09999996]` |

The fix switches the restart perturbation to also work from zero:

```julia
xt = @. x0 + ET(1 // 2) * eps * (abs(x0) + ET(1))
```

This is approximately the same relative-scale jitter as before for `|x0|` large, but adds an absolute floor so zero-valued constants actually get perturbed.

Fixes #510

## Test plan
- [x] Added a regression test in `test/unit/misc/test_guesses.jl` modeled directly on #510's repro (`TemplateStructure` with 4 categorical parameters, `1/p1[cat]` term) — fails with `loss == Inf` on master, passes with the fix
- [x] `test/unit/misc/test_guesses.jl` — 62/62 pass
- [x] `test/unit/evolution-core/test_custom_type_constant_optimization.jl` (constant-optimization restart path, custom types) — 2/2 pass