### PR TITLE
fix: finalize logging after all search outputs complete

### DIFF
--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -21,9 +21,10 @@ Abstract type for symbolic regression loggers. Subtypes must implement:
 
 - `get_logger(logger)`: Return the underlying logger
 - `logging_callback!(logger; kws...)`: Callback function for logging.
-    Called with the current state, datasets, runtime options, and options. If you wish to
-    reduce the logging frequency, you can increment and monitor a counter within this
-    function.
+    Called once after each completed search cycle, including the globally terminal
+    cycle, with the current state, datasets, runtime options, and options. If you wish
+    to reduce the logging frequency, you can increment and monitor a counter within
+    this function.
 """
 abstract type AbstractSRLogger <: AbstractLogger end
 
@@ -34,7 +35,9 @@ A logger for symbolic regression that wraps another logger.
 
 # Arguments
 - `logger`: The base logger to wrap
-- `log_interval`: Number of steps between logging events. Default is 100 (log every 100 steps).
+- `log_interval`: Number of steps between intermediate logging events. Default is 100.
+    Positive intervals always emit the normally completed terminal state, even when it
+    does not align with the interval. Nonpositive intervals disable logging.
 """
 Base.@kwdef struct SRLogger{L<:AbstractLogger} <: AbstractSRLogger
     logger::L
@@ -63,6 +66,9 @@ end
 
 Default logging callback for SymbolicRegression.
 
+For positive `log_interval` values, the normally completed terminal state is always
+logged exactly once. Nonpositive intervals disable logging.
+
 To override the default logging behavior, create a new type `MyLogger <: AbstractSRLogger`
 and define a method for `SymbolicRegression.logging_callback`.
 """
@@ -73,7 +79,8 @@ function logging_callback!(
     @nospecialize(ropt::AbstractRuntimeOptions),
     @nospecialize(options::AbstractOptions),
 ) where {T,L}
-    if should_log(logger)
+    is_terminal = all(iszero, state.cycles_remaining)
+    if should_log(logger) || (logger.log_interval > 0 && is_terminal)
         data = log_payload(logger, state, datasets, options)
         LG.with_logger(logger) do
             @info("search", data = data)

--- a/src/SymbolicRegression.jl
+++ b/src/SymbolicRegression.jl
@@ -1149,67 +1149,68 @@ function _main_search_loop!(
             ###################################################################
 
             state.cycles_remaining[j] -= 1
-            if state.cycles_remaining[j] == 0
-                break
-            end
-            worker_idx = assign_next_worker!(
-                state.worker_assignment;
-                out=j,
-                pop=i,
-                parallelism=ropt.parallelism,
-                state.procs,
-            )
-            iteration = if options.use_recorder isa Val{true}
-                key = "out$(j)_pop$(i)"
-                find_iteration_from_record(key, state.record[]) + 1
-            else
-                0
-            end
+            if state.cycles_remaining[j] > 0
+                worker_idx = assign_next_worker!(
+                    state.worker_assignment;
+                    out=j,
+                    pop=i,
+                    parallelism=ropt.parallelism,
+                    state.procs,
+                )
+                iteration = if options.use_recorder isa Val{true}
+                    key = "out$(j)_pop$(i)"
+                    find_iteration_from_record(key, state.record[]) + 1
+                else
+                    0
+                end
 
-            in_pop = copy(cur_pop::Population{T,L,N})
-            worker_plugin_states = strictmap(
-                options.plugins, returned_plugin_states, state.plugin_states[j]
-            ) do plugin, worker_state, latest_head_state
-                refresh_worker_plugin_state(worker_state, latest_head_state, plugin, dataset)
-            end
-            state.worker_output[j][i] = @sr_spawner(
-                begin
-                    _dispatch_s_r_cycle(
-                        in_pop,
-                        dataset,
-                        options;
-                        pop=i,
-                        out=j,
-                        iteration,
-                        ropt.verbosity,
-                        cur_maxsize,
-                        plugin_states=worker_plugin_states,
+                in_pop = copy(cur_pop::Population{T,L,N})
+                worker_plugin_states = strictmap(
+                    options.plugins, returned_plugin_states, state.plugin_states[j]
+                ) do plugin, worker_state, latest_head_state
+                    refresh_worker_plugin_state(
+                        worker_state, latest_head_state, plugin, dataset
                     )
-                end,
-                parallelism = ropt.parallelism,
-                worker_idx = worker_idx
-            )
-            if ropt.parallelism in (:multiprocessing, :multithreading)
-                state.tasks[j][i] = @filtered_async put!(
-                    state.channels[j][i], fetch(state.worker_output[j][i])
+                end
+                state.worker_output[j][i] = @sr_spawner(
+                    begin
+                        _dispatch_s_r_cycle(
+                            in_pop,
+                            dataset,
+                            options;
+                            pop=i,
+                            out=j,
+                            iteration,
+                            ropt.verbosity,
+                            cur_maxsize,
+                            plugin_states=worker_plugin_states,
+                        )
+                    end,
+                    parallelism = ropt.parallelism,
+                    worker_idx = worker_idx
                 )
-            end
+                if ropt.parallelism in (:multiprocessing, :multithreading)
+                    state.tasks[j][i] = @filtered_async put!(
+                        state.channels[j][i], fetch(state.worker_output[j][i])
+                    )
+                end
 
-            total_cycles = ropt.niterations * options.populations
-            state.cur_maxsizes[j] = get_cur_maxsize(;
-                options, total_cycles, cycles_remaining=state.cycles_remaining[j]
-            )
-            if !isnothing(progress_bar)
-                head_node_occupation = estimate_work_fraction(resource_monitor)
-                update_progress_bar!(
-                    progress_bar,
-                    only(state.halls_of_fame),
-                    only(datasets),
-                    options,
-                    equation_speed,
-                    head_node_occupation,
-                    ropt.parallelism,
+                total_cycles = ropt.niterations * options.populations
+                state.cur_maxsizes[j] = get_cur_maxsize(;
+                    options, total_cycles, cycles_remaining=state.cycles_remaining[j]
                 )
+                if !isnothing(progress_bar)
+                    head_node_occupation = estimate_work_fraction(resource_monitor)
+                    update_progress_bar!(
+                        progress_bar,
+                        only(state.halls_of_fame),
+                        only(datasets),
+                        options,
+                        equation_speed,
+                        head_node_occupation,
+                        ropt.parallelism,
+                    )
+                end
             end
             if ropt.logger !== nothing
                 logging_callback!(ropt.logger; state, datasets, ropt, options)

--- a/test/integration/ext/mlj/core/test_logging.jl
+++ b/test/integration/ext/mlj/core/test_logging.jl
@@ -36,7 +36,8 @@
 
     # Check TensorBoardLogger
     b = TensorBoardLogger.steps(tb_logger)
-    @test length(b) == (niterations * populations//2) + 1
+    # Interval-selected records, the forced terminal record, and TensorBoard metadata:
+    @test length(b) == (niterations * populations ÷ 2) + 2
     files_and_dirs = readdir(dir)
     @test length(files_and_dirs) == 1
     @test occursin(r"events\.out\.tfevents", only(files_and_dirs))

--- a/test/unit/basic/test_logging.jl
+++ b/test/unit/basic/test_logging.jl
@@ -1,0 +1,96 @@
+@testitem "Logger receives terminal search state" begin
+    using SymbolicRegression
+
+    mutable struct CapturingLogger <: SymbolicRegression.AbstractSRLogger
+        cycles_remaining::Vector{Vector{Int}}
+    end
+
+    function SymbolicRegression.logging_callback!(logger::CapturingLogger; state, kws...)
+        push!(logger.cycles_remaining, copy(state.cycles_remaining))
+        return nothing
+    end
+
+    X = reshape(Float32.(1:8), 1, :)
+    y = @. X[1, :]^2
+    options = Options(;
+        binary_operators=(+, *),
+        populations=1,
+        population_size=5,
+        ncycles_per_iteration=1,
+        tournament_selection_n=2,
+        maxsize=5,
+        should_optimize_constants=false,
+        deterministic=true,
+        seed=0,
+        verbosity=0,
+        progress=false,
+    )
+    logger = CapturingLogger(Vector{Int}[])
+
+    equation_search(X, y; niterations=1, options, parallelism=:serial, logger)
+
+    @test logger.cycles_remaining == [[0]]
+
+    multi_output_logger = CapturingLogger(Vector{Int}[])
+    multi_output_y = vcat(reshape((@. X[1, :]^2), 1, :), reshape((@. X[1, :]^3), 1, :))
+
+    equation_search(
+        X,
+        multi_output_y;
+        niterations=1,
+        options,
+        parallelism=:serial,
+        logger=multi_output_logger,
+    )
+
+    @test length(multi_output_logger.cycles_remaining) == 2
+    @test sum(first(multi_output_logger.cycles_remaining)) == 1
+    @test last(multi_output_logger.cycles_remaining) == [0, 0]
+    @test count(all ∘ iszero, multi_output_logger.cycles_remaining) == 1
+end
+
+@testitem "SRLogger always emits normal terminal state" begin
+    using Logging: SimpleLogger
+    using SymbolicRegression
+
+    function count_search_records(io)
+        return length(collect(eachmatch(r"search\s*\n\s*│\s*data\s*=", String(take!(io)))))
+    end
+
+    X = reshape(Float32.(1:8), 1, :)
+    y = @. X[1, :]^2
+    options = Options(;
+        binary_operators=(+, *),
+        populations=1,
+        population_size=5,
+        ncycles_per_iteration=1,
+        tournament_selection_n=2,
+        maxsize=5,
+        should_optimize_constants=false,
+        deterministic=true,
+        seed=0,
+        verbosity=0,
+        progress=false,
+    )
+
+    unaligned_io = IOBuffer()
+    unaligned_logger = SRLogger(; logger=SimpleLogger(unaligned_io), log_interval=100)
+    equation_search(
+        X, y; niterations=2, options, parallelism=:serial, logger=unaligned_logger
+    )
+    @test count_search_records(unaligned_io) == 2
+
+    aligned_io = IOBuffer()
+    aligned_logger = SRLogger(; logger=SimpleLogger(aligned_io), log_interval=2)
+    equation_search(
+        X, y; niterations=3, options, parallelism=:serial, logger=aligned_logger
+    )
+    @test count_search_records(aligned_io) == 2
+
+    disabled_io = IOBuffer()
+    disabled_logger = SRLogger(; logger=SimpleLogger(disabled_io), log_interval=0)
+    equation_search(
+        X, y; niterations=1, options, parallelism=:serial, logger=disabled_logger
+    )
+    @test count_search_records(disabled_io) == 0
+end


### PR DESCRIPTION
## Summary

- Continue processing remaining outputs when one output reaches its final cycle.
- Invoke `logging_callback!` after every completed cycle, including the terminal cycle.
- Emit the default logger's terminal event exactly once after all outputs finish.
- Add regression coverage for terminal callbacks and multi-output searches.

## Root cause

The search loop used `break` when the current output reached zero remaining cycles. In a multi-output search, that exited the shared loop as soon as one output completed and could leave other outputs unfinished. The callback also ran only on the nonterminal path, so loggers could miss the final state.

The loop now skips rescheduling completed outputs while continuing to process the others. Logging runs after each completed cycle, and the default logger identifies the global terminal state from all outputs.

## Validation

- `unit/basic`: 1494 assertions
- `unit/parallel`: 13 assertions
- Multi-output multithreading probe observed one intermediate state and one terminal state
