### PR TITLE
feat!: enable adaptive mutation weights by default

### DIFF
--- a/docs/src/plugins.md
+++ b/docs/src/plugins.md
@@ -46,6 +46,11 @@ default. It biases tournament selection and mutation acceptance away from
 over-represented complexities, using a sliding window of recent equation
 frequencies.
 
+[`AdaptiveMutationWeightsPlugin`](@ref) is also enabled by default. It learns
+relative mutation weights from successful search moves, with the learned
+multipliers regularized halfway toward the configured weights in log space.
+Pass `default_plugins=()` to `Options` to disable automatic plugins.
+
 ## Writing a custom plugin
 
 Define a struct that subtypes [`AbstractPlugin`](@ref), then override whichever

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -121,6 +121,7 @@ using .PluginModule:
     plugin_mutations,
     plugin_crossovers,
     default_adaptive_parsimony_plugin,
-    default_simulated_annealing_plugin
+    default_simulated_annealing_plugin,
+    default_adaptive_mutation_weights_plugin
 
 end

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -44,6 +44,7 @@ using ..OptionsStructModule: ComplexityMapping, operator_specialization
 using ..PluginModule:
     default_adaptive_parsimony_plugin,
     default_simulated_annealing_plugin,
+    default_adaptive_mutation_weights_plugin,
     _merge_with_default_plugins,
     plugin_mutations,
     plugin_crossovers
@@ -1067,6 +1068,7 @@ $(OPTION_DESCRIPTIONS)
         (
             default_simulated_annealing_plugin(; annealing, alpha),
             default_adaptive_parsimony_plugin(; use_frequency, use_frequency_in_tournament),
+            default_adaptive_mutation_weights_plugin(),
         )
     else
         Tuple(default_plugins)

--- a/src/Plugin.jl
+++ b/src/Plugin.jl
@@ -515,6 +515,7 @@ end
 # `nothing` (when the legacy kwarg is off).
 function default_adaptive_parsimony_plugin end
 function default_simulated_annealing_plugin end
+function default_adaptive_mutation_weights_plugin end
 
 # Append defaults whose type isn't already in the user tuple. Each default
 # may be `nothing` (auto-injected plugin disabled by the legacy kwarg) and

--- a/src/plugins/AdaptiveMutationWeights.jl
+++ b/src/plugins/AdaptiveMutationWeights.jl
@@ -8,6 +8,7 @@ using ..CoreModule:
     DoNothingMutation,
     MutationEvent
 import ..CoreModule: init_plugin_state, on_mutation_end!
+import ..CoreModule: default_adaptive_mutation_weights_plugin
 import ..MutateModule: condition_mutation_weights!
 
 """
@@ -28,6 +29,9 @@ Statistics persist independently for each population.
   starved.
 - `reward::Symbol = :cost`: objective used to count improvements. Supported
   values are `:cost` and `:loss`.
+- `adaptation_strength::Float64 = 0.5`: strength of the learned multiplier in
+  log space. Zero preserves the original mutation weights, while one applies
+  the learned multipliers without regularization.
 
 Mutation kinds excluded from accounting are declared by dispatch on
 `skip_in_adaptive_weights`; by default `SimplifyMutation` and
@@ -43,19 +47,30 @@ struct AdaptiveMutationWeightsPlugin <: AbstractPlugin
     smoothing::Float64
     floor::Float64
     reward::Symbol
+    adaptation_strength::Float64
     function AdaptiveMutationWeightsPlugin(;
-        smoothing::Real=0.02, floor::Real=0.05, reward::Symbol=:cost
+        smoothing::Real=0.02,
+        floor::Real=0.05,
+        reward::Symbol=:cost,
+        adaptation_strength::Real=0.5,
     )
         converted_smoothing = Float64(smoothing)
         converted_floor = Float64(floor)
+        converted_adaptation_strength = Float64(adaptation_strength)
         0 <= converted_smoothing <= 1 ||
             throw(ArgumentError("`smoothing` must be between 0 and 1."))
         0 < converted_floor <= 1 || throw(ArgumentError("`floor` must be in (0, 1]."))
         reward in (:cost, :loss) ||
             throw(ArgumentError("`reward` must be either `:cost` or `:loss`."))
-        return new(converted_smoothing, converted_floor, reward)
+        0 <= converted_adaptation_strength <= 1 ||
+            throw(ArgumentError("`adaptation_strength` must be between 0 and 1."))
+        return new(
+            converted_smoothing, converted_floor, reward, converted_adaptation_strength
+        )
     end
 end
+
+default_adaptive_mutation_weights_plugin()::AdaptiveMutationWeightsPlugin = AdaptiveMutationWeightsPlugin()
 
 """
     skip_in_adaptive_weights(::AbstractMutation) -> Bool
