### PR TITLE
ci: benchmark PRs with their own scripts

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           julia-version: "1"
           exeflags: "-O3 --threads=auto"
+          bench-on: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

Pass the pull request head SHA to AirspeedVelocity as `bench-on`.

## Why

The benchmark workflow currently loads `benchmark/benchmarks.jl` from `master`. Breaking API changes can therefore fail before performance is measured because the old benchmark script is run against the new package revision. Using the PR head script lets one compatible benchmark definition run against both compared revisions.

## Validation

- Confirmed the workflow diff contains one added input line.
- `git diff --check` passes.