### PR TITLE
Add generic optimizable parameters for template expressions

### DIFF
--- a/ext/SymbolicRegressionMooncakeExt.jl
+++ b/ext/SymbolicRegressionMooncakeExt.jl
@@ -2,13 +2,12 @@ module SymbolicRegressionMooncakeExt
 
 using DynamicExpressions: DynamicExpressions as DE
 using SymbolicRegression: SymbolicRegression as SR
-using SymbolicRegression.ConstantOptimizationModule: count_constants_for_optimization
 using Mooncake: Mooncake
 
 function DE.extract_gradient(
     gradient::Mooncake.Tangent, ex::SR.TemplateExpression{T}
 ) where {T}
-    n_const = count_constants_for_optimization(ex)
+    n_const = DE.count_scalar_constants(ex)
     out = Array{T}(undef, n_const)
     i = firstindex(out)
     for (tree_gradient, tree) in zip(values(gradient.fields.trees), values(ex.trees))

--- a/src/ComposableExpression.jl
+++ b/src/ComposableExpression.jl
@@ -95,8 +95,16 @@ function DE.set_scalar_constants!(ex::AbstractComposableExpression, constants, r
     return DE.set_scalar_constants!(DE.get_contents(ex), constants, refs)
 end
 
-function Base.copy(ex::AbstractComposableExpression)
-    return ComposableExpression(copy(ex.tree), copy(ex.metadata))
+function _copy_candidate_state(ex::E)::E where {E<:ComposableExpression}
+    eval_options = DE.get_metadata(ex).eval_options
+    isnothing(eval_options) && return ex
+    copied_eval_options = deepcopy(eval_options)::typeof(eval_options)
+    return DE.with_metadata(ex; eval_options=copied_eval_options)::E
+end
+
+function Base.copy(ex::E) where {E<:ComposableExpression}
+    copied = DE.with_contents(ex, copy(DE.get_contents(ex)))::E
+    return _copy_candidate_state(copied)
 end
 
 function Base.convert(::Type{E}, ex::AbstractComposableExpression) where {E<:Expression}
@@ -120,19 +128,48 @@ function CO.count_constants_for_optimization(ex::AbstractComposableExpression)
     return CO.count_constants_for_optimization(convert(Expression, ex))
 end
 
-struct PreallocatedComposableExpression{N}
+struct PreallocatedComposableExpression{N,E}
     tree::N
+    eval_options::E
 end
+
+_copy_eval_options_into!(::Nothing, ::Nothing) = nothing
+_copy_eval_options_into!(::EvalOptions, ::Nothing) = nothing
+function _copy_eval_options_into!(::Nothing, src::E)::E where {E<:EvalOptions}
+    return deepcopy(src)::E
+end
+function _copy_eval_options_into!(::EvalOptions, src::E)::E where {E<:EvalOptions}
+    return deepcopy(src)::E
+end
+function _copy_eval_options_into!(dest::E, src::E) where {E<:EvalOptions}
+    dest_buffer = dest.buffer
+    src_buffer = src.buffer
+    isnothing(src_buffer) && return src
+    if isnothing(dest_buffer) || axes(dest_buffer.array) != axes(src_buffer.array)
+        return deepcopy(src)::E
+    end
+    copyto!(dest_buffer.array, src_buffer.array)
+    dest_buffer.index[] = src_buffer.index[]
+    return dest
+end
+
 function DE.allocate_container(
     prototype::ComposableExpression, n::Union{Nothing,Integer}=nothing
 )
+    eval_options = DE.get_metadata(prototype).eval_options
+    copied_eval_options = isnothing(eval_options) ? nothing : deepcopy(eval_options)
     return PreallocatedComposableExpression(
-        DE.allocate_container(get_contents(prototype), n)
+        DE.allocate_container(get_contents(prototype), n), copied_eval_options
     )
 end
 function DE.copy_into!(dest::PreallocatedComposableExpression, src::ComposableExpression)
     new_tree = DE.copy_into!(dest.tree, get_contents(src))
-    return DE.with_contents(src, new_tree)
+    metadata = DE.get_metadata(src)
+    eval_options = _copy_eval_options_into!(dest.eval_options, metadata.eval_options)
+    new_metadata = Metadata((;
+        operators=metadata.operators, variable_names=metadata.variable_names, eval_options
+    ))
+    return ComposableExpression(new_tree, new_metadata)
 end
 
 @implements(

--- a/src/ComposableExpression.jl
+++ b/src/ComposableExpression.jl
@@ -95,16 +95,8 @@ function DE.set_scalar_constants!(ex::AbstractComposableExpression, constants, r
     return DE.set_scalar_constants!(DE.get_contents(ex), constants, refs)
 end
 
-function _copy_candidate_state(ex::E)::E where {E<:ComposableExpression}
-    eval_options = DE.get_metadata(ex).eval_options
-    isnothing(eval_options) && return ex
-    copied_eval_options = deepcopy(eval_options)::typeof(eval_options)
-    return DE.with_metadata(ex; eval_options=copied_eval_options)::E
-end
-
-function Base.copy(ex::E) where {E<:ComposableExpression}
-    copied = DE.with_contents(ex, copy(DE.get_contents(ex)))::E
-    return _copy_candidate_state(copied)
+function Base.copy(ex::ComposableExpression)
+    return ComposableExpression(copy(DE.get_contents(ex)), copy(DE.get_metadata(ex)))
 end
 
 function Base.convert(::Type{E}, ex::AbstractComposableExpression) where {E<:Expression}
@@ -124,8 +116,14 @@ end
 function DE.count_scalar_constants(ex::AbstractComposableExpression)
     return DE.count_scalar_constants(convert(Expression, ex))
 end
-function CO.count_constants_for_optimization(ex::AbstractComposableExpression)
-    return CO.count_constants_for_optimization(convert(Expression, ex))
+function CO.get_optimizable_parameters(ex::ComposableExpression, _options)
+    return DE.get_scalar_constants(ex)
+end
+function CO.set_optimizable_parameters!(ex::ComposableExpression, x, refs)
+    return DE.set_scalar_constants!(ex, x, refs)
+end
+function CO.extract_optimizable_gradient(grad, ex::ComposableExpression, _refs)
+    return DE.extract_gradient(grad, ex)
 end
 
 struct PreallocatedComposableExpression{N,E}
@@ -133,39 +131,31 @@ struct PreallocatedComposableExpression{N,E}
     eval_options::E
 end
 
-_copy_eval_options_into!(::Nothing, ::Nothing) = nothing
-_copy_eval_options_into!(::EvalOptions, ::Nothing) = nothing
-function _copy_eval_options_into!(::Nothing, src::E)::E where {E<:EvalOptions}
-    return deepcopy(src)::E
-end
-function _copy_eval_options_into!(::EvalOptions, src::E)::E where {E<:EvalOptions}
-    return deepcopy(src)::E
-end
-function _copy_eval_options_into!(dest::E, src::E) where {E<:EvalOptions}
-    dest_buffer = dest.buffer
-    src_buffer = src.buffer
-    isnothing(src_buffer) && return src
-    if isnothing(dest_buffer) || axes(dest_buffer.array) != axes(src_buffer.array)
-        return deepcopy(src)::E
+_reuse_or_copy_eval_options(::Nothing, ::Nothing) = nothing
+_reuse_or_copy_eval_options(::EvalOptions, ::Nothing) = nothing
+_reuse_or_copy_eval_options(::Nothing, src::EvalOptions) = copy(src)
+function _reuse_or_copy_eval_options(dest::E, src::E) where {E<:EvalOptions}
+    if isnothing(src.buffer) ||
+        (!isnothing(dest.buffer) && axes(dest.buffer.array) == axes(src.buffer.array))
+        return dest
     end
-    copyto!(dest_buffer.array, src_buffer.array)
-    dest_buffer.index[] = src_buffer.index[]
-    return dest
+    return copy(src)
 end
+_reuse_or_copy_eval_options(::EvalOptions, src::EvalOptions) = copy(src)
 
 function DE.allocate_container(
     prototype::ComposableExpression, n::Union{Nothing,Integer}=nothing
 )
     eval_options = DE.get_metadata(prototype).eval_options
-    copied_eval_options = isnothing(eval_options) ? nothing : deepcopy(eval_options)
     return PreallocatedComposableExpression(
-        DE.allocate_container(get_contents(prototype), n), copied_eval_options
+        DE.allocate_container(get_contents(prototype), n),
+        isnothing(eval_options) ? nothing : copy(eval_options),
     )
 end
 function DE.copy_into!(dest::PreallocatedComposableExpression, src::ComposableExpression)
     new_tree = DE.copy_into!(dest.tree, get_contents(src))
     metadata = DE.get_metadata(src)
-    eval_options = _copy_eval_options_into!(dest.eval_options, metadata.eval_options)
+    eval_options = _reuse_or_copy_eval_options(dest.eval_options, metadata.eval_options)
     new_metadata = Metadata((;
         operators=metadata.operators, variable_names=metadata.variable_names, eval_options
     ))

--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -58,6 +58,58 @@ By default this forwards to `extract_gradient`.
 """
 extract_gradient_for_optimization(grad, ex::AbstractExpression) = extract_gradient(grad, ex)
 
+"""
+    count_optimizable_parameters(ex, options)
+
+Return the number of parameters from `ex` that should be optimized under `options`.
+
+By default this forwards to [`count_constants_for_optimization`](@ref). Custom
+expression integrations may overload this method to make parameter selection depend
+on the active options.
+"""
+function count_optimizable_parameters(ex, options)
+    return count_constants_for_optimization(ex)
+end
+
+"""
+    get_optimizable_parameters(ex, options) -> x0, refs
+
+Flatten the parameters from `ex` that should be optimized under `options` into `x0`.
+The returned `refs` object is passed unchanged to
+[`set_optimizable_parameters!`](@ref) and
+[`extract_optimizable_gradient`](@ref).
+
+By default this forwards to [`get_constants_for_optimization`](@ref).
+"""
+function get_optimizable_parameters(ex, options)
+    return get_constants_for_optimization(ex)
+end
+
+"""
+    set_optimizable_parameters!(ex, x, refs)
+
+Set the optimizable parameters of `ex` from `x`, using the opaque `refs` object
+returned by [`get_optimizable_parameters`](@ref).
+
+By default this forwards to [`set_constants_for_optimization!`](@ref).
+"""
+function set_optimizable_parameters!(ex, x, refs)
+    return set_constants_for_optimization!(ex, x, refs)
+end
+
+"""
+    extract_optimizable_gradient(grad, ex, refs)
+
+Extract the gradient of the selected parameters in the same order returned by
+[`get_optimizable_parameters`](@ref). The `refs` object is the exact object returned
+by that call, allowing custom integrations to preserve an active parameter subset.
+
+By default this forwards to [`extract_gradient_for_optimization`](@ref).
+"""
+function extract_optimizable_gradient(grad, ex, refs)
+    return extract_gradient_for_optimization(grad, ex)
+end
+
 @unstable function optimize_constants(
     dataset::Dataset{T,L},
     member::P,
@@ -65,7 +117,7 @@ extract_gradient_for_optimization(grad, ex::AbstractExpression) = extract_gradie
     rng::AbstractRNG=default_rng(),
 )::Tuple{P,Float64} where {T<:DATA_TYPE,L<:LOSS_TYPE,N,P<:AbstractPopMember{T,L,N}}
     can_optimize(member.tree, options) || return (member, 0.0)
-    x0, refs = get_constants_for_optimization(member.tree)
+    x0, refs = get_optimizable_parameters(member.tree, options)
     nconst = length(x0)
     nconst == 0 && return (member, 0.0)
     if nconst == 1 && !(T <: Complex)
@@ -112,7 +164,7 @@ end
 function _optimize_constants(
     dataset, member::P, options, algorithm, optimizer_options, rng
 )::Tuple{P,Float64} where {T,L,N,P<:AbstractPopMember{T,L,N}}
-    x0, refs = get_constants_for_optimization(member.tree)
+    x0, refs = get_optimizable_parameters(member.tree, options)
     return _optimize_constants(
         dataset, member, x0, refs, options, algorithm, optimizer_options, rng
     )
@@ -146,7 +198,7 @@ function _optimize_constants_inner(
     end
 
     if result.minimum < baseline
-        set_constants_for_optimization!(member.tree, result.minimizer, refs)
+        set_optimizable_parameters!(member.tree, result.minimizer, refs)
         member.loss = f(result.minimizer; regularization=true)
         member.cost = loss_to_cost(
             member.loss, dataset.use_baseline, dataset.baseline_loss, member, options
@@ -155,7 +207,7 @@ function _optimize_constants_inner(
         num_evals += eval_fraction
     else
         # Reset to original state
-        set_constants_for_optimization!(member.tree, x0, refs)
+        set_optimizable_parameters!(member.tree, x0, refs)
     end
 
     return member, num_evals
@@ -175,7 +227,7 @@ struct Evaluator{N<:AbstractExpression,R,C<:EvaluatorContext} <: Function
     ctx::C
 end
 function (e::Evaluator)(x::AbstractVector; regularization=false)
-    set_constants_for_optimization!(e.tree, x, e.refs)
+    set_optimizable_parameters!(e.tree, x, e.refs)
     return e.ctx(e.tree; regularization)
 end
 
@@ -203,11 +255,11 @@ end
 
 function (g::GradEvaluator{<:Any,AD})(_, G, x::AbstractVector) where {AD}
     AD isa AutoEnzyme && error("Please load the `Enzyme.jl` package.")
-    set_constants_for_optimization!(g.e.tree, x, g.e.refs)
+    set_optimizable_parameters!(g.e.tree, x, g.e.refs)
     maybe_prep = isnothing(g.prep) ? () : (g.prep,)
     (val, grad) = value_and_gradient(g.e.ctx, maybe_prep..., g.backend, g.e.tree)
     if G !== nothing && grad !== nothing
-        G .= extract_gradient_for_optimization(grad, g.e.tree)
+        G .= extract_optimizable_gradient(grad, g.e.tree, g.e.refs)
     end
     return val
 end

--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -8,7 +8,6 @@ using DifferentiationInterface: value_and_gradient, prepare_gradient
 using DynamicExpressions:
     AbstractExpression,
     Expression,
-    count_scalar_constants,
     get_scalar_constants,
     set_scalar_constants!,
     extract_gradient
@@ -33,6 +32,9 @@ Flatten all parameters optimized by `optimize_constants` into a single vector `x
 along with any references needed by [`set_constants_for_optimization!`](@ref).
 
 By default this forwards to `get_scalar_constants`.
+
+New expression integrations should overload [`get_optimizable_parameters`](@ref)
+instead. This method remains as a compatibility hook for existing integrations.
 """
 get_constants_for_optimization(ex::AbstractExpression) = get_scalar_constants(ex)
 
@@ -43,6 +45,9 @@ Set the optimizable parameters of `ex` from the flat vector `x`, using the `refs
 returned by [`get_constants_for_optimization`](@ref).
 
 By default this forwards to `set_scalar_constants!`.
+
+New expression integrations should overload [`set_optimizable_parameters!`](@ref)
+instead. This method remains as a compatibility hook for existing integrations.
 """
 function set_constants_for_optimization!(ex::AbstractExpression, x, refs)
     set_scalar_constants!(ex, x, refs)
@@ -55,33 +60,11 @@ Extract the gradient of all optimizable parameters of `ex` into the same flatten
 order returned by [`get_constants_for_optimization`](@ref).
 
 By default this forwards to `extract_gradient`.
+
+New expression integrations should overload [`extract_optimizable_gradient`](@ref)
+instead. This method remains as a compatibility hook for existing integrations.
 """
 extract_gradient_for_optimization(grad, ex::AbstractExpression) = extract_gradient(grad, ex)
-
-"""
-    count_optimizable_parameters(ex, options)
-
-Return the number of parameters from `ex` that should be optimized under `options`.
-
-By default this forwards to [`count_constants_for_optimization`](@ref). Custom
-expression integrations may overload this method to make parameter selection depend
-on the active options.
-"""
-function count_optimizable_parameters(ex, options)
-    return count_constants_for_optimization(ex)
-end
-
-"""
-    count_optimizable_parameters(context, ex, options)
-
-Return the number of parameters selected for `ex` by an owning `context`.
-
-Structured expressions may route parameter selection through a context object such
-as their combiner. By default the context does not alter constant selection.
-"""
-function count_optimizable_parameters(context, ex, options)
-    return count_constants_for_optimization(ex)
-end
 
 """
     get_optimizable_parameters(ex, options) -> x0, refs
@@ -92,9 +75,17 @@ The returned `refs` object is passed unchanged to
 [`extract_optimizable_gradient`](@ref).
 
 By default this forwards to [`get_constants_for_optimization`](@ref).
+
+The returned `refs` is opaque and only valid for the expression state and `x0`
+returned by the same call. Implementations must preserve parameter ordering across
+this function, [`set_optimizable_parameters!`](@ref), and
+[`extract_optimizable_gradient`](@ref).
 """
 function get_optimizable_parameters(ex, options)
     return get_constants_for_optimization(ex)
+end
+function get_optimizable_parameters(ex::Expression, options)
+    return get_scalar_constants(ex)
 end
 
 """
@@ -106,7 +97,7 @@ Structured expressions may route parameter selection through a context object su
 as their combiner. By default the context does not alter constant selection.
 """
 function get_optimizable_parameters(context, ex, options)
-    return get_constants_for_optimization(ex)
+    return get_optimizable_parameters(ex, options)
 end
 
 """
@@ -116,9 +107,15 @@ Set the optimizable parameters of `ex` from `x`, using the opaque `refs` object
 returned by [`get_optimizable_parameters`](@ref).
 
 By default this forwards to [`set_constants_for_optimization!`](@ref).
+
+Implementations must consume parameters in exactly the order returned by
+[`get_optimizable_parameters`](@ref).
 """
 function set_optimizable_parameters!(ex, x, refs)
     return set_constants_for_optimization!(ex, x, refs)
+end
+function set_optimizable_parameters!(ex::Expression, x, refs)
+    return set_scalar_constants!(ex, x, refs)
 end
 
 """
@@ -129,9 +126,15 @@ Extract the gradient of the selected parameters in the same order returned by
 by that call, allowing custom integrations to preserve an active parameter subset.
 
 By default this forwards to [`extract_gradient_for_optimization`](@ref).
+
+Implementations must return one gradient entry for each parameter returned by
+[`get_optimizable_parameters`](@ref), in the same order.
 """
 function extract_optimizable_gradient(grad, ex, refs)
     return extract_gradient_for_optimization(grad, ex)
+end
+function extract_optimizable_gradient(grad, ex::Expression, refs)
+    return extract_gradient(grad, ex)
 end
 
 @unstable function optimize_constants(
@@ -170,9 +173,6 @@ end
         rng,
     )
 end
-
-"""How many constants will be optimized."""
-count_constants_for_optimization(ex::Expression) = count_scalar_constants(ex)
 
 function _optimize_constants(
     dataset, member::P, x0, refs, options, algorithm, optimizer_options, rng
@@ -283,7 +283,14 @@ function (g::GradEvaluator{<:Any,AD})(_, G, x::AbstractVector) where {AD}
     maybe_prep = isnothing(g.prep) ? () : (g.prep,)
     (val, grad) = value_and_gradient(g.e.ctx, maybe_prep..., g.backend, g.e.tree)
     if G !== nothing && grad !== nothing
-        G .= extract_optimizable_gradient(grad, g.e.tree, g.e.refs)
+        extracted_gradient = extract_optimizable_gradient(grad, g.e.tree, g.e.refs)
+        length(extracted_gradient) == length(G) || throw(
+            DimensionMismatch(
+                "extracted $(length(extracted_gradient)) parameter gradients for " *
+                "an optimization vector of length $(length(G))",
+            ),
+        )
+        G .= extracted_gradient
     end
     return val
 end

--- a/src/ConstantOptimization.jl
+++ b/src/ConstantOptimization.jl
@@ -72,6 +72,18 @@ function count_optimizable_parameters(ex, options)
 end
 
 """
+    count_optimizable_parameters(context, ex, options)
+
+Return the number of parameters selected for `ex` by an owning `context`.
+
+Structured expressions may route parameter selection through a context object such
+as their combiner. By default the context does not alter constant selection.
+"""
+function count_optimizable_parameters(context, ex, options)
+    return count_constants_for_optimization(ex)
+end
+
+"""
     get_optimizable_parameters(ex, options) -> x0, refs
 
 Flatten the parameters from `ex` that should be optimized under `options` into `x0`.
@@ -82,6 +94,18 @@ The returned `refs` object is passed unchanged to
 By default this forwards to [`get_constants_for_optimization`](@ref).
 """
 function get_optimizable_parameters(ex, options)
+    return get_constants_for_optimization(ex)
+end
+
+"""
+    get_optimizable_parameters(context, ex, options) -> x0, refs
+
+Flatten the parameters selected for `ex` by an owning `context`.
+
+Structured expressions may route parameter selection through a context object such
+as their combiner. By default the context does not alter constant selection.
+"""
+function get_optimizable_parameters(context, ex, options)
     return get_constants_for_optimization(ex)
 end
 

--- a/src/ParametricExpression.jl
+++ b/src/ParametricExpression.jl
@@ -166,8 +166,14 @@ function MF.crossover_trees(
     return ex1, ex2
 end
 
-function CO.count_constants_for_optimization(ex::ParametricExpression)
-    return CO.count_scalar_constants(get_tree(ex)) + length(get_metadata(ex).parameters)
+function CO.get_optimizable_parameters(ex::ParametricExpression, _options)
+    return DE.get_scalar_constants(ex)
+end
+function CO.set_optimizable_parameters!(ex::ParametricExpression, x, refs)
+    return DE.set_scalar_constants!(ex, x, refs)
+end
+function CO.extract_optimizable_gradient(grad, ex::ParametricExpression, _refs)
+    return DE.extract_gradient(grad, ex)
 end
 
 function MF.mutate_constant(

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -204,7 +204,7 @@ using Compat: @compat, Fix
         AbstractComposableExpression,
         optimize_constants, get_constants_for_optimization,
         set_constants_for_optimization!, extract_gradient_for_optimization,
-        count_optimizable_parameters, get_optimizable_parameters,
+        get_optimizable_parameters,
         set_optimizable_parameters!, extract_optimizable_gradient,
         AbstractPlugin, MutationEvent,
         init_plugin_state,
@@ -377,7 +377,6 @@ using .ConstantOptimizationModule:
     get_constants_for_optimization,
     set_constants_for_optimization!,
     extract_gradient_for_optimization,
-    count_optimizable_parameters,
     get_optimizable_parameters,
     set_optimizable_parameters!,
     extract_optimizable_gradient

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -204,6 +204,8 @@ using Compat: @compat, Fix
         AbstractComposableExpression,
         optimize_constants, get_constants_for_optimization,
         set_constants_for_optimization!, extract_gradient_for_optimization,
+        count_optimizable_parameters, get_optimizable_parameters,
+        set_optimizable_parameters!, extract_optimizable_gradient,
         AbstractPlugin, MutationEvent,
         init_plugin_state,
         on_search_start!, on_search_end!,
@@ -374,7 +376,11 @@ using .ConstantOptimizationModule:
     optimize_constants,
     get_constants_for_optimization,
     set_constants_for_optimization!,
-    extract_gradient_for_optimization
+    extract_gradient_for_optimization,
+    count_optimizable_parameters,
+    get_optimizable_parameters,
+    set_optimizable_parameters!,
+    extract_optimizable_gradient
 using .PopMemberModule:
     AbstractPopMember, PopMember, reset_birth!, popmember_type, expression_type
 using .CoreModule.UtilsModule: get_birth_order

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -605,8 +605,11 @@ function EB.extra_init_params(
     else
         # COV_EXCL_START
         if prototype === nothing
-            NamedTuple{keys(num_parameters)}(
-                map(n -> ParamVector(randn(T, (n,))), values(num_parameters))
+            _initialize_template_parameters(
+                default_rng(),
+                T,
+                num_parameters,
+                options.expression_options.parameter_initializer,
             )
         else
             _copy(get_metadata(prototype).parameters::NamedTuple)
@@ -616,6 +619,49 @@ function EB.extra_init_params(
     # We also need to include the operators here to be consistent with `create_expression`.
     return (; options.operators, options.expression_options..., parameters)
 end
+
+function _initialize_template_parameters(
+    rng::AbstractRNG, ::Type{T}, num_parameters::NamedTuple, parameter_initializer::Nothing
+) where {T}
+    return NamedTuple{keys(num_parameters)}(
+        map(n -> ParamVector(randn(rng, T, (n,))), values(num_parameters))
+    )
+end
+function _initialize_template_parameters(
+    rng::AbstractRNG, ::Type{T}, num_parameters::NamedTuple, parameter_initializer
+) where {T}
+    initialized = parameter_initializer(rng, T, num_parameters)
+    initialized isa NamedTuple || throw(
+        ArgumentError(
+            "`parameter_initializer` must return a `NamedTuple`, got $(typeof(initialized))",
+        ),
+    )
+
+    expected_keys = keys(num_parameters)
+    initialized_keys = keys(initialized)
+    issetequal(initialized_keys, expected_keys) || throw(
+        ArgumentError(
+            "`parameter_initializer` returned keys $(initialized_keys), expected $(expected_keys)",
+        ),
+    )
+
+    parameters = map(expected_keys, values(num_parameters)) do key, expected_length
+        parameter = initialized[key]
+        parameter isa AbstractVector || throw(
+            ArgumentError(
+                "`parameter_initializer` must return an `AbstractVector` for parameter `$(key)`, got $(typeof(parameter))",
+            ),
+        )
+        length(parameter) == expected_length || throw(
+            DimensionMismatch(
+                "`parameter_initializer` returned $(length(parameter)) values for parameter `$(key)`, expected $(expected_length)",
+            ),
+        )
+        return ParamVector(Vector{T}(parameter))
+    end
+    return NamedTuple{expected_keys}(parameters)
+end
+
 function EB.sort_params(params::NamedTuple, ::Type{<:TemplateExpression})
     return (; params.structure, params.operators, params.variable_names, params.parameters)
 end
@@ -1038,16 +1084,32 @@ end
     TemplateExpressionSpec <: AbstractExpressionSpec
 
 (Experimental) Specification for template expressions with pre-defined structure.
+
+# Fields
+- `structure`: The `TemplateStructure` defining how inner expressions and parameters
+    are combined.
+- `inner_expression_type`: The expression type used for each inner expression.
+- `inner_expression_options`: Additional keyword arguments passed to inner expressions.
+- `parameter_initializer`: Optional function called as
+    `parameter_initializer(rng, T, num_parameters)` when creating a new candidate.
+    It must return a `NamedTuple` with the same keys and vector lengths as
+    `num_parameters`. By default, template parameters are initialized with `randn`.
 """
-struct TemplateExpressionSpec{ST<:TemplateStructure,IET,IEO<:NamedTuple} <:
+struct TemplateExpressionSpec{ST<:TemplateStructure,IET,IEO<:NamedTuple,PI} <:
        AbstractExpressionSpec
     structure::ST
     inner_expression_type::Type{IET}
     inner_expression_options::IEO
-    function TemplateExpressionSpec{ST,IET,IEO}(
-        structure, inner_expression_type, inner_expression_options
-    ) where {ST<:TemplateStructure,IET,IEO<:NamedTuple}
-        return new{ST,IET,IEO}(structure, inner_expression_type, inner_expression_options)
+    parameter_initializer::PI
+    function TemplateExpressionSpec{ST,IET,IEO,PI}(
+        structure, inner_expression_type, inner_expression_options, parameter_initializer
+    ) where {ST<:TemplateStructure,IET,IEO<:NamedTuple,PI}
+        return new{ST,IET,IEO,PI}(
+            structure,
+            inner_expression_type,
+            inner_expression_options,
+            parameter_initializer,
+        )
     end
 end
 # Positional form. `::Type{IET}` with a positional default binds IET in the
@@ -1057,18 +1119,22 @@ function TemplateExpressionSpec(
     structure::TemplateStructure,
     (::Type{IET})=ComposableExpression,
     inner_expression_options::NamedTuple=NamedTuple(),
+    parameter_initializer=nothing,
 ) where {IET}
-    return TemplateExpressionSpec{typeof(structure),IET,typeof(inner_expression_options)}(
-        structure, IET, inner_expression_options
+    return TemplateExpressionSpec{
+        typeof(structure),IET,typeof(inner_expression_options),typeof(parameter_initializer)
+    }(
+        structure, IET, inner_expression_options, parameter_initializer
     )
 end
 @unstable function TemplateExpressionSpec(;
     structure::TemplateStructure,
     inner_expression_type::Type=ComposableExpression,
     inner_expression_options::NamedTuple=NamedTuple(),
+    parameter_initializer=nothing,
 )
     return TemplateExpressionSpec(
-        structure, inner_expression_type, inner_expression_options
+        structure, inner_expression_type, inner_expression_options, parameter_initializer
     )
 end
 
@@ -1077,12 +1143,22 @@ ES.get_expression_type(::TemplateExpressionSpec) = TemplateExpression
 # Explicit NamedTuple type pins `inner_expression_type` as `Type{IET}`
 # (a `(; ...)` shorthand widens it to `Type`, killing inference).
 function ES.get_expression_options(
-    spec::TemplateExpressionSpec{ST,IET,IEO}
-) where {ST,IET,IEO}
+    spec::TemplateExpressionSpec{ST,IET,IEO,PI}
+) where {ST,IET,IEO,PI}
     return NamedTuple{
-        (:structure, :inner_expression_type, :inner_expression_options),
-        Tuple{ST,Type{IET},IEO},
-    }((spec.structure, spec.inner_expression_type, spec.inner_expression_options))
+        (
+            :structure,
+            :inner_expression_type,
+            :inner_expression_options,
+            :parameter_initializer,
+        ),
+        Tuple{ST,Type{IET},IEO,PI},
+    }((
+        spec.structure,
+        spec.inner_expression_type,
+        spec.inner_expression_options,
+        spec.parameter_initializer,
+    ),)
 end
 ES.get_node_type(::TemplateExpressionSpec) = Node
 # COV_EXCL_STOP

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -54,7 +54,7 @@ using ..LossFunctionsModule: LossFunctionsModule as LF
 using ..MutateModule: MutateModule as MM
 using ..PopMemberModule: PopMember, AbstractPopMember
 using ..ComposableExpressionModule:
-    AbstractComposableExpression, ComposableExpression, ValidVector, _copy_candidate_state
+    AbstractComposableExpression, ComposableExpression, ValidVector
 
 struct ParamVector{T} <: AbstractVector{T}
     _data::Vector{T}
@@ -434,54 +434,33 @@ function DE.set_scalar_constants!(e::TemplateExpression, constants, refs)
     return e
 end
 
-_parameter_data(x::ParamVector) = x._data
-_parameter_data(x) = x
-
-function CO.get_constants_for_optimization(e::TemplateExpression{T}) where {T}
-    inner_params_and_refs = map(CO.get_constants_for_optimization, values(get_contents(e)))
-    inner_chunks = first.(inner_params_and_refs)
-    parameter_chunks = if has_params(e)
-        map(_parameter_data, values(get_metadata(e).parameters))
-    else
-        ()
-    end
-    flat = if isempty(inner_chunks) && isempty(parameter_chunks)
-        T[]
-    else
-        vcat(inner_chunks..., parameter_chunks...)
-    end
-    refs = (
-        inner=map(pr -> (; n=length(first(pr)), ref=last(pr)), inner_params_and_refs),
-        parameter_keys=has_params(e) ? collect(keys(get_metadata(e).parameters)) : Symbol[],
-    )
-    return flat, refs
+struct TemplateOptimizableRefs{R}
+    scalar_refs::R
+    length::Int
 end
+
 function CO.get_optimizable_parameters(e::TemplateExpression, options)
     combiner = get_metadata(e).structure.combine
     return CO.get_optimizable_parameters(combiner, e, options)
 end
-function CO.count_optimizable_parameters(e::TemplateExpression, options)
-    combiner = get_metadata(e).structure.combine
-    return CO.count_optimizable_parameters(combiner, e, options)
+function CO.get_optimizable_parameters(_context, e::TemplateExpression, _options)
+    parameters, scalar_refs = DE.get_scalar_constants(e)
+    return parameters, TemplateOptimizableRefs(scalar_refs, length(parameters))
 end
-function CO.set_constants_for_optimization!(e::TemplateExpression, constants, refs)
-    cursor = Ref(1)
-    foreach(values(get_contents(e)), refs.inner) do tree, r
-        let n = r.n, i = cursor[]
-            CO.set_constants_for_optimization!(tree, constants[i:(i + n - 1)], r.ref)
-            cursor[] = i + n
-        end
-    end
-    if has_params(e)
-        parameters = get_metadata(e).parameters
-        for k in refs.parameter_keys
-            let n = length(parameters[k]), i = cursor[]
-                parameters[k]._data[:] = constants[i:(i + n - 1)]
-                cursor[] = i + n
-            end
-        end
-    end
-    return e
+function CO.set_optimizable_parameters!(
+    e::TemplateExpression, parameters, refs::TemplateOptimizableRefs
+)
+    length(parameters) == refs.length || throw(
+        DimensionMismatch(
+            "received $(length(parameters)) optimizable parameters but expected $(refs.length)",
+        ),
+    )
+    return DE.set_scalar_constants!(e, parameters, refs.scalar_refs)
+end
+function CO.extract_optimizable_gradient(
+    grad, e::TemplateExpression, _refs::TemplateOptimizableRefs
+)
+    return DE.extract_gradient(grad, e)
 end
 Base.@kwdef struct PreallocatedTemplateExpression{A,B}
     trees::A
@@ -918,11 +897,6 @@ end
 
 function _crossover_template_inners(
     ex1::E, ex2::E, rng::AbstractRNG
-) where {E<:ComposableExpression}
-    return MF.crossover_trees(_copy_candidate_state(ex1), _copy_candidate_state(ex2), rng)
-end
-function _crossover_template_inners(
-    ex1::E, ex2::E, rng::AbstractRNG
 ) where {E<:AbstractComposableExpression}
     return MF.crossover_trees(copy(ex1), copy(ex2), rng)
 end
@@ -1054,18 +1028,21 @@ end
 
 # TODO: Look at other ParametricExpression behavior
 
-for f in (:(DE.count_scalar_constants), :(CO.count_constants_for_optimization))
-    @eval function $f(ex::TemplateExpression)
-        return (
-            sum($f, values(get_contents(ex))) +
-            (has_params(ex) ? sum($f, values(get_metadata(ex).parameters)) : 0)
+function DE.count_scalar_constants(ex::TemplateExpression)
+    return (
+        sum(DE.count_scalar_constants, values(get_contents(ex))) + (
+            if has_params(ex)
+                sum(DE.count_scalar_constants, values(get_metadata(ex).parameters))
+            else
+                0
+            end
         )
-    end
-    @eval function $f(p::ParamVector)
-        # TODO: This is not general enough; we should be using `get_scalar_constants`
-        # on the parameters themselves.
-        return length(p._data)
-    end
+    )
+end
+function DE.count_scalar_constants(p::ParamVector)
+    # TODO: This is not general enough; we should be using `get_scalar_constants`
+    # on the parameters themselves.
+    return length(p._data)
 end
 
 function CC.check_constraints(

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -1106,7 +1106,7 @@ end
     types must implement the DynamicExpressions expression interface, including
     `Base.copy` with independent copies of any mutable candidate-local metadata.
 - `inner_expression_options`: Additional keyword arguments passed to inner expressions.
-- `parameter_initializer`: Optional function called as
+- `parameter_initializer`: **Experimental** optional function called as
     `parameter_initializer(rng, T, num_parameters)` when creating a new candidate.
     It must return a `NamedTuple` with the same keys and vector lengths as
     `num_parameters`. By default, template parameters are initialized with `randn`.

--- a/src/TemplateExpression.jl
+++ b/src/TemplateExpression.jl
@@ -54,7 +54,7 @@ using ..LossFunctionsModule: LossFunctionsModule as LF
 using ..MutateModule: MutateModule as MM
 using ..PopMemberModule: PopMember, AbstractPopMember
 using ..ComposableExpressionModule:
-    AbstractComposableExpression, ComposableExpression, ValidVector
+    AbstractComposableExpression, ComposableExpression, ValidVector, _copy_candidate_state
 
 struct ParamVector{T} <: AbstractVector{T}
     _data::Vector{T}
@@ -373,18 +373,9 @@ end
 
 function Base.copy(e::TemplateExpression)
     ts = get_contents(e)
-    meta = get_metadata(e)
-    meta_inner = DE.ExpressionModule.unpack_metadata(meta)
     copy_ts = NamedTuple{keys(ts)}(map(copy, values(ts)))
-    keys_except_structure = filter(!=(:structure), keys(meta_inner))
-    copy_metadata = (;
-        meta_inner.structure,
-        # Note: this `_copy` is just `copy` but with handling for `nothing` and `NamedTuple`
-        NamedTuple{keys_except_structure}(
-            map(_copy, values(meta_inner[keys_except_structure]))
-        )...,
-    )
-    return DE.constructorof(typeof(e))(copy_ts, Metadata(copy_metadata))
+    copy_parameters = _copy(get_metadata(e).parameters::NamedTuple)
+    return with_metadata(with_contents(e, copy_ts); parameters=copy_parameters)
 end
 function DE.get_contents(e::TemplateExpression)
     return e.trees
@@ -464,6 +455,14 @@ function CO.get_constants_for_optimization(e::TemplateExpression{T}) where {T}
         parameter_keys=has_params(e) ? collect(keys(get_metadata(e).parameters)) : Symbol[],
     )
     return flat, refs
+end
+function CO.get_optimizable_parameters(e::TemplateExpression, options)
+    combiner = get_metadata(e).structure.combine
+    return CO.get_optimizable_parameters(combiner, e, options)
+end
+function CO.count_optimizable_parameters(e::TemplateExpression, options)
+    combiner = get_metadata(e).structure.combine
+    return CO.count_optimizable_parameters(combiner, e, options)
 end
 function CO.set_constants_for_optimization!(e::TemplateExpression, constants, refs)
     cursor = Ref(1)
@@ -917,6 +916,44 @@ function MF.get_contents_for_mutation(ex::TemplateExpression, rng::AbstractRNG)
     return raw_contents[key_to_mutate], key_to_mutate
 end
 
+function _crossover_template_inners(
+    ex1::E, ex2::E, rng::AbstractRNG
+) where {E<:ComposableExpression}
+    return MF.crossover_trees(_copy_candidate_state(ex1), _copy_candidate_state(ex2), rng)
+end
+function _crossover_template_inners(
+    ex1::E, ex2::E, rng::AbstractRNG
+) where {E<:AbstractComposableExpression}
+    return MF.crossover_trees(copy(ex1), copy(ex2), rng)
+end
+
+function _template_crossover_child(
+    ex::TemplateExpression, crossed_inner::AbstractComposableExpression, context::Symbol
+)
+    raw_contents = get_contents(ex)
+    raw_contents_keys = keys(raw_contents)
+    new_contents = NamedTuple{raw_contents_keys}(
+        ntuple(length(raw_contents_keys)) do i
+            key = raw_contents_keys[i]
+            return key == context ? crossed_inner : copy(raw_contents[key])
+        end,
+    )
+    new_parameters = _copy(get_metadata(ex).parameters::NamedTuple)
+    return with_metadata(with_contents(ex, new_contents); parameters=new_parameters)
+end
+
+function MF.crossover_trees(
+    ex1::E, ex2::E, rng::AbstractRNG=default_rng()
+) where {E<:TemplateExpression}
+    ex1 === ex2 && error("Attempted to crossover the same expression!")
+    inner1, context1 = MF.get_contents_for_mutation(ex1, rng)
+    inner2, context2 = MF.get_contents_for_mutation(ex2, rng)
+    crossed1, crossed2 = _crossover_template_inners(inner1, inner2, rng)
+    child1 = _template_crossover_child(ex1, crossed1, context1)
+    child2 = _template_crossover_child(ex2, crossed2, context2)
+    return child1, child2
+end
+
 """See `get_contents_for_mutation(::TemplateExpression, ::AbstractRNG)`."""
 function MF.with_contents_for_mutation(
     ex::TemplateExpression, new_inner_contents, context::Symbol
@@ -1088,7 +1125,9 @@ end
 # Fields
 - `structure`: The `TemplateStructure` defining how inner expressions and parameters
     are combined.
-- `inner_expression_type`: The expression type used for each inner expression.
+- `inner_expression_type`: The expression type used for each inner expression. Custom
+    types must implement the DynamicExpressions expression interface, including
+    `Base.copy` with independent copies of any mutable candidate-local metadata.
 - `inner_expression_options`: Additional keyword arguments passed to inner expressions.
 - `parameter_initializer`: Optional function called as
     `parameter_initializer(rng, T, num_parameters)` when creating a new candidate.

--- a/test/integration/ext/mlj/templates/Project.toml
+++ b/test/integration/ext/mlj/templates/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+DynamicExpressions = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"

--- a/test/unit/evolution-core/test_constants_for_optimization.jl
+++ b/test/unit/evolution-core/test_constants_for_optimization.jl
@@ -10,7 +10,6 @@
     flat = SymbolicRegression.get_optimizable_parameters(expr, options)[1]
     @test flat == [2.0]
     @test length(flat) == 1
-    @test SymbolicRegression.count_optimizable_parameters(expr, options) == 1
 
     structure = TemplateStructure{(:f,),(:p,)}(
         ((; f), (; p), (x,)) -> f(x) * p[1]; num_parameters=(; p=1)
@@ -26,10 +25,12 @@
     params, refs = SymbolicRegression.get_optimizable_parameters(template, options)
     @test params == [3.0, 2.0]
     @test length(params) == 2
-    @test SymbolicRegression.count_optimizable_parameters(template, options) == 2
 
     SymbolicRegression.set_optimizable_parameters!(template, [4.0, 5.0], refs)
     @test SymbolicRegression.get_optimizable_parameters(template, options)[1] == [4.0, 5.0]
+    @test_throws DimensionMismatch SymbolicRegression.set_optimizable_parameters!(
+        template, [6.0], refs
+    )
 end
 
 @testitem "Template optimizable selection delegates through its combiner" begin
@@ -41,11 +42,6 @@ end
         return fs.f(x) + parameters.p[1]
     end
     struct ContextAwareRefs end
-    function SymbolicRegression.count_optimizable_parameters(
-        ::ContextAwareCombiner, ::TemplateExpression, _options
-    )
-        return 1
-    end
     function SymbolicRegression.get_optimizable_parameters(
         ::ContextAwareCombiner, ::TemplateExpression, _options
     )
@@ -67,7 +63,6 @@ end
     parameters, refs = SymbolicRegression.get_optimizable_parameters(ex, options)
     @test parameters == [42.0]
     @test refs isa ContextAwareRefs
-    @test SymbolicRegression.count_optimizable_parameters(ex, options) == 1
 end
 
 @testitem "Generic optimizable hooks are options- and refs-aware" begin
@@ -80,9 +75,6 @@ end
         indices::Vector{Int}
     end
 
-    function SymbolicRegression.count_optimizable_parameters(box::OptimizableBox, options)
-        return count(options.active)
-    end
     function SymbolicRegression.get_optimizable_parameters(box::OptimizableBox, options)
         refs = OptimizableBoxRefs(findall(options.active))
         return box.values[refs.indices], refs
@@ -103,7 +95,6 @@ end
     options = (; active=Bool[true, false, true])
     params, refs = SymbolicRegression.get_optimizable_parameters(box, options)
 
-    @test SymbolicRegression.count_optimizable_parameters(box, options) == 2
     @test params == [1.0, 3.0]
     @test refs.indices == [1, 3]
     @test SymbolicRegression.extract_optimizable_gradient([0.1, 0.2, 0.3], box, refs) ==

--- a/test/unit/evolution-core/test_constants_for_optimization.jl
+++ b/test/unit/evolution-core/test_constants_for_optimization.jl
@@ -32,6 +32,44 @@
     @test SymbolicRegression.get_optimizable_parameters(template, options)[1] == [4.0, 5.0]
 end
 
+@testitem "Template optimizable selection delegates through its combiner" begin
+    using DynamicExpressions
+    using SymbolicRegression
+
+    struct ContextAwareCombiner <: Function end
+    function (::ContextAwareCombiner)(fs, parameters, (x,))
+        return fs.f(x) + parameters.p[1]
+    end
+    struct ContextAwareRefs end
+    function SymbolicRegression.count_optimizable_parameters(
+        ::ContextAwareCombiner, ::TemplateExpression, _options
+    )
+        return 1
+    end
+    function SymbolicRegression.get_optimizable_parameters(
+        ::ContextAwareCombiner, ::TemplateExpression, _options
+    )
+        return [42.0], ContextAwareRefs()
+    end
+
+    operators = OperatorEnum(; binary_operators=(+,))
+    structure = TemplateStructure{(:f,),(:p,)}(
+        ContextAwareCombiner(); num_features=(; f=1), num_parameters=(; p=1)
+    )
+    ex = TemplateExpression(
+        (; f=ComposableExpression(Node{Float64}(; val=3.0); operators));
+        structure,
+        operators,
+        parameters=(; p=[2.0]),
+    )
+    options = Options(; operators)
+
+    parameters, refs = SymbolicRegression.get_optimizable_parameters(ex, options)
+    @test parameters == [42.0]
+    @test refs isa ContextAwareRefs
+    @test SymbolicRegression.count_optimizable_parameters(ex, options) == 1
+end
+
 @testitem "Generic optimizable hooks are options- and refs-aware" begin
     using SymbolicRegression
 

--- a/test/unit/evolution-core/test_constants_for_optimization.jl
+++ b/test/unit/evolution-core/test_constants_for_optimization.jl
@@ -1,14 +1,16 @@
-@testitem "Optimizable parameter hooks aggregate constants and template parameters" begin
+@testitem "Generic optimizable hooks aggregate constants and template parameters" begin
     using DynamicExpressions
     using SymbolicRegression
 
     operators = OperatorEnum(; unary_operators=(), binary_operators=(+, *))
     variable_names = ["x1"]
+    options = Options(; operators)
 
     expr = parse_expression("x1 + 2.0"; operators, variable_names)
-    flat = SymbolicRegression.get_constants_for_optimization(expr)[1]
+    flat = SymbolicRegression.get_optimizable_parameters(expr, options)[1]
     @test flat == [2.0]
     @test length(flat) == 1
+    @test SymbolicRegression.count_optimizable_parameters(expr, options) == 1
 
     structure = TemplateStructure{(:f,),(:p,)}(
         ((; f), (; p), (x,)) -> f(x) * p[1]; num_parameters=(; p=1)
@@ -21,12 +23,56 @@
         parameters=(; p=[2.0]),
     )
 
-    params, refs = SymbolicRegression.get_constants_for_optimization(template)
+    params, refs = SymbolicRegression.get_optimizable_parameters(template, options)
     @test params == [3.0, 2.0]
     @test length(params) == 2
+    @test SymbolicRegression.count_optimizable_parameters(template, options) == 2
 
-    SymbolicRegression.set_constants_for_optimization!(template, [4.0, 5.0], refs)
-    @test SymbolicRegression.get_constants_for_optimization(template)[1] == [4.0, 5.0]
+    SymbolicRegression.set_optimizable_parameters!(template, [4.0, 5.0], refs)
+    @test SymbolicRegression.get_optimizable_parameters(template, options)[1] == [4.0, 5.0]
+end
+
+@testitem "Generic optimizable hooks are options- and refs-aware" begin
+    using SymbolicRegression
+
+    mutable struct OptimizableBox{T}
+        values::Vector{T}
+    end
+    struct OptimizableBoxRefs
+        indices::Vector{Int}
+    end
+
+    function SymbolicRegression.count_optimizable_parameters(box::OptimizableBox, options)
+        return count(options.active)
+    end
+    function SymbolicRegression.get_optimizable_parameters(box::OptimizableBox, options)
+        refs = OptimizableBoxRefs(findall(options.active))
+        return box.values[refs.indices], refs
+    end
+    function SymbolicRegression.set_optimizable_parameters!(
+        box::OptimizableBox, x, refs::OptimizableBoxRefs
+    )
+        box.values[refs.indices] = x
+        return box
+    end
+    function SymbolicRegression.extract_optimizable_gradient(
+        grad, ::OptimizableBox, refs::OptimizableBoxRefs
+    )
+        return grad[refs.indices]
+    end
+
+    box = OptimizableBox([1.0, 2.0, 3.0])
+    options = (; active=Bool[true, false, true])
+    params, refs = SymbolicRegression.get_optimizable_parameters(box, options)
+
+    @test SymbolicRegression.count_optimizable_parameters(box, options) == 2
+    @test params == [1.0, 3.0]
+    @test refs.indices == [1, 3]
+    @test SymbolicRegression.extract_optimizable_gradient([0.1, 0.2, 0.3], box, refs) ==
+        [0.1, 0.3]
+
+    SymbolicRegression.set_optimizable_parameters!(box, [4.0, 5.0], refs)
+    @test box.values == [4.0, 2.0, 5.0]
 end
 
 @testitem "Default optimize_constants handles custom optimizable expression state" begin
@@ -144,6 +190,18 @@ end
         loss_function_expression=loss,
         parsimony=0.0,
     )
+
+    generic_params, generic_refs = SymbolicRegression.get_optimizable_parameters(
+        wrapped, options
+    )
+    @test generic_params == initial_params
+    @test SymbolicRegression.extract_optimizable_gradient(
+        gradient, wrapped, generic_refs
+    ) == [-0.5, 0.75]
+    SymbolicRegression.set_optimizable_parameters!(wrapped, [1.5, -0.5], generic_refs)
+    @test SymbolicRegression.get_constants_for_optimization(wrapped)[1] == [1.5, -0.5]
+    SymbolicRegression.set_optimizable_parameters!(wrapped, initial_params, generic_refs)
+
     initial_loss = loss(wrapped, dataset, options)
     member = PopMember(wrapped, initial_loss, initial_loss, options, 1; deterministic=true)
 

--- a/test/unit/expressions/test_template_inner_expression_type.jl
+++ b/test/unit/expressions/test_template_inner_expression_type.jl
@@ -11,27 +11,22 @@
     using SymbolicRegression: ComposableExpression
 
     operators = OperatorEnum(; binary_operators=(+,))
-    variable_name_storage = ["x"]
-    variable_names = @view variable_name_storage[:]
-    buffer_storage = zeros(3, 4)
-    buffer_array = @view buffer_storage[1:2, :]
-    eval_options = EvalOptions(; buffer=ArrayBuffer(buffer_array, Ref(0)))
+    variable_names = ["x"]
+    eval_options = EvalOptions(; buffer=ArrayBuffer(zeros(2, 4), Ref(0)))
     expression = ComposableExpression(
         Node{Float64}(; feature=1); operators, variable_names, eval_options
     )
 
     copied = copy(expression)
 
-    @test typeof(copied) === typeof(expression)
     @test get_contents(copied) !== get_contents(expression)
     @test get_metadata(copied).operators === operators
-    @test get_metadata(copied).variable_names === variable_names
+    @test get_metadata(copied).variable_names == variable_names
+    @test get_metadata(copied).variable_names !== variable_names
     @test get_metadata(copied).eval_options !== eval_options
     @test get_metadata(copied).eval_options.buffer !== eval_options.buffer
     @test get_metadata(copied).eval_options.buffer.array !== eval_options.buffer.array
     @test get_metadata(copied).eval_options.buffer.index !== eval_options.buffer.index
-    @test parent(get_metadata(copied).eval_options.buffer.array) !==
-        parent(eval_options.buffer.array)
     get_metadata(copied).eval_options.buffer.array[1, 1] = 1.0
     @test eval_options.buffer.array[1, 1] == 0.0
 
@@ -46,6 +41,10 @@
         eval_options.buffer.index
     get_metadata(buffered_copy).eval_options.buffer.array[1, 2] = 2.0
     @test eval_options.buffer.array[1, 2] == 0.0
+
+    same_shape_copy = copy_into!(preallocated, expression)
+    @test get_metadata(same_shape_copy).eval_options.buffer.array ===
+        get_metadata(buffered_copy).eval_options.buffer.array
 
     source_buffer = fill(3.0, 3, 4)
     source_eval_options = EvalOptions(;
@@ -111,7 +110,7 @@ end
         metadata = get_metadata(ex)
         variable_names = metadata.variable_names
         eval_options = metadata.eval_options
-        copied_eval_options = isnothing(eval_options) ? nothing : deepcopy(eval_options)
+        copied_eval_options = isnothing(eval_options) ? nothing : copy(eval_options)
         return WrappedExpression(
             copy(get_contents(ex));
             operators=metadata.operators,

--- a/test/unit/expressions/test_template_inner_expression_type.jl
+++ b/test/unit/expressions/test_template_inner_expression_type.jl
@@ -53,3 +53,93 @@
     @test created_inner isa WrappedExpression
     @test get_metadata(created_inner).tag == :custom_inner
 end
+
+@testitem "TemplateExpressionSpec initializes template parameters" begin
+    using Random: AbstractRNG
+    using DynamicExpressions: Node, OperatorEnum, get_metadata
+    using SymbolicRegression
+    using SymbolicRegression: ParamVector
+    using SymbolicRegression.ExpressionBuilderModule: create_expression, strip_metadata
+
+    operators = OperatorEnum(; binary_operators=(+,))
+    structure = TemplateStructure{(:f,),(:weights, :bias)}(
+        ((; f), (; weights, bias), (x,)) -> f(x) + weights[1] + bias[1];
+        num_features=(; f=1),
+        num_parameters=(; weights=2, bias=1),
+    )
+    initializer_calls = Ref(0)
+    parameter_initializer = function (rng, T, num_parameters)
+        @test rng isa AbstractRNG
+        @test T === Float32
+        @test num_parameters == (; weights=2, bias=1)
+        initializer_calls[] += 1
+        return (; bias=T[-1], weights=T[2, 3])
+    end
+    spec = TemplateExpressionSpec(; structure, parameter_initializer)
+    @test spec.parameter_initializer === parameter_initializer
+    dataset = Dataset(randn(Float32, 1, 8), randn(Float32, 8))
+    options = Options(; operators, expression_spec=spec, tournament_selection_n=5)
+
+    created = create_expression(Node{Float32}(; val=0.0f0), options, dataset)
+    created_parameters = get_metadata(created).parameters
+    @test initializer_calls[] == 1
+    @test created_parameters.weights isa ParamVector{Float32}
+    @test created_parameters.bias isa ParamVector{Float32}
+    @test collect(created_parameters.weights) == Float32[2, 3]
+    @test collect(created_parameters.bias) == Float32[-1]
+
+    copied = strip_metadata(created, options, dataset)
+    copied_parameters = get_metadata(copied).parameters
+    @test initializer_calls[] == 1
+    @test copied_parameters == created_parameters
+    @test copied_parameters.weights !== created_parameters.weights
+    @test copied_parameters.bias !== created_parameters.bias
+
+    default_spec = TemplateExpressionSpec(structure)
+    @test default_spec.parameter_initializer === nothing
+    default_options = Options(;
+        operators, expression_spec=default_spec, tournament_selection_n=5
+    )
+    default_created = create_expression(
+        Node{Float32}(; val=0.0f0), default_options, dataset
+    )
+    default_parameters = get_metadata(default_created).parameters
+    @test default_parameters.weights isa ParamVector{Float32}
+    @test default_parameters.bias isa ParamVector{Float32}
+    @test length(default_parameters.weights) == 2
+    @test length(default_parameters.bias) == 1
+end
+
+@testitem "TemplateExpressionSpec validates initialized template parameters" begin
+    using DynamicExpressions: Node, OperatorEnum
+    using SymbolicRegression
+    using SymbolicRegression.ExpressionBuilderModule: create_expression
+
+    operators = OperatorEnum(; binary_operators=(+,))
+    structure = TemplateStructure{(:f,),(:weights, :bias)}(
+        ((; f), (; weights, bias), (x,)) -> f(x) + weights[1] + bias[1];
+        num_features=(; f=1),
+        num_parameters=(; weights=2, bias=1),
+    )
+    dataset = Dataset(randn(Float32, 1, 8), randn(Float32, 8))
+
+    wrong_keys = TemplateExpressionSpec(;
+        structure, parameter_initializer=(_, T, _) -> (; weights=T[2, 3], offset=T[-1])
+    )
+    wrong_keys_options = Options(;
+        operators, expression_spec=wrong_keys, tournament_selection_n=5
+    )
+    @test_throws ArgumentError create_expression(
+        Node{Float32}(; val=0.0f0), wrong_keys_options, dataset
+    )
+
+    wrong_length = TemplateExpressionSpec(;
+        structure, parameter_initializer=(_, T, _) -> (; weights=T[2], bias=T[-1])
+    )
+    wrong_length_options = Options(;
+        operators, expression_spec=wrong_length, tournament_selection_n=5
+    )
+    @test_throws DimensionMismatch create_expression(
+        Node{Float32}(; val=0.0f0), wrong_length_options, dataset
+    )
+end

--- a/test/unit/expressions/test_template_inner_expression_type.jl
+++ b/test/unit/expressions/test_template_inner_expression_type.jl
@@ -1,3 +1,73 @@
+@testitem "ComposableExpression copy preserves metadata types and buffer isolation" begin
+    using DynamicExpressions:
+        ArrayBuffer,
+        EvalOptions,
+        Node,
+        OperatorEnum,
+        allocate_container,
+        copy_into!,
+        get_contents,
+        get_metadata
+    using SymbolicRegression: ComposableExpression
+
+    operators = OperatorEnum(; binary_operators=(+,))
+    variable_name_storage = ["x"]
+    variable_names = @view variable_name_storage[:]
+    buffer_storage = zeros(3, 4)
+    buffer_array = @view buffer_storage[1:2, :]
+    eval_options = EvalOptions(; buffer=ArrayBuffer(buffer_array, Ref(0)))
+    expression = ComposableExpression(
+        Node{Float64}(; feature=1); operators, variable_names, eval_options
+    )
+
+    copied = copy(expression)
+
+    @test typeof(copied) === typeof(expression)
+    @test get_contents(copied) !== get_contents(expression)
+    @test get_metadata(copied).operators === operators
+    @test get_metadata(copied).variable_names === variable_names
+    @test get_metadata(copied).eval_options !== eval_options
+    @test get_metadata(copied).eval_options.buffer !== eval_options.buffer
+    @test get_metadata(copied).eval_options.buffer.array !== eval_options.buffer.array
+    @test get_metadata(copied).eval_options.buffer.index !== eval_options.buffer.index
+    @test parent(get_metadata(copied).eval_options.buffer.array) !==
+        parent(eval_options.buffer.array)
+    get_metadata(copied).eval_options.buffer.array[1, 1] = 1.0
+    @test eval_options.buffer.array[1, 1] == 0.0
+
+    preallocated = allocate_container(expression)
+    buffered_copy = copy_into!(preallocated, expression)
+    @test get_contents(buffered_copy) !== get_contents(expression)
+    @test get_metadata(buffered_copy).eval_options !== eval_options
+    @test get_metadata(buffered_copy).eval_options.buffer !== eval_options.buffer
+    @test get_metadata(buffered_copy).eval_options.buffer.array !==
+        eval_options.buffer.array
+    @test get_metadata(buffered_copy).eval_options.buffer.index !==
+        eval_options.buffer.index
+    get_metadata(buffered_copy).eval_options.buffer.array[1, 2] = 2.0
+    @test eval_options.buffer.array[1, 2] == 0.0
+
+    source_buffer = fill(3.0, 3, 4)
+    source_eval_options = EvalOptions(;
+        early_exit=false, buffer=ArrayBuffer(source_buffer, Ref(2))
+    )
+    source = ComposableExpression(
+        Node{Float64}(; feature=1);
+        operators,
+        variable_names,
+        eval_options=source_eval_options,
+    )
+    adapted_copy = copy_into!(preallocated, source)
+    adapted_eval_options = get_metadata(adapted_copy).eval_options
+    @test adapted_eval_options.early_exit isa Val{false}
+    @test adapted_eval_options.buffer.array == source_buffer
+    @test adapted_eval_options.buffer.index[] == 2
+    @test adapted_eval_options !== source_eval_options
+    @test adapted_eval_options.buffer !== source_eval_options.buffer
+    @test adapted_eval_options.buffer.array !== source_eval_options.buffer.array
+    @test adapted_eval_options.buffer.index !== source_eval_options.buffer.index
+end
+
 @testitem "TemplateExpressionSpec supports custom inner expression types" begin
     using DynamicExpressions:
         DynamicExpressions,
@@ -9,9 +79,11 @@
         OperatorEnum,
         get_contents,
         get_metadata
+    using Random: AbstractRNG, MersenneTwister
     using SymbolicRegression
     using SymbolicRegression: AbstractComposableExpression
     using SymbolicRegression.ExpressionBuilderModule: create_expression
+    using SymbolicRegression.MutationFunctionsModule: crossover_trees
 
     struct WrappedExpression{T,N<:AbstractExpressionNode{T},D} <:
            AbstractComposableExpression{T,N}
@@ -25,13 +97,41 @@
         variable_names::Union{AbstractVector{<:AbstractString},Nothing}=nothing,
         eval_options::Union{EvalOptions,Nothing}=nothing,
         tag::Symbol=:wrapped,
+        local_parameter::Vector{T}=T[0],
     ) where {T}
         return WrappedExpression(
-            tree, Metadata((; operators, variable_names, eval_options, tag))
+            tree,
+            Metadata((; operators, variable_names, eval_options, tag, local_parameter)),
         )
     end
 
     DynamicExpressions.constructorof(::Type{<:WrappedExpression}) = WrappedExpression
+    local_parameter(ex::WrappedExpression) = only(get_metadata(ex).local_parameter)
+    function Base.copy(ex::WrappedExpression)
+        metadata = get_metadata(ex)
+        variable_names = metadata.variable_names
+        eval_options = metadata.eval_options
+        copied_eval_options = isnothing(eval_options) ? nothing : deepcopy(eval_options)
+        return WrappedExpression(
+            copy(get_contents(ex));
+            operators=metadata.operators,
+            variable_names,
+            eval_options=copied_eval_options,
+            tag=metadata.tag,
+            local_parameter=copy(metadata.local_parameter),
+        )
+    end
+    crossover_calls = Ref(0)
+    function SymbolicRegression.MutationFunctionsModule.crossover_trees(
+        ex1::WrappedExpression{T}, ex2::WrappedExpression{T}, rng::AbstractRNG
+    ) where {T}
+        crossover_calls[] += 1
+        tree1, tree2 = crossover_trees(get_contents(ex1), get_contents(ex2), rng)
+        return (
+            DynamicExpressions.with_contents(ex1, tree1),
+            DynamicExpressions.with_contents(ex2, tree2),
+        )
+    end
 
     operators = OperatorEnum(; unary_operators=(cos,), binary_operators=(+,))
     structure = TemplateStructure{(:f,)}(((; f), (x,)) -> f(x); num_features=(; f=1))
@@ -45,6 +145,91 @@
     parsed_inner = first(values(get_contents(parsed)))
     @test parsed_inner isa WrappedExpression
     @test get_metadata(parsed_inner).tag == :custom_inner
+
+    copied_inner = copy(parsed_inner)
+    @test copied_inner isa WrappedExpression
+    @test typeof(copied_inner) === typeof(parsed_inner)
+    @test get_metadata(copied_inner).tag == :custom_inner
+    @test get_contents(copied_inner) !== get_contents(parsed_inner)
+    get_metadata(parsed_inner).local_parameter[1] = 3.0
+    get_metadata(copied_inner).local_parameter[1] = 9.0
+    @test local_parameter(parsed_inner) == 3.0
+
+    copied = copy(parsed)
+    @test typeof(copied) === typeof(parsed)
+    copied_template_inner = first(values(get_contents(copied)))
+    @test copied_template_inner isa WrappedExpression
+    @test typeof(copied_template_inner) === typeof(parsed_inner)
+    @test get_metadata(copied_template_inner).tag == :custom_inner
+    @test get_contents(copied_template_inner) !== get_contents(parsed_inner)
+
+    parent1 = parse_expression((; f="1.0"); expression_spec=spec, operators)
+    parent2 = parse_expression((; f="2.0"); expression_spec=spec, operators)
+    parent_inners = map(parent -> first(values(get_contents(parent))), (parent1, parent2))
+    get_metadata(parent_inners[1]).local_parameter[1] = 11.0
+    get_metadata(parent_inners[2]).local_parameter[1] = 22.0
+    crossover_calls[] = 0
+    child1, child2 = crossover_trees(parent1, parent2, MersenneTwister(0))
+    child_inners = map(child -> first(values(get_contents(child))), (child1, child2))
+    @test typeof(child1) === typeof(parent1)
+    @test typeof(child2) === typeof(parent2)
+    @test crossover_calls[] == 1
+    @test all(inner -> inner isa WrappedExpression, child_inners)
+    @test map(typeof, child_inners) == map(typeof, parent_inners)
+    @test all(inner -> get_metadata(inner).tag == :custom_inner, child_inners)
+    @test map(local_parameter, child_inners) == (11.0, 22.0)
+    @test get_metadata(child_inners[1]).local_parameter !==
+        get_metadata(parent_inners[1]).local_parameter
+    @test get_metadata(child_inners[2]).local_parameter !==
+        get_metadata(parent_inners[2]).local_parameter
+    @test get_contents(child_inners[1]).val == 2.0
+    @test get_contents(child_inners[2]).val == 1.0
+    for child_inner in child_inners, parent_inner in parent_inners
+        @test get_contents(child_inner) !== get_contents(parent_inner)
+    end
+    @test get_contents(child_inners[1]) !== get_contents(child_inners[2])
+    get_metadata(child_inners[1]).local_parameter[1] = 111.0
+    get_metadata(child_inners[2]).local_parameter[1] = 222.0
+    @test map(local_parameter, parent_inners) == (11.0, 22.0)
+
+    two_structure = TemplateStructure{(:f, :g)}(
+        ((; f, g), (x,)) -> f(x) + g(x); num_features=(; f=1, g=1)
+    )
+    two_spec = TemplateExpressionSpec(;
+        structure=two_structure,
+        inner_expression_type=WrappedExpression,
+        inner_expression_options=(; tag=:custom_inner),
+    )
+    two_parent1 = parse_expression(
+        (; f="1.0", g="3.0"); expression_spec=two_spec, operators
+    )
+    two_parent2 = parse_expression(
+        (; f="2.0", g="4.0"); expression_spec=two_spec, operators
+    )
+    two_parents = (two_parent1, two_parent2)
+    for (parent_index, parent) in enumerate(two_parents)
+        for (inner_index, inner) in enumerate(values(get_contents(parent)))
+            get_metadata(inner).local_parameter[1] = 10 * parent_index + inner_index
+        end
+    end
+    crossover_calls[] = 0
+    two_child1, two_child2 = crossover_trees(two_parent1, two_parent2, MersenneTwister(3))
+    two_children = (two_child1, two_child2)
+    @test crossover_calls[] == 1
+    for child in two_children
+        for child_inner in values(get_contents(child))
+            for parent in two_parents, parent_inner in values(get_contents(parent))
+                @test get_metadata(child_inner).local_parameter !==
+                    get_metadata(parent_inner).local_parameter
+            end
+        end
+    end
+    for inner1 in values(get_contents(two_child1))
+        for inner2 in values(get_contents(two_child2))
+            @test get_metadata(inner1).local_parameter !==
+                get_metadata(inner2).local_parameter
+        end
+    end
 
     dataset = Dataset(randn(Float32, 1, 8), randn(Float32, 8))
     options = Options(; operators, expression_spec=spec, tournament_selection_n=5)

--- a/test/unit/templates/test_template_expression_mutation.jl
+++ b/test/unit/templates/test_template_expression_mutation.jl
@@ -191,15 +191,11 @@ end
         binary_operators=(+, *), expression_spec=TemplateExpressionSpec(; structure)
     )
     operators = options.operators
-    variable_name_storage = ["x"]
-    variable_names = @view variable_name_storage[:]
+    variable_names = ["x"]
 
     function make_parent(f_value, g_value, parameters)
         function make_inner(value)
-            buffer_storage = zeros(3, 4)
-            eval_options = EvalOptions(;
-                buffer=ArrayBuffer(@view(buffer_storage[1:2, :]), Ref(0))
-            )
+            eval_options = EvalOptions(; buffer=ArrayBuffer(zeros(2, 4), Ref(0)))
             return ComposableExpression(
                 Node{Float64}(;
                     op=1, l=Node{Float64}(; val=value), r=Node{Float64}(; feature=1)
@@ -268,14 +264,12 @@ end
         for buffer in buffers, original_buffer in original_buffers
             @test buffer !== original_buffer
             @test buffer.array !== original_buffer.array
-            @test parent(buffer.array) !== parent(original_buffer.array)
             @test buffer.index !== original_buffer.index
         end
     end
     for buffer1 in child_buffers[1], buffer2 in child_buffers[2]
         @test buffer1 !== buffer2
         @test buffer1.array !== buffer2.array
-        @test parent(buffer1.array) !== parent(buffer2.array)
         @test buffer1.index !== buffer2.index
     end
     child_buffers[1][1].array[1, 1] = 1.0

--- a/test/unit/templates/test_template_expression_mutation.jl
+++ b/test/unit/templates/test_template_expression_mutation.jl
@@ -106,3 +106,221 @@
     @test only(weight for (mutation, weight) in weights if mutation isa SimplifyMutation) ==
         0.0
 end
+
+@testitem "template crossover isolates shared graph nodes" begin
+    using DynamicExpressions: get_child, get_contents
+    using Random: MersenneTwister
+    using SymbolicRegression
+    using SymbolicRegression.MutationFunctionsModule:
+        crossover_trees, get_contents_for_mutation
+
+    options = Options(; binary_operators=(+, *), node_type=GraphNode)
+    operators = options.operators
+    variable_names = ["x1", "x2"]
+    structure = TemplateStructure{(:f, :g)}(
+        ((; f, g), (x1, x2)) -> f(x1, x2) + g(x1, x2); num_features=(; f=2, g=2)
+    )
+
+    function make_parent(value, feature)
+        function make_inner(offset)
+            shared = GraphNode{Float64}(;
+                op=1,
+                children=(
+                    GraphNode{Float64}(; val=value + offset),
+                    GraphNode{Float64}(; feature=feature),
+                ),
+            )
+            tree = GraphNode{Float64}(; op=2, children=(shared, shared))
+            return ComposableExpression(tree; operators, variable_names)
+        end
+        return TemplateExpression(
+            (; f=make_inner(0.0), g=make_inner(10.0)); structure, operators, variable_names
+        )
+    end
+
+    function inner_nodes(ex)
+        nodes = Any[]
+        for inner in values(get_contents(ex))
+            foreach(node -> push!(nodes, node), get_contents(inner))
+        end
+        return nodes
+    end
+
+    parent1 = make_parent(1.0, 1)
+    parent2 = make_parent(2.0, 2)
+    for parent in (parent1, parent2), inner in values(get_contents(parent))
+        tree = get_contents(inner)
+        @test get_child(tree, 1) === get_child(tree, 2)
+    end
+
+    parent_nodes = (inner_nodes(parent1), inner_nodes(parent2))
+    for seed in 0:25
+        context_rng = MersenneTwister(seed)
+        _, context1 = get_contents_for_mutation(parent1, context_rng)
+        _, context2 = get_contents_for_mutation(parent2, context_rng)
+        child1, child2 = crossover_trees(parent1, parent2, MersenneTwister(seed))
+        child_nodes = (inner_nodes(child1), inner_nodes(child2))
+        @test all(
+            child_node !== parent_node for nodes in child_nodes for
+            original_nodes in parent_nodes for child_node in nodes for
+            parent_node in original_nodes
+        )
+        @test all(a !== b for a in child_nodes[1] for b in child_nodes[2])
+        for (child, selected_context) in zip((child1, child2), (context1, context2))
+            for key in keys(get_contents(child))
+                if key != selected_context
+                    tree = get_contents(get_contents(child)[key])
+                    @test get_child(tree, 1) === get_child(tree, 2)
+                end
+            end
+        end
+    end
+end
+
+@testitem "template crossover isolates recipient candidate state" begin
+    using DynamicExpressions: ArrayBuffer, EvalOptions, get_contents, get_metadata
+    using Random: MersenneTwister
+    using SymbolicRegression
+    using SymbolicRegression.MutateModule: crossover_generation
+    using SymbolicRegression.MutationFunctionsModule: crossover_trees
+
+    structure = TemplateStructure{(:f, :g),(:p,)}(
+        ((; f, g), (; p), (x,)) -> f(x) + g(x) * p[1]; num_parameters=(; p=2)
+    )
+    options = Options(;
+        binary_operators=(+, *), expression_spec=TemplateExpressionSpec(; structure)
+    )
+    operators = options.operators
+    variable_name_storage = ["x"]
+    variable_names = @view variable_name_storage[:]
+
+    function make_parent(f_value, g_value, parameters)
+        function make_inner(value)
+            buffer_storage = zeros(3, 4)
+            eval_options = EvalOptions(;
+                buffer=ArrayBuffer(@view(buffer_storage[1:2, :]), Ref(0))
+            )
+            return ComposableExpression(
+                Node{Float64}(;
+                    op=1, l=Node{Float64}(; val=value), r=Node{Float64}(; feature=1)
+                );
+                operators,
+                variable_names,
+                eval_options,
+            )
+        end
+        return TemplateExpression(
+            (; f=make_inner(f_value), g=make_inner(g_value));
+            structure,
+            operators,
+            variable_names,
+            parameters=(; p=parameters),
+        )
+    end
+
+    function inner_nodes(ex)
+        nodes = Any[]
+        for inner in values(get_contents(ex))
+            foreach(node -> push!(nodes, node), get_contents(inner))
+        end
+        return nodes
+    end
+
+    parent1 = make_parent(1.0, 2.0, [3.0, 4.0])
+    parent2 = make_parent(5.0, 6.0, [7.0, 8.0])
+    copied_parent1 = copy(parent1)
+    @test typeof(copied_parent1) === typeof(parent1)
+    parent1_values = copy(
+        first(SymbolicRegression.get_optimizable_parameters(parent1, options))
+    )
+    parent2_values = copy(
+        first(SymbolicRegression.get_optimizable_parameters(parent2, options))
+    )
+
+    child1, child2 = crossover_trees(parent1, parent2, MersenneTwister(3))
+
+    @test typeof(child1) === typeof(parent1)
+    @test typeof(child2) === typeof(parent2)
+    @test get_metadata(child1).parameters == get_metadata(parent1).parameters
+    @test get_metadata(child2).parameters == get_metadata(parent2).parameters
+    @test get_metadata(child1).parameters.p._data !==
+        get_metadata(parent1).parameters.p._data
+    @test get_metadata(child2).parameters.p._data !==
+        get_metadata(parent2).parameters.p._data
+    @test get_metadata(child1).parameters.p._data !==
+        get_metadata(child2).parameters.p._data
+
+    parent_buffers = map(
+        parent -> map(
+            inner -> get_metadata(inner).eval_options.buffer,
+            values(get_contents(parent)),
+        ),
+        (parent1, parent2),
+    )
+    child_buffers = map(
+        child -> map(
+            inner -> get_metadata(inner).eval_options.buffer,
+            values(get_contents(child)),
+        ),
+        (child1, child2),
+    )
+    for buffers in child_buffers, original_buffers in parent_buffers
+        for buffer in buffers, original_buffer in original_buffers
+            @test buffer !== original_buffer
+            @test buffer.array !== original_buffer.array
+            @test parent(buffer.array) !== parent(original_buffer.array)
+            @test buffer.index !== original_buffer.index
+        end
+    end
+    for buffer1 in child_buffers[1], buffer2 in child_buffers[2]
+        @test buffer1 !== buffer2
+        @test buffer1.array !== buffer2.array
+        @test parent(buffer1.array) !== parent(buffer2.array)
+        @test buffer1.index !== buffer2.index
+    end
+    child_buffers[1][1].array[1, 1] = 1.0
+    @test all(buffer.array[1, 1] == 0.0 for buffers in parent_buffers for buffer in buffers)
+
+    parent_nodes = (inner_nodes(parent1), inner_nodes(parent2))
+    child_nodes = (inner_nodes(child1), inner_nodes(child2))
+    for nodes in child_nodes, original_nodes in parent_nodes
+        for node in nodes, original_node in original_nodes
+            @test node !== original_node
+        end
+    end
+    for node1 in child_nodes[1], node2 in child_nodes[2]
+        @test node1 !== node2
+    end
+
+    for (child, offset) in zip((child1, child2), (10.0, 20.0))
+        child_values, child_refs = SymbolicRegression.get_optimizable_parameters(
+            child, options
+        )
+        SymbolicRegression.set_optimizable_parameters!(
+            child, child_values .+ offset, child_refs
+        )
+
+        @test first(SymbolicRegression.get_optimizable_parameters(child, options)) ==
+            child_values .+ offset
+        @test first(SymbolicRegression.get_optimizable_parameters(parent1, options)) ==
+            parent1_values
+        @test first(SymbolicRegression.get_optimizable_parameters(parent2, options)) ==
+            parent2_values
+    end
+
+    dataset = Dataset(zeros(Float64, 1, 4), zeros(Float64, 4))
+    complexity1 = compute_complexity(parent1, options)
+    complexity2 = compute_complexity(parent2, options)
+    member1 = PopMember(
+        parent1, 0.0, 0.0, options, complexity1; deterministic=options.deterministic
+    )
+    member2 = PopMember(
+        parent2, 0.0, 0.0, options, complexity2; deterministic=options.deterministic
+    )
+    baby1, baby2, accepted, _ = crossover_generation(
+        member1, member2, dataset, 100, options
+    )
+    @test accepted
+    @test typeof(baby1) === typeof(member1)
+    @test typeof(baby2) === typeof(member2)
+end


### PR DESCRIPTION
## Summary

This PR replaces #619 with a template-owned optimizable-parameter interface and builds on #645.

## Changes

- Add custom parameter initialization for template expressions.
- Add `get_optimizable_parameters`, `set_optimizable_parameters!`, and `extract_optimizable_gradient` hooks with access to options and an opaque reference object.
- Keep the previous constant-optimization hooks as compatibility fallbacks for existing expression integrations.
- Use DynamicExpressions scalar counts for structural counting and remove the duplicate optimization-specific count hook.
- Route template parameter selection through the template combiner so custom integrations can select their own parameter subsets.
- Isolate each optimization candidate before applying selected parameters.
- Validate parameter and gradient lengths before assignment.
- Add regression coverage for template parameters, custom selection, mutation, copying, and inner expression types.

## API contract

The reference object returned by `get_optimizable_parameters` is opaque. It belongs to the expression state and parameter vector returned by that call. Getter, setter, and gradient extraction implementations must preserve the same parameter order.

## Validation

- `unit/expressions`: 182 assertions
- `unit/templates`: 416 assertions
- `unit/evolution-core`: 1166 assertions
- `unit/operators-core`: 28 assertions
- `integration/ad/mooncake`: 13 assertions
- `integration/ext/mlj/templates`: 36 assertions
- LearnableOperators downstream suite: 155 assertions

Supersedes #619.