@@ -125,14 +140,19 @@ function on_mutation_end!(
     mean_rate = (total_successes + n) / (total_attempts + 2n)
     f = p.floor
     upper = inv(f)
+    rate = (s.successes[idx] + 1.0) / (s.attempts[idx] + 2.0)
+    target = clamp(rate / mean_rate, f, upper)
+    s.multipliers[idx] = (1 - p.smoothing) * s.multipliers[idx] + p.smoothing * target
+
+    active_multiplier_sum = 0.0
     @inbounds for i in eachindex(s.multipliers)
-        if !s.active[i]
-            s.multipliers[i] = 1.0
-            continue
-        end
-        rate = (s.successes[i] + 1.0) / (s.attempts[i] + 2.0)
-        target = clamp(rate / mean_rate, f, upper)
-        s.multipliers[i] = (1 - p.smoothing) * s.multipliers[i] + p.smoothing * target
+        s.active[i] || continue
+        active_multiplier_sum += s.multipliers[i]
+    end
+    mean_multiplier = active_multiplier_sum / n
+    @inbounds for i in eachindex(s.multipliers)
+        s.active[i] || continue
+        s.multipliers[i] /= mean_multiplier
     end
     return nothing
 end
@@ -140,16 +160,24 @@ end
 function condition_mutation_weights!(
     weights::AbstractVector,
     s::AdaptiveMutationWeightsState,
-    ::AdaptiveMutationWeightsPlugin,
+    p::AdaptiveMutationWeightsPlugin,
     member,
     options::AbstractOptions,
     curmaxsize,
     nfeatures,
 )
     mutations = options.mutations
+    exponent = p.adaptation_strength
     @inbounds for i in eachindex(mutations)
         m, w = weights[i]
-        weights[i] = m => w * s.multipliers[i]
+        effective_multiplier = if exponent == 1
+            s.multipliers[i]
+        elseif exponent == 0
+            1.0
+        else
+            exp(exponent * log(s.multipliers[i]))
+        end
+        weights[i] = m => w * effective_multiplier
     end
     return nothing
 end

--- a/test/unit/misc/test_plugin_interface.jl
+++ b/test/unit/misc/test_plugin_interface.jl
@@ -30,6 +30,7 @@
         use_frequency=false,
         use_frequency_in_tournament=false,
         annealing=false,
+        default_plugins=(),
     )
     @test opts.plugins isa Tuple{}
 
@@ -43,6 +44,7 @@
         use_frequency_in_tournament=false,
         annealing=false,
         plugins=(p,),
+        default_plugins=(),
     )
     @test init_plugin_states(plugin_opts, nothing) === (nothing,)
     dataset = Dataset(randn(1, 4), randn(4))

--- a/test/unit/parallel/test_plugin_teardown.jl
+++ b/test/unit/parallel/test_plugin_teardown.jl
@@ -56,6 +56,7 @@
         annealing=false,
         save_to_file=false,
         plugins=(TeardownProbePlugin(),),
+        default_plugins=(),
     )
     ropt = TeardownProbeRuntimeOptions(:multiprocessing)
 

--- a/test/unit/plugins/test_adaptive_mutation_mechanisms.jl
+++ b/test/unit/plugins/test_adaptive_mutation_mechanisms.jl
@@ -10,6 +10,65 @@
     s = SymbolicRegression.init_plugin_state(AdaptiveMutationWeightsPlugin(), opts, nothing)
     @test length(s.attempts) == length(opts.mutations)
     @test all(s.multipliers .== 1.0)
+    @test AdaptiveMutationWeightsPlugin().reward === :cost
+    @test AdaptiveMutationWeightsPlugin().adaptation_strength == 0.5
+    @test count(p -> p isa AdaptiveMutationWeightsPlugin, opts.plugins) == 1
+    @test !any(p -> p isa MutationBurstPlugin, opts.plugins)
+    @test isempty(Options(; default_plugins=()).plugins)
+end
+
+@testitem "AdaptiveMutationWeightsPlugin updates sampled operator and normalizes" begin
+    using SymbolicRegression
+    using SymbolicRegression: MutationEvent, init_plugin_state, on_mutation_end!
+    using Test
+
+    options = Options(;
+        default_mutations=(),
+        mutations=(ConstantMutation() => 1.0, OperatorMutation() => 1.0),
+        default_plugins=(),
+    )
+    plugin = AdaptiveMutationWeightsPlugin(; smoothing=0.2, reward=:loss)
+    state = init_plugin_state(plugin, options, nothing)
+
+    on_mutation_end!(
+        state,
+        plugin,
+        ConstantMutation(),
+        MutationEvent(true, 1.0, 0.5, 1.0, 0.5, 1),
+        nothing,
+        options,
+    )
+
+    updated = 0.8 + 0.2 * ((2 / 3) / (3 / 5))
+    normalizer = (updated + 1.0) / 2
+    @test state.multipliers ≈ [updated / normalizer, 1.0 / normalizer]
+    @test sum(state.multipliers) / length(state.multipliers) ≈ 1.0
+end
+
+@testitem "AdaptiveMutationWeightsPlugin regularizes multipliers in log space" begin
+    using SymbolicRegression
+    using SymbolicRegression: condition_mutation_weights!, init_plugin_state
+    using Test
+
+    options = Options(;
+        default_mutations=(),
+        mutations=(ConstantMutation() => 2.0, OperatorMutation() => 3.0),
+        default_plugins=(),
+    )
+    learned_multipliers = [4.0, 0.25]
+
+    function conditioned_weights(adaptation_strength)
+        plugin = AdaptiveMutationWeightsPlugin(; adaptation_strength)
+        state = init_plugin_state(plugin, options, nothing)
+        state.multipliers .= learned_multipliers
+        weights = collect(options.mutations)
+        condition_mutation_weights!(weights, state, plugin, nothing, options, 20, 2)
+        return last.(weights)
+    end
+
+    @test conditioned_weights(0.0) == [2.0, 3.0]
+    @test conditioned_weights(0.5) == [4.0, 1.5]
+    @test conditioned_weights(1.0) == [8.0, 0.75]
 end
 
 @testitem "skipped mutation kinds stay out of adaptive-weights accounting" begin
@@ -72,6 +131,8 @@ end
     @test_throws ArgumentError AdaptiveMutationWeightsPlugin(; floor=0.0)
     @test_throws ArgumentError AdaptiveMutationWeightsPlugin(; floor=1.1)
     @test_throws ArgumentError AdaptiveMutationWeightsPlugin(; reward=:unknown)
+    @test_throws ArgumentError AdaptiveMutationWeightsPlugin(; adaptation_strength=-0.1)
+    @test_throws ArgumentError AdaptiveMutationWeightsPlugin(; adaptation_strength=1.1)
     @test_throws ArgumentError MutationBurstPlugin(; retry_attempts=0)
     @test_throws ArgumentError MutationBurstPlugin(; compound_probability=-0.1)
     @test_throws ArgumentError MutationBurstPlugin(; compound_probability=1.1)

--- a/test/unit/plugins/test_adaptive_parsimony.jl
+++ b/test/unit/plugins/test_adaptive_parsimony.jl
@@ -56,7 +56,8 @@ end
         annealing=false,
         plugins=[DefaultProbePlugin(1)],
     )
-    @test opts_vector.plugins === (DefaultProbePlugin(1),)
+    @test first(opts_vector.plugins) === DefaultProbePlugin(1)
+    @test count(p -> p isa AdaptiveMutationWeightsPlugin, opts_vector.plugins) == 1
 
     opts_no_defaults = Options(; binary_operators=[+, *], default_plugins=())
     @test isempty(opts_no_defaults.plugins)


### PR DESCRIPTION
Enable `AdaptiveMutationWeightsPlugin` in the default plugin set with `adaptation_strength=0.5`. Learned multipliers are regularized halfway toward the configured weights in log space, updates affect only the sampled mutation, and active multipliers remain mean-normalized. `MutationBurstPlugin` remains opt-in.

This intentionally changes default seeded search trajectories. `default_plugins=()` remains the explicit opt-out.

Validation:
- all 13 unit-test groups on Julia 1.12.6
- Aqua quality checks
- JET static analysis
- repeated benchmark suite: +0.0143 aggregate score over disabled adaptation on the full set, with every task safety gate passing
- untouched holdout suite: neutral-to-positive aggregate result, with every task safety gate passing